### PR TITLE
feat(#48): add PeopleAccessPolicy for resource_person

### DIFF
--- a/src/Access/PeopleAccessPolicy.php
+++ b/src/Access/PeopleAccessPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: 'resource_person')]
+final class PeopleAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'resource_person';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view' => (int) $entity->get('status') === 1 && $account->hasPermission('access content')
+                ? AccessResult::allowed('Published and user has access content.')
+                : AccessResult::neutral('Cannot view unpublished people content.'),
+            default => AccessResult::neutral('Non-admin cannot modify people content.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Non-admin cannot create people content.');
+    }
+}

--- a/src/Entity/ResourcePerson.php
+++ b/src/Entity/ResourcePerson.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Entity;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class ResourcePerson extends ContentEntityBase
+{
+    protected string $entityTypeId = 'resource_person';
+
+    protected array $entityKeys = [
+        'id' => 'rpid',
+        'uuid' => 'uuid',
+        'label' => 'name',
+    ];
+
+    /** @param array<string, mixed> $values */
+    public function __construct(array $values = [])
+    {
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = 0;
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = 0;
+        }
+
+        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+    }
+}

--- a/tests/Minoo/Unit/Access/PeopleAccessPolicyTest.php
+++ b/tests/Minoo/Unit/Access/PeopleAccessPolicyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Access;
+
+use Minoo\Access\PeopleAccessPolicy;
+use Minoo\Entity\ResourcePerson;
+use Waaseyaa\Access\AccountInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PeopleAccessPolicy::class)]
+final class PeopleAccessPolicyTest extends TestCase
+{
+    #[Test]
+    public function it_applies_to_resource_person(): void
+    {
+        $policy = new PeopleAccessPolicy();
+
+        $this->assertTrue($policy->appliesTo('resource_person'));
+        $this->assertFalse($policy->appliesTo('event'));
+        $this->assertFalse($policy->appliesTo('speaker'));
+    }
+
+    #[Test]
+    public function anonymous_can_view_published_resource_person(): void
+    {
+        $policy = new PeopleAccessPolicy();
+        $person = new ResourcePerson(['name' => 'Mary Trudeau', 'slug' => 'mary-trudeau', 'status' => 1]);
+
+        $account = new class implements AccountInterface {
+            public function id(): int { return 0; }
+            public function hasPermission(string $p): bool { return $p === 'access content'; }
+            public function getRoles(): array { return ['anonymous']; }
+            public function isAuthenticated(): bool { return false; }
+        };
+
+        $result = $policy->access($person, 'view', $account);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_create_resource_person(): void
+    {
+        $policy = new PeopleAccessPolicy();
+
+        $account = new class implements AccountInterface {
+            public function id(): int { return 0; }
+            public function hasPermission(string $p): bool { return $p === 'access content'; }
+            public function getRoles(): array { return ['anonymous']; }
+            public function isAuthenticated(): bool { return false; }
+        };
+
+        $result = $policy->createAccess('resource_person', '', $account);
+        $this->assertFalse($result->isAllowed());
+    }
+}


### PR DESCRIPTION
Closes #48

## Summary

- Add `PeopleAccessPolicy` with public read / admin write for `resource_person`
- Add `ResourcePerson` entity class (minimal, needed by policy tests)
- Add unit tests (appliesTo, anonymous view, anonymous create denied)

## Test plan

- [x] Unit tests for PeopleAccessPolicy (3 tests)
- [x] Full test suite passes (119 tests, 310 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)