### PR TITLE
feat(#48): add person_roles and person_offerings vocabularies

### DIFF
--- a/src/Seed/TaxonomySeeder.php
+++ b/src/Seed/TaxonomySeeder.php
@@ -37,4 +37,46 @@ final class TaxonomySeeder
             ],
         ];
     }
+
+    /** @return array{vocabulary: array<string, string>, terms: list<array<string, string>>} */
+    public static function personRolesVocabulary(): array
+    {
+        return [
+            'vocabulary' => ['vid' => 'person_roles', 'name' => 'Person Roles', 'description' => 'Community roles for resource people.'],
+            'terms' => [
+                ['name' => 'Elder', 'vid' => 'person_roles'],
+                ['name' => 'Knowledge Keeper', 'vid' => 'person_roles'],
+                ['name' => 'Dancer', 'vid' => 'person_roles'],
+                ['name' => 'Drummer', 'vid' => 'person_roles'],
+                ['name' => 'Language Speaker', 'vid' => 'person_roles'],
+                ['name' => 'Regalia Maker', 'vid' => 'person_roles'],
+                ['name' => 'Caterer', 'vid' => 'person_roles'],
+                ['name' => 'Crafter', 'vid' => 'person_roles'],
+                ['name' => 'Workshop Facilitator', 'vid' => 'person_roles'],
+                ['name' => 'Small Business Owner', 'vid' => 'person_roles'],
+                ['name' => 'Youth Worker', 'vid' => 'person_roles'],
+                ['name' => 'Cedar Harvester', 'vid' => 'person_roles'],
+            ],
+        ];
+    }
+
+    /** @return array{vocabulary: array<string, string>, terms: list<array<string, string>>} */
+    public static function personOfferingsVocabulary(): array
+    {
+        return [
+            'vocabulary' => ['vid' => 'person_offerings', 'name' => 'Person Offerings', 'description' => 'Services and products offered by resource people.'],
+            'terms' => [
+                ['name' => 'Food', 'vid' => 'person_offerings'],
+                ['name' => 'Regalia', 'vid' => 'person_offerings'],
+                ['name' => 'Crafts', 'vid' => 'person_offerings'],
+                ['name' => 'Teachings', 'vid' => 'person_offerings'],
+                ['name' => 'Workshops', 'vid' => 'person_offerings'],
+                ['name' => 'Cultural Services', 'vid' => 'person_offerings'],
+                ['name' => 'Performances', 'vid' => 'person_offerings'],
+                ['name' => 'Cedar Products', 'vid' => 'person_offerings'],
+                ['name' => 'Beadwork', 'vid' => 'person_offerings'],
+                ['name' => 'Traditional Medicine', 'vid' => 'person_offerings'],
+            ],
+        ];
+    }
 }

--- a/tests/Minoo/Unit/Seed/TaxonomySeederTest.php
+++ b/tests/Minoo/Unit/Seed/TaxonomySeederTest.php
@@ -32,4 +32,26 @@ final class TaxonomySeederTest extends TestCase
         $this->assertCount(6, $data['terms']);
         $this->assertSame('ceremony', $data['terms'][0]['name']);
     }
+
+    #[Test]
+    public function it_provides_person_roles_vocabulary_with_terms(): void
+    {
+        $data = TaxonomySeeder::personRolesVocabulary();
+
+        $this->assertSame('person_roles', $data['vocabulary']['vid']);
+        $this->assertSame('Person Roles', $data['vocabulary']['name']);
+        $this->assertCount(12, $data['terms']);
+        $this->assertSame('Elder', $data['terms'][0]['name']);
+    }
+
+    #[Test]
+    public function it_provides_person_offerings_vocabulary_with_terms(): void
+    {
+        $data = TaxonomySeeder::personOfferingsVocabulary();
+
+        $this->assertSame('person_offerings', $data['vocabulary']['vid']);
+        $this->assertSame('Person Offerings', $data['vocabulary']['name']);
+        $this->assertCount(10, $data['terms']);
+        $this->assertSame('Food', $data['terms'][0]['name']);
+    }
 }


### PR DESCRIPTION
Closes #48

## Summary

- Add `personRolesVocabulary()` with 12 terms (Elder, Knowledge Keeper, etc.)
- Add `personOfferingsVocabulary()` with 10 terms (Food, Regalia, etc.)
- Add unit tests for both vocabularies

## Test plan

- [x] Unit tests for both new vocabularies (2 tests)
- [x] Full test suite passes (existing seeder tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)