### PR TITLE
fix(ci): dereference symlinks when assembling artifact (rsync -aL)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Assemble build artifact
         run: |
           mkdir -p minoo/.build
-          rsync -a \
+          rsync -aL \
             --exclude='.git' \
             --exclude='.build/' \
             --exclude='tests/' \


### PR DESCRIPTION
vendor/ contains symlinks to `../waaseyaa/packages/*` that resolve in CI but not on the server. `rsync -L` follows symlinks and copies the real files, so the server gets actual package contents instead of broken symlinks. Fixes the ClassLoader 'Failed to open stream' fatal error on minoo.live.