### PR TITLE
feat(#48): add people templates, card component, and CSS

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -376,6 +376,11 @@
     color: var(--color-forest-500);
   }
 
+  .card__badge--person {
+    background: oklch(0.95 0.02 160);
+    color: oklch(0.35 0.06 160);
+  }
+
   .card__date {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
@@ -417,6 +422,14 @@
 
   .detail__body {
     line-height: var(--leading-loose);
+  }
+
+  .detail__contact {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
   }
 
   /* Search form */

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -19,6 +19,7 @@
             <li><a href="/groups"{% if path is defined and path starts with '/groups' %} aria-current="page"{% endif %}>Groups</a></li>
             <li><a href="/teachings"{% if path is defined and path starts with '/teachings' %} aria-current="page"{% endif %}>Teachings</a></li>
             <li><a href="/language"{% if path is defined and path starts with '/language' %} aria-current="page"{% endif %}>Language</a></li>
+            <li><a href="/people"{% if path is defined and path starts with '/people' %} aria-current="page"{% endif %}>People</a></li>
             <li><a href="/search"{% if path is defined and path starts with '/search' %} aria-current="page"{% endif %}>Search</a></li>
           </ul>
         </nav>

--- a/templates/components/resource-person-card.html.twig
+++ b/templates/components/resource-person-card.html.twig
@@ -1,0 +1,17 @@
+<article class="card">
+  <span class="card__badge card__badge--person">{{ role }}</span>
+  <h3 class="card__title"><a href="{{ url }}">{{ name }}</a></h3>
+  {% if community is defined and community %}
+    <p class="card__meta">{{ community }}</p>
+  {% endif %}
+  {% if offerings is defined and offerings %}
+    <div class="card__tags">
+      {% for offering in offerings %}
+        <span class="card__tag">{{ offering }}</span>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% if excerpt is defined and excerpt %}
+    <p class="card__body">{{ excerpt }}</p>
+  {% endif %}
+</article>

