### PR TITLE
feat: v0.5 People Directory enhancements

### DIFF
--- a/docs/specs/search.md
+++ b/docs/specs/search.md
@@ -19,7 +19,7 @@ SearchServiceProvider
   boot()     → SearchTwigExtension(provider, baseTopics) → Twig
 ```
 
-The search page uses a Twig function `search(query, filters, page)` provided by the framework's `SearchTwigExtension`. This calls `NorthCloudSearchProvider::search(SearchRequest)` which makes an HTTP GET to NorthCloud's `/api/search` endpoint.
+The search page uses a Twig function `search(query, filters, page)` provided by the framework's `SearchTwigExtension`. This calls `NorthCloudSearchProvider::search(SearchRequest)` which makes an HTTP GET to NorthCloud's `/api/v1/search` endpoint.
 
 ## Interface: SearchProviderInterface
 
@@ -50,7 +50,7 @@ In-memory array cache keyed by `SearchRequest::cacheKey()`. TTL-based expiration
 
 ### Query URL Building
 ```
-GET {baseUrl}/api/search?q={query}&page={page}&page_size={pageSize}&include_facets=1&include_highlights=1
+GET {baseUrl}/api/v1/search?q={query}&page={page}&page_size={pageSize}&include_facets=1&include_highlights=1
   &content_type={filter}      // optional
   &min_quality_score={score}  // optional
   &topics[]={topic}           // repeated, from filters + base_topics

--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -387,6 +387,139 @@
     color: var(--text-secondary);
   }
 
+  /* Person photo */
+  .person-photo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    background-color: var(--accent-surface);
+    color: var(--color-forest-700);
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .person-photo--card {
+    inline-size: 3rem;
+    block-size: 3rem;
+    font-size: var(--text-sm);
+  }
+
+  .person-photo--detail {
+    inline-size: 6rem;
+    block-size: 6rem;
+    font-size: var(--text-xl);
+  }
+
+  .person-photo__img {
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  .person-photo__initials {
+    line-height: 1;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  /* Person card layout */
+  .card--person .card__header-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+
+  .card--person .card__header-text {
+    min-inline-size: 0;
+  }
+
+  .card--person .card__title {
+    font-size: var(--text-lg);
+  }
+
+  .card__business {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  .card__tags--compact {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3xs);
+  }
+
+  .card__tags--compact .card__tag {
+    font-size: calc(var(--text-sm) * 0.9);
+    padding: 0.125rem var(--space-2xs);
+  }
+
+  /* People search */
+  .people-search {
+    max-inline-size: 24rem;
+  }
+
+  .people-search__input {
+    inline-size: 100%;
+  }
+
+  /* People filters */
+  .people-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: var(--space-xs);
+  }
+
+  .people-filters__group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
+  }
+
+  .people-filters__label {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .people-filters__select {
+    min-inline-size: 12rem;
+  }
+
+  .people-filters__clear {
+    padding: var(--space-2xs) var(--space-xs);
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .people-filters__clear:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
+
+  .people-filters__empty {
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  /* Detail business name */
+  .detail__business {
+    font-size: var(--text-lg);
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  /* Detail website link */
+  .detail__website::before {
+    content: "\1F310\00a0";
+  }
+
   .detail {
     max-inline-size: var(--width-prose);
   }

--- a/src/Controller/ElderSupportController.php
+++ b/src/Controller/ElderSupportController.php
@@ -57,7 +57,7 @@ final class ElderSupportController
                 'values' => compact('name', 'phone', 'community', 'type', 'notes'),
             ]);
 
-            return new SsrResponse(content: $html);
+            return new SsrResponse(content: $html, statusCode: 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
@@ -73,12 +73,10 @@ final class ElderSupportController
         ]);
         $storage->save($entity);
 
-        $id = $entity->id();
-
         return new SsrResponse(
             content: '',
             statusCode: 302,
-            headers: ['Location' => '/elders/request/' . $id],
+            headers: ['Location' => '/elders/request/' . $entity->uuid()],
         );
     }
 
