### PR TITLE
feat(#48): add ResourcePerson entity and PeopleServiceProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
                 "Minoo\\Provider\\CulturalCollectionServiceProvider",
                 "Minoo\\Provider\\LanguageServiceProvider",
                 "Minoo\\Provider\\IngestServiceProvider",
-                "Minoo\\Provider\\SearchServiceProvider"
+                "Minoo\\Provider\\SearchServiceProvider",
+                "Minoo\\Provider\\PeopleServiceProvider"
             ]
         }
     },

--- a/src/Entity/ResourcePerson.php
+++ b/src/Entity/ResourcePerson.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Entity;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class ResourcePerson extends ContentEntityBase
+{
+    protected string $entityTypeId = 'resource_person';
+
+    protected array $entityKeys = [
+        'id' => 'rpid',
+        'uuid' => 'uuid',
+        'label' => 'name',
+    ];
+
+    /** @param array<string, mixed> $values */
+    public function __construct(array $values = [])
+    {
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = 0;
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = 0;
+        }
+
+        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+    }
+}

--- a/src/Provider/PeopleServiceProvider.php
+++ b/src/Provider/PeopleServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Provider;
+
+use Minoo\Entity\ResourcePerson;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+final class PeopleServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: 'resource_person',
+            label: 'Resource Person',
+            class: ResourcePerson::class,
+            keys: ['id' => 'rpid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'people',
+            fieldDefinitions: [
+                'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
+                'bio' => ['type' => 'text_long', 'label' => 'Biography', 'weight' => 5],
+                'community' => ['type' => 'string', 'label' => 'Community', 'description' => 'Community affiliation (e.g. Sagamok Anishnawbek).', 'weight' => 10],
+                'roles' => ['type' => 'entity_reference', 'label' => 'Roles', 'settings' => ['target_type' => 'taxonomy_term', 'target_vocabulary' => 'person_roles'], 'cardinality' => -1, 'weight' => 15],
+                'offerings' => ['type' => 'entity_reference', 'label' => 'Offerings', 'settings' => ['target_type' => 'taxonomy_term', 'target_vocabulary' => 'person_offerings'], 'cardinality' => -1, 'weight' => 16],
+                'email' => ['type' => 'string', 'label' => 'Email', 'weight' => 20],
+                'phone' => ['type' => 'string', 'label' => 'Phone', 'weight' => 21],
+                'business_name' => ['type' => 'string', 'label' => 'Business Name', 'weight' => 25],
+                'media_id' => ['type' => 'entity_reference', 'label' => 'Photo', 'settings' => ['target_type' => 'media'], 'weight' => 28],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
+        ));
+    }
+}

--- a/tests/Minoo/Unit/Entity/ResourcePersonTest.php
+++ b/tests/Minoo/Unit/Entity/ResourcePersonTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Entity;
+
+use Minoo\Entity\ResourcePerson;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourcePerson::class)]
+final class ResourcePersonTest extends TestCase
+{
+    #[Test]
+    public function it_creates_with_required_fields(): void
+    {
+        $person = new ResourcePerson([
+            'name' => 'Mary Trudeau',
+            'slug' => 'mary-trudeau',
+        ]);
+
+        $this->assertSame('Mary Trudeau', $person->get('name'));
+        $this->assertSame('mary-trudeau', $person->get('slug'));
+        $this->assertSame('resource_person', $person->getEntityTypeId());
+    }
+
+    #[Test]
+    public function it_defaults_status_to_published(): void
+    {
+        $person = new ResourcePerson(['name' => 'Test']);
+
+        $this->assertSame(1, $person->get('status'));
+    }
+
+    #[Test]
+    public function it_supports_all_optional_fields(): void
+    {
+        $person = new ResourcePerson([
+            'name' => 'John Beaucage',
+            'slug' => 'john-beaucage',
+            'bio' => 'Elder and knowledge keeper.',
+            'community' => 'Sagamok Anishnawbek',
+            'email' => 'john@example.com',
+            'phone' => '705-555-1234',
+            'business_name' => 'Beaucage Consulting',
+            'media_id' => 5,
+        ]);
+
+        $this->assertSame('Elder and knowledge keeper.', $person->get('bio'));
+        $this->assertSame('Sagamok Anishnawbek', $person->get('community'));
+        $this->assertSame('john@example.com', $person->get('email'));
+        $this->assertSame('705-555-1234', $person->get('phone'));
+        $this->assertSame('Beaucage Consulting', $person->get('business_name'));
+        $this->assertSame(5, $person->get('media_id'));
+    }
+}


### PR DESCRIPTION
Closes #48

## Summary

- Add `ResourcePerson` entity class with `rpid` primary key
- Add `PeopleServiceProvider` with 12 field definitions
- Register provider in `composer.json`
- Add unit tests for entity class

## Test plan

- [x] Unit tests for ResourcePerson entity (3 tests)
- [x] Full test suite passes
- [x] Integration test passes (kernel boots with new provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)