### PR TITLE
fix(ci): put .build/ inside minoo/ so dep can find it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Assemble build artifact
         run: |
-          mkdir -p .build
+          mkdir -p minoo/.build
           rsync -a \
             --exclude='.git' \
+            --exclude='.build/' \
             --exclude='tests/' \
             --exclude='docs/' \
             --exclude='mcp/' \
@@ -92,7 +93,7 @@ jobs:
             --exclude='deploy.php' \
             --exclude='ops/' \
             --exclude='*.png' \
-            minoo/ .build/
+            minoo/ minoo/.build/
 
       # -----------------------------------------------------------------------
       # Deploy via PHP Deployer


### PR DESCRIPTION
dep runs with `working-directory: minoo`, so `upload('.build/')` resolves relative to `minoo/`. Artifact was being assembled at workspace root. Fixes rsync exit code 23.