@@ -86,9 +84,16 @@ final class ElderSupportController
     /** @param array<string, mixed> $query */
     public function requestDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $esrid = (int) ($params['esrid'] ?? 0);
-        $storage = $this->entityTypeManager->getStorage('elder_support_request');
-        $entity = $esrid > 0 ? $storage->load($esrid) : null;
+        $uuid = $params['uuid'] ?? '';
+        $entity = null;
+
+        if ($uuid !== '') {
+            $storage = $this->entityTypeManager->getStorage('elder_support_request');
+            $ids = $storage->getQuery()->condition('uuid', $uuid)->execute();
+            if ($ids !== []) {
+                $entity = $storage->load(reset($ids));
+            }
+        }
 
         $html = $this->twig->render('elders/request-confirmation.html.twig', [
             'entity' => $entity,

--- a/src/Controller/PeopleController.php
+++ b/src/Controller/PeopleController.php
@@ -7,6 +7,7 @@ namespace Minoo\Controller;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\SsrResponse;
 
@@ -27,11 +28,41 @@ final class PeopleController
             ->sort('name', 'ASC');
 
         $ids = $queryBuilder->execute();
-        $people = $ids !== [] ? $storage->loadMultiple($ids) : [];
+        $people = $ids !== [] ? array_values($storage->loadMultiple($ids)) : [];
+
+        $mediaIds = [];
+        $allRoles = [];
+        $allOfferings = [];
+
+        foreach ($people as $person) {
+            $mid = $person->get('media_id');
+            if ($mid !== null && $mid !== '') {
+                $mediaIds[] = (int) $mid;
+            }
+
+            $roles = $person->get('roles');
+            if (is_array($roles)) {
+                foreach ($roles as $role) {
+                    $allRoles[$role] = true;
+                }
+            }
+
+            $offerings = $person->get('offerings');
+            if (is_array($offerings)) {
+                foreach ($offerings as $offering) {
+                    $allOfferings[$offering] = true;
+                }
+            }
+        }
+
+        $photoUrls = $mediaIds !== [] ? $this->resolvePhotoUrls($mediaIds) : [];
 
         $html = $this->twig->render('people.html.twig', [
             'path' => '/people',
-            'people' => array_values($people),
+            'people' => $people,
+            'photo_urls' => $photoUrls,
+            'all_roles' => array_keys($allRoles),
+            'all_offerings' => array_keys($allOfferings),
         ]);
 
         return new SsrResponse(content: $html);
@@ -50,14 +81,45 @@ final class PeopleController
 
         $person = $ids !== [] ? $storage->load(reset($ids)) : null;
 
+        $photoUrl = '';
+        if ($person !== null) {
+            $mid = $person->get('media_id');
+            if ($mid !== null && $mid !== '') {
+                $urls = $this->resolvePhotoUrls([(int) $mid]);
+                $photoUrl = $urls[(int) $mid] ?? '';
+            }
+        }
+
         $html = $this->twig->render('people.html.twig', [
             'path' => '/people/' . $slug,
             'person' => $person,
+            'photo_url' => $photoUrl,
         ]);
 
         return new SsrResponse(
             content: $html,
             statusCode: $person !== null ? 200 : 404,
         );
+    }
+
+    /**
+     * @param int[] $mediaIds
+     * @return array<int, string> Map of media ID to file URL
+     */
+    private function resolvePhotoUrls(array $mediaIds): array
+    {
+        $mediaStorage = $this->entityTypeManager->getStorage('media');
+        $mediaEntities = $mediaStorage->loadMultiple($mediaIds);
+
+        $urls = [];
+        foreach ($mediaEntities as $media) {
+            /** @var EntityInterface $media */
+            $url = $media->get('file_url');
+            if (is_string($url) && $url !== '') {
+                $urls[(int) $media->id()] = $url;
+            }
+        }
+
+        return $urls;
     }
 }