--- a/templates/people.html.twig
+++ b/templates/people.html.twig
@@ -1,0 +1,145 @@
+{% extends "base.html.twig" %}
+
+{% block title %}
+  {%- if path == '/people' -%}
+    People — Minoo
+  {%- elseif path starts with '/people/' -%}
+    Person — Minoo
+  {%- else -%}
+    Person Not Found — Minoo
+  {%- endif -%}
+{% endblock %}
+
+{% block content %}
+  {% set people = [
+    {
+      slug: "mary-trudeau",
+      name: "Mary Trudeau",
+      role: "Caterer",
+      roles: ["Caterer", "Small Business Owner"],
+      community: "Sagamok Anishnawbek",
+      offerings: ["Food"],
+      business_name: "Mary's Bannock & Catering",
+      excerpt: "Traditional and contemporary Indigenous catering for community events, feasts, and celebrations.",
+      bio: "Mary has been catering community events in Sagamok for over fifteen years. She specializes in traditional dishes including bannock, wild rice soup, and smoked fish, as well as contemporary meals for large gatherings.\n\nHer business, Mary's Bannock & Catering, serves events ranging from small family celebrations to community-wide feasts. She is passionate about keeping traditional food practices alive while making them accessible for modern events.",
+      email: "mary@example.com",
+      phone: "705-555-0101"
+    },
+    {
+      slug: "john-beaucage",
+      name: "John Beaucage",
+      role: "Elder",
+      roles: ["Elder", "Knowledge Keeper"],
+      community: "Sagamok Anishnawbek",
+      offerings: ["Teachings", "Cultural Services"],
+      business_name: "",
+      excerpt: "Elder available for opening prayers, teachings on governance and treaty rights, and cultural guidance for community programs.",
+      bio: "John is a respected Elder in the Sagamok community with deep knowledge of Anishinaabe governance traditions and treaty history. He is frequently called upon to provide opening prayers and cultural guidance for community events and government meetings.\n\nJohn is available for teachings on treaty rights, traditional governance, and land-based education. He has mentored many young leaders in the community over the past three decades.",
+      email: "john@example.com",
+      phone: "705-555-0102"
+    },
+    {
+      slug: "sarah-owl",
+      name: "Sarah Owl",
+      role: "Regalia Maker",
+      roles: ["Regalia Maker", "Crafter", "Workshop Facilitator"],
+      community: "Garden River First Nation",
+      offerings: ["Regalia", "Beadwork", "Workshops"],
+      business_name: "Owl Designs",
+      excerpt: "Custom regalia, beadwork, and crafting workshops. Specializing in jingle dress and fancy shawl regalia.",
+      bio: "Sarah is a skilled regalia maker and beadwork artist from Garden River First Nation. She creates custom jingle dresses, fancy shawl regalia, and beadwork pieces for powwow dancers and community members across the region.\n\nThrough her business Owl Designs, Sarah also runs regular workshops teaching beadwork fundamentals, ribbon skirt making, and regalia construction. She believes in passing traditional crafting skills to the next generation.",
+      email: "sarah@example.com",
+      phone: "705-555-0103"
+    },
+    {
+      slug: "mike-abitong",
+      name: "Mike Abitong",
+      role: "Cedar Harvester",
+      roles: ["Cedar Harvester", "Youth Worker"],
+      community: "Atikameksheng Anishnawbek",
+      offerings: ["Cedar Products", "Workshops", "Cultural Services"],
+      business_name: "",
+      excerpt: "Cedar harvesting, land-based youth programming, and cultural workshops connecting young people to traditional land practices.",
+      bio: "Mike leads land-based youth programs in Atikameksheng, teaching young people traditional harvesting practices including cedar picking, medicine gathering, and seasonal land stewardship.\n\nHe provides cedar bundles and other harvested materials for community ceremonies and events. Mike also runs week-long summer camps focused on reconnecting youth with the land through hands-on traditional activities.",
+      email: "mike@example.com",
+      phone: "705-555-0104"
+    }
+  ] %}
+
+  {% set slug = path|replace({'/people/': '', '/people': ''})|trim('/') %}
+  {% set current_person = null %}
+  {% for p in people %}
+    {% if p.slug == slug %}
+      {% set current_person = p %}
+    {% endif %}
+  {% endfor %}
+
+  {% if path == '/people' %}
+    <div class="flow-lg">
+      <h1>People</h1>
+      <p>Community members, knowledge keepers, and service providers.</p>
+
+      <div class="card-grid">
+        {% for person in people %}
+          {% include "components/resource-person-card.html.twig" with {
+            name: person.name,
+            role: person.role,
+            community: person.community,
+            offerings: person.offerings,
+            excerpt: person.excerpt,
+            url: "/people/" ~ person.slug
+          } %}
+        {% endfor %}
+      </div>
+    </div>
+  {% elseif current_person %}
+    <div class="flow-lg detail">
+      <a href="/people" class="detail__back">People</a>
+      <div class="detail__header">
+        {% for r in current_person.roles %}
+          <span class="card__badge card__badge--person">{{ r }}</span>
+        {% endfor %}
+        <h1>{{ current_person.name }}</h1>
+        <div class="detail__meta">
+          {% if current_person.community %}
+            <span>{{ current_person.community }}</span>
+          {% endif %}
+          {% if current_person.business_name %}
+            <span>{{ current_person.business_name }}</span>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if current_person.offerings %}
+        <div class="card__tags">
+          {% for offering in current_person.offerings %}
+            <span class="card__tag">{{ offering }}</span>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      <div class="detail__body flow">
+        {% for paragraph in current_person.bio|split("\n\n") %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      </div>
+
+      {% if current_person.email or current_person.phone %}
+        <div class="detail__contact">
+          {% if current_person.email %}
+            <a href="mailto:{{ current_person.email }}">{{ current_person.email }}</a>
+          {% endif %}
+          {% if current_person.phone %}
+            <span>{{ current_person.phone }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  {% else %}
+    <div class="flow-lg">
+      <h1>Person Not Found</h1>
+      <p>The person at <code>{{ path }}</code> could not be found.</p>
+      <p><a href="/people">Browse all people</a></p>
+    </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #48

## Summary

- Add `people.html.twig` listing+detail page at `/people`
- Add `resource-person-card.html.twig` component
- Add `.card__badge--person` CSS variant (sage hue 160)
- Add `.detail__contact` styles
- Add People nav link in `base.html.twig`
- 4 sample resource people with full profiles

## Test plan

- [x] `/people` returns 200 with 4 cards
- [x] `/people/mary-trudeau` returns 200 with detail view
- [x] Badge variant renders with sage color

🤖 Generated with [Claude Code](https://claude.com/claude-code)