### PR TITLE
feat: add sidebar group to all Minoo entity types

### DIFF
--- a/src/Provider/CulturalCollectionServiceProvider.php
+++ b/src/Provider/CulturalCollectionServiceProvider.php
@@ -17,6 +17,7 @@ final class CulturalCollectionServiceProvider extends ServiceProvider
             label: 'Cultural Collection',
             class: CulturalCollection::class,
             keys: ['id' => 'ccid', 'uuid' => 'uuid', 'label' => 'title'],
+            group: 'knowledge',
             fieldDefinitions: [
                 'slug' => [
                     'type' => 'string',

--- a/src/Provider/CulturalGroupServiceProvider.php
+++ b/src/Provider/CulturalGroupServiceProvider.php
@@ -17,6 +17,7 @@ final class CulturalGroupServiceProvider extends ServiceProvider
             label: 'Cultural Group',
             class: CulturalGroup::class,
             keys: ['id' => 'cgid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'community',
             fieldDefinitions: [
                 'slug' => [
                     'type' => 'string',

--- a/src/Provider/EventServiceProvider.php
+++ b/src/Provider/EventServiceProvider.php
@@ -18,6 +18,7 @@ final class EventServiceProvider extends ServiceProvider
             label: 'Event',
             class: Event::class,
             keys: ['id' => 'eid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            group: 'events',
             fieldDefinitions: [
                 'slug' => [
                     'type' => 'string',
@@ -77,6 +78,7 @@ final class EventServiceProvider extends ServiceProvider
             label: 'Event Type',
             class: EventType::class,
             keys: ['id' => 'type', 'label' => 'name'],
+            group: 'events',
         ));
     }
 }

--- a/src/Provider/GroupServiceProvider.php
+++ b/src/Provider/GroupServiceProvider.php
@@ -18,6 +18,7 @@ final class GroupServiceProvider extends ServiceProvider
             label: 'Community Group',
             class: Group::class,
             keys: ['id' => 'gid', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'type'],
+            group: 'community',
             fieldDefinitions: [
                 'slug' => [
                     'type' => 'string',
@@ -71,6 +72,7 @@ final class GroupServiceProvider extends ServiceProvider
             label: 'Group Type',
             class: GroupType::class,
             keys: ['id' => 'type', 'label' => 'name'],
+            group: 'community',
         ));
     }
 }

--- a/src/Provider/LanguageServiceProvider.php
+++ b/src/Provider/LanguageServiceProvider.php
@@ -20,6 +20,7 @@ final class LanguageServiceProvider extends ServiceProvider
             label: 'Dictionary Entry',
             class: DictionaryEntry::class,
             keys: ['id' => 'deid', 'uuid' => 'uuid', 'label' => 'word'],
+            group: 'language',
             fieldDefinitions: [
                 'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
                 'definition' => ['type' => 'string', 'label' => 'Definition', 'weight' => 5],
@@ -39,6 +40,7 @@ final class LanguageServiceProvider extends ServiceProvider
             label: 'Example Sentence',
             class: ExampleSentence::class,
             keys: ['id' => 'esid', 'uuid' => 'uuid', 'label' => 'ojibwe_text'],
+            group: 'language',
             fieldDefinitions: [
                 'english_text' => ['type' => 'string', 'label' => 'English Translation', 'weight' => 5],
                 'dictionary_entry_id' => ['type' => 'entity_reference', 'label' => 'Dictionary Entry', 'settings' => ['target_type' => 'dictionary_entry'], 'weight' => 10],
@@ -56,6 +58,7 @@ final class LanguageServiceProvider extends ServiceProvider
             label: 'Word Part',
             class: WordPart::class,
             keys: ['id' => 'wpid', 'uuid' => 'uuid', 'label' => 'form'],
+            group: 'language',
             fieldDefinitions: [
                 'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
                 'type' => ['type' => 'string', 'label' => 'Type', 'description' => 'initial, medial, or final.', 'weight' => 5],
@@ -72,6 +75,7 @@ final class LanguageServiceProvider extends ServiceProvider
             label: 'Speaker',
             class: Speaker::class,
             keys: ['id' => 'sid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'language',
             fieldDefinitions: [
                 'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
                 'code' => ['type' => 'string', 'label' => 'Speaker Code', 'description' => 'Abbreviation (e.g., es, nj, gh).', 'weight' => 5],

--- a/src/Provider/TeachingServiceProvider.php
+++ b/src/Provider/TeachingServiceProvider.php
@@ -18,6 +18,7 @@ final class TeachingServiceProvider extends ServiceProvider
             label: 'Teaching',
             class: Teaching::class,
             keys: ['id' => 'tid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            group: 'knowledge',
             fieldDefinitions: [
                 'slug' => [
                     'type' => 'string',
@@ -73,6 +74,7 @@ final class TeachingServiceProvider extends ServiceProvider
             label: 'Teaching Type',
             class: TeachingType::class,
             keys: ['id' => 'type', 'label' => 'name'],
+            group: 'knowledge',
         ));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `group` property to all 12 Minoo entity type registrations across 4 domains
- Events (`events`), Community (`community`), Cultural Knowledge (`knowledge`), Language (`language`)

## Dependencies
- Requires waaseyaa/framework PR for `EntityType::group` property

## Test plan
- [x] All 58 Minoo tests pass (131 assertions)
- [x] Verified sidebar grouping via Playwright — no "Other" group, all types properly categorized

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)