--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -55,7 +55,7 @@ final class VolunteerController
                 'values' => compact('name', 'phone', 'availability', 'skills', 'notes'),
             ]);
 
-            return new SsrResponse(content: $html);
+            return new SsrResponse(content: $html, statusCode: 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('volunteer');
@@ -71,12 +71,10 @@ final class VolunteerController
         ]);
         $storage->save($entity);
 
-        $id = $entity->id();
-
         return new SsrResponse(
             content: '',
             statusCode: 302,
-            headers: ['Location' => '/elders/volunteer/' . $id],
+            headers: ['Location' => '/elders/volunteer/' . $entity->uuid()],
         );
     }
 
@@ -84,9 +82,16 @@ final class VolunteerController
     /** @param array<string, mixed> $query */
     public function signupDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $vid = (int) ($params['vid'] ?? 0);
-        $storage = $this->entityTypeManager->getStorage('volunteer');
-        $entity = $vid > 0 ? $storage->load($vid) : null;
+        $uuid = $params['uuid'] ?? '';
+        $entity = null;
+
+        if ($uuid !== '') {
+            $storage = $this->entityTypeManager->getStorage('volunteer');
+            $ids = $storage->getQuery()->condition('uuid', $uuid)->execute();
+            if ($ids !== []) {
+                $entity = $storage->load(reset($ids));
+            }
+        }
 
         $html = $this->twig->render('elders/volunteer-confirmation.html.twig', [
             'entity' => $entity,

--- a/src/Provider/ElderSupportServiceProvider.php
+++ b/src/Provider/ElderSupportServiceProvider.php
@@ -86,7 +86,7 @@ final class ElderSupportServiceProvider extends ServiceProvider
 
         $router->addRoute(
             'elders.request.detail',
-            RouteBuilder::create('/elders/request/{esrid}')
+            RouteBuilder::create('/elders/request/{uuid}')
                 ->controller('Minoo\Controller\ElderSupportController::requestDetail')
                 ->allowAll()
                 ->render()
@@ -116,7 +116,7 @@ final class ElderSupportServiceProvider extends ServiceProvider
 
         $router->addRoute(
             'elders.volunteer.detail',
-            RouteBuilder::create('/elders/volunteer/{vid}')
+            RouteBuilder::create('/elders/volunteer/{uuid}')
                 ->controller('Minoo\Controller\VolunteerController::signupDetail')
                 ->allowAll()
                 ->render()

--- a/src/Provider/PeopleServiceProvider.php
+++ b/src/Provider/PeopleServiceProvider.php
@@ -29,6 +29,7 @@ final class PeopleServiceProvider extends ServiceProvider
                 'email' => ['type' => 'string', 'label' => 'Email', 'weight' => 20],
                 'phone' => ['type' => 'string', 'label' => 'Phone', 'weight' => 21],
                 'business_name' => ['type' => 'string', 'label' => 'Business Name', 'weight' => 25],
+                'website' => ['type' => 'string', 'label' => 'Website', 'weight' => 26],
                 'media_id' => ['type' => 'entity_reference', 'label' => 'Photo', 'settings' => ['target_type' => 'media'], 'weight' => 28],
                 'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
                 'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],

--- a/src/Search/NorthCloudSearchProvider.php
+++ b/src/Search/NorthCloudSearchProvider.php
@@ -81,7 +81,7 @@ final class NorthCloudSearchProvider implements SearchProviderInterface
             $params['min_quality_score'] = (string) $request->filters->minQuality;
         }
 
-        $url = rtrim($this->baseUrl, '/') . '/api/search?' . http_build_query($params);
+        $url = rtrim($this->baseUrl, '/') . '/api/v1/search?' . http_build_query($params);
 
         // Array params need explicit bracket notation for Go's query parser.
         foreach ($request->filters->topics as $topic) {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,5 +55,6 @@
       this.setAttribute('aria-expanded', open ? 'true' : 'false');
     });
   </script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/components/resource-person-card.html.twig
+++ b/templates/components/resource-person-card.html.twig
@@ -1,11 +1,25 @@
-<article class="card">
+<article class="card card--person" data-role="{{ role }}" data-offerings="{{ offerings is defined and offerings ? offerings|join(',') : '' }}" data-search="{{ ([name, business_name ?? '', bio ?? ''])|join(' ')|lower }}">
+  <div class="card__header-row">
+    <div class="person-photo person-photo--card">
+      {% if photo_url is defined and photo_url %}
+        <img src="{{ photo_url }}" alt="{{ name }}" class="person-photo__img" loading="lazy">
+      {% else %}
+        <span class="person-photo__initials">{{ name|split(' ')|map(n => n|first|upper)|join('') }}</span>
+      {% endif %}
+    </div>
+    <div class="card__header-text">
+      <h3 class="card__title"><a href="{{ url }}">{{ name }}</a></h3>
+      {% if business_name is defined and business_name %}
+        <p class="card__business">{{ business_name }}</p>
+      {% endif %}
+      {% if community is defined and community %}
+        <p class="card__meta">{{ community }}</p>
+      {% endif %}
+    </div>
+  </div>
   <span class="card__badge card__badge--person">{{ role }}</span>
-  <h3 class="card__title"><a href="{{ url }}">{{ name }}</a></h3>
-  {% if community is defined and community %}
-    <p class="card__meta">{{ community }}</p>
-  {% endif %}
   {% if offerings is defined and offerings %}
-    <div class="card__tags">
+    <div class="card__tags card__tags--compact">
       {% for offering in offerings %}
         <span class="card__tag">{{ offering }}</span>
       {% endfor %}

--- a/templates/people.html.twig
+++ b/templates/people.html.twig
@@ -17,18 +17,52 @@
       <p>Community members, knowledge keepers, and service providers.</p>
 
       {% if people is defined and people|length > 0 %}
-        <div class="card-grid">
+        <div class="people-search">
+          <input type="search" class="form__input people-search__input" id="people-search" placeholder="Search people…" autocomplete="off">
+        </div>
+
+        <div class="people-filters" id="people-filters">
+          {% if all_roles is defined and all_roles|length > 0 %}
+            <div class="people-filters__group">
+              <label class="people-filters__label" for="filter-role">Role</label>
+              <select class="form__select people-filters__select" id="filter-role" data-filter="role">
+                <option value="">All roles</option>
+                {% for role in all_roles|sort %}
+                  <option value="{{ role }}">{{ role }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
+          {% if all_offerings is defined and all_offerings|length > 0 %}
+            <div class="people-filters__group">
+              <label class="people-filters__label" for="filter-offering">Offering</label>
+              <select class="form__select people-filters__select" id="filter-offering" data-filter="offering">
+                <option value="">All offerings</option>
+                {% for offering in all_offerings|sort %}
+                  <option value="{{ offering }}">{{ offering }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
+          <button class="people-filters__clear" id="filters-clear" type="button" hidden>Clear filters</button>
+        </div>
+
+        <div class="card-grid" id="people-grid">
           {% for p in people %}
             {% include "components/resource-person-card.html.twig" with {
               name: p.get('name'),
               role: p.get('roles') is iterable ? p.get('roles')|first : '',
               community: p.get('community'),
+              business_name: p.get('business_name'),
               offerings: p.get('offerings') is iterable ? p.get('offerings') : [],
+              bio: p.get('bio') ? p.get('bio')|striptags : '',
               excerpt: p.get('bio') ? p.get('bio')|striptags|slice(0, 160) ~ '…' : '',
-              url: "/people/" ~ p.get('slug')
+              url: "/people/" ~ p.get('slug'),
+              photo_url: photo_urls[p.get('media_id')] ?? ''
             } %}
           {% endfor %}
         </div>
+        <p class="people-filters__empty" id="filters-empty" hidden>No people match your search or filters.</p>
       {% else %}
         <p>No resource people found.</p>
       {% endif %}
@@ -37,18 +71,25 @@
     <div class="flow-lg detail">
       <a href="/people" class="detail__back">People</a>
       <div class="detail__header">
+        <div class="person-photo person-photo--detail">
+          {% if photo_url is defined and photo_url %}
+            <img src="{{ photo_url }}" alt="{{ person.get('name') }}" class="person-photo__img">
+          {% else %}
+            <span class="person-photo__initials">{{ person.get('name')|split(' ')|map(n => n|first|upper)|join('') }}</span>
+          {% endif %}
+        </div>
         {% if person.get('roles') is iterable %}
           {% for r in person.get('roles') %}
             <span class="card__badge card__badge--person">{{ r }}</span>
           {% endfor %}
         {% endif %}
         <h1>{{ person.get('name') }}</h1>
+        {% if person.get('business_name') %}
+          <p class="detail__business">{{ person.get('business_name') }}</p>
+        {% endif %}
         <div class="detail__meta">
           {% if person.get('community') %}
             <span>{{ person.get('community') }}</span>
-          {% endif %}
-          {% if person.get('business_name') %}
-            <span>{{ person.get('business_name') }}</span>
           {% endif %}
         </div>
       </div>
@@ -69,8 +110,11 @@
         </div>
       {% endif %}
 
-      {% if person.get('email') or person.get('phone') %}
+      {% if person.get('email') or person.get('phone') or person.get('website') %}
         <div class="detail__contact">
+          {% if person.get('website') %}
+            <a href="{{ person.get('website') }}" class="detail__website" rel="noopener noreferrer" target="_blank">{{ person.get('website')|replace({'https://': '', 'http://': ''})|trim('/') }}</a>
+          {% endif %}
           {% if person.get('email') %}
             <a href="mailto:{{ person.get('email') }}">{{ person.get('email') }}</a>
           {% endif %}
@@ -86,5 +130,94 @@
       <p>The person at <code>{{ path }}</code> could not be found.</p>
       <p><a href="/people">Browse all people</a></p>
     </div>
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {% if path == '/people' %}
+  <script>
+  (function() {
+    const grid = document.getElementById('people-grid');
+    if (!grid) return;
+
+    const searchInput = document.getElementById('people-search');
+    const roleSelect = document.getElementById('filter-role');
+    const offeringSelect = document.getElementById('filter-offering');
+    const clearBtn = document.getElementById('filters-clear');
+    const emptyMsg = document.getElementById('filters-empty');
+    const cards = grid.querySelectorAll('.card--person');
+
+    function getParams() {
+      const params = new URLSearchParams(window.location.search);
+      return {
+        q: params.get('q') || '',
+        role: params.get('role') || '',
+        offering: params.get('offering') || ''
+      };
+    }
+
+    function applyFromParams() {
+      const { q, role, offering } = getParams();
+      if (searchInput) searchInput.value = q;
+      if (roleSelect) roleSelect.value = role;
+      if (offeringSelect) offeringSelect.value = offering;
+      filter();
+    }
+
+    function updateURL(q, role, offering) {
+      const params = new URLSearchParams();
+      if (q) params.set('q', q);
+      if (role) params.set('role', role);
+      if (offering) params.set('offering', offering);
+      const qs = params.toString();
+      const url = window.location.pathname + (qs ? '?' + qs : '');
+      history.replaceState(null, '', url);
+    }
+
+    function filter() {
+      const q = searchInput ? searchInput.value.toLowerCase().trim() : '';
+      const role = roleSelect ? roleSelect.value : '';
+      const offering = offeringSelect ? offeringSelect.value : '';
+      let visible = 0;
+
+      cards.forEach(function(card) {
+        const cardSearch = card.dataset.search || '';
+        const cardRole = card.dataset.role || '';
+        const cardOfferings = card.dataset.offerings || '';
+        const matchQuery = !q || cardSearch.indexOf(q) !== -1;
+        const matchRole = !role || cardRole === role;
+        const matchOffering = !offering || cardOfferings.split(',').indexOf(offering) !== -1;
+        const show = matchQuery && matchRole && matchOffering;
+        card.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+
+      const hasFilters = q || role || offering;
+      if (clearBtn) clearBtn.hidden = !hasFilters;
+      if (emptyMsg) emptyMsg.hidden = visible > 0;
+      updateURL(q, role, offering);
+    }
+
+    var debounceTimer;
+    if (searchInput) {
+      searchInput.addEventListener('input', function() {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(filter, 150);
+      });
+    }
+    if (roleSelect) roleSelect.addEventListener('change', filter);
+    if (offeringSelect) offeringSelect.addEventListener('change', filter);
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function() {
+        if (searchInput) searchInput.value = '';
+        if (roleSelect) roleSelect.value = '';
+        if (offeringSelect) offeringSelect.value = '';
+        filter();
+      });
+    }
+
+    applyFromParams();
+  })();
+  </script>
   {% endif %}
 {% endblock %}

--- a/tests/Minoo/Unit/Controller/ElderSupportControllerTest.php
+++ b/tests/Minoo/Unit/Controller/ElderSupportControllerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\ElderSupportController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+#[CoversClass(ElderSupportController::class)]
+final class ElderSupportControllerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private Environment $twig;
+    private AccountInterface $account;
+
+    protected function setUp(): void
+    {
+        $this->entityTypeManager = $this->createMock(EntityTypeManager::class);
+
+        $this->twig = new Environment(new ArrayLoader([
+            'elders/request.html.twig' => '{{ errors|keys|join(",") }}',
+            'elders/request-confirmation.html.twig' => 'ok',
+        ]));
+
+        $this->account = $this->createMock(AccountInterface::class);
+    }
+
+    #[Test]
+    public function request_form_returns_200(): void
+    {
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $response = $controller->requestForm([], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(200, $response->statusCode);
+    }
+
+    #[Test]
+    public function submit_with_empty_fields_returns_422(): void
+    {
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/request', 'POST');
+
+        $response = $controller->submitRequest([], [], $this->account, $request);
+
+        $this->assertSame(422, $response->statusCode);
+    }
+
+    #[Test]
+    public function submit_with_missing_name_returns_422(): void
+    {
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/request', 'POST', [
+            'phone' => '555-1234',
+            'type' => 'ride',
+        ]);
+
+        $response = $controller->submitRequest([], [], $this->account, $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('name', $response->content);
+    }
+
+    #[Test]
+    public function submit_with_invalid_type_returns_422(): void
+    {
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/request', 'POST', [
+            'name' => 'Mary',
+            'phone' => '555-1234',
+            'type' => 'invalid',
+        ]);
+
+        $response = $controller->submitRequest([], [], $this->account, $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('type', $response->content);
+    }
+
+    #[Test]
+    public function request_detail_with_valid_uuid_returns_200(): void
+    {
+        $uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+        $entity = $this->createMock(EntityInterface::class);
+
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn([1]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('elder_support_request')
+            ->willReturn($storage);
+
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $response = $controller->requestDetail(['uuid' => $uuid], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(200, $response->statusCode);
+    }
+
+    #[Test]
+    public function request_detail_with_unknown_uuid_returns_404(): void
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn([]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('elder_support_request')
+            ->willReturn($storage);
+
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $response = $controller->requestDetail(['uuid' => 'nonexistent'], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(404, $response->statusCode);
+    }
+
+    #[Test]
+    public function request_detail_with_empty_uuid_returns_404(): void
+    {
+        $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
+        $response = $controller->requestDetail([], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(404, $response->statusCode);
+    }
+}

--- a/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
+++ b/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\VolunteerController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+#[CoversClass(VolunteerController::class)]
+final class VolunteerControllerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private Environment $twig;
+    private AccountInterface $account;
+
+    protected function setUp(): void
+    {
+        $this->entityTypeManager = $this->createMock(EntityTypeManager::class);
+
+        $this->twig = new Environment(new ArrayLoader([
+            'elders/volunteer.html.twig' => '{{ errors|keys|join(",") }}',
+            'elders/volunteer-confirmation.html.twig' => 'ok',
+        ]));
+
+        $this->account = $this->createMock(AccountInterface::class);
+    }
+
+    #[Test]
+    public function signup_form_returns_200(): void
+    {
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $response = $controller->signupForm([], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(200, $response->statusCode);
+    }
+
+    #[Test]
+    public function submit_with_empty_fields_returns_422(): void
+    {
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/volunteer', 'POST');
+
+        $response = $controller->submitSignup([], [], $this->account, $request);
+
+        $this->assertSame(422, $response->statusCode);
+    }
+
+    #[Test]
+    public function submit_with_missing_phone_returns_422(): void
+    {
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/volunteer', 'POST', [
+            'name' => 'John',
+        ]);
+
+        $response = $controller->submitSignup([], [], $this->account, $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('phone', $response->content);
+    }
+
+    #[Test]
+    public function signup_detail_with_valid_uuid_returns_200(): void
+    {
+        $uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+        $entity = $this->createMock(EntityInterface::class);
+
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn([1]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('volunteer')
+            ->willReturn($storage);
+
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $response = $controller->signupDetail(['uuid' => $uuid], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(200, $response->statusCode);
+    }
+
+    #[Test]
+    public function signup_detail_with_unknown_uuid_returns_404(): void
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn([]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('volunteer')
+            ->willReturn($storage);
+
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $response = $controller->signupDetail(['uuid' => 'nonexistent'], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(404, $response->statusCode);
+    }
+
+    #[Test]
+    public function signup_detail_with_empty_uuid_returns_404(): void
+    {
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $response = $controller->signupDetail([], [], $this->account, HttpRequest::create('/'));
+
+        $this->assertSame(404, $response->statusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Implements all 7 issues in the **v0.5 milestone** — People Directory enhancements, elder support correctness fixes, and search URL fix.

### Correctness fixes
- **#59**: Fix search API URL (`/api/search` → `/api/v1/search`) in provider and spec
- **#63**: Return 422 on validation failure for elder support and volunteer form submissions (was 200)
- **#62**: Use UUIDs instead of integer IDs in public confirmation URLs to prevent enumeration

### People Directory features
- **#54**: Wire `media_id` into people templates — photo display with circular initials fallback
- **#57**: Add `website` field, enhanced card layout with photo+text side-by-side, business name styling, compact tags
- **#55**: Client-side filtering by role and offering with `<select>` dropdowns, URL param sync, clear button
- **#56**: Client-side search across name, bio, and business_name with debounced input

### Stats
- **197/197 tests green**, 470 assertions
- 13 files changed, +656/-33 lines
- 2 new test files (ElderSupportControllerTest, VolunteerControllerTest) with 13 new tests

## Test plan
- [ ] Run `vendor/bin/phpunit` — all 197 tests pass
- [ ] Verify elder support form returns 422 on empty submission
- [ ] Verify volunteer form returns 422 on empty submission  
- [ ] Verify `/elders/request/{uuid}` routes work, `/elders/request/{integer}` returns 404
- [ ] Verify `/people` shows photo or initials for each card
- [ ] Verify `/people` filter dropdowns filter cards by role and offering
- [ ] Verify `/people` search input filters by name/bio/business_name
- [ ] Verify `/people?q=elder&role=Knowledge+Keeper` URL params restore filters on page load

Closes #59, closes #63, closes #62, closes #54, closes #57, closes #55, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)