### PR TITLE
fix(ci): use PHP 8.4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: pdo_sqlite, sqlite3, mbstring, xml
           coverage: none
 


### PR DESCRIPTION
Lock file has symfony/clock v8.0+ which requires PHP 8.4. CI was set to 8.3. Fixes first deploy run failure.