### PR TITLE
fix: GIS review fixes — community cache, max_travel_km validation

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -971,20 +971,6 @@
     font-style: italic;
   }
 
-  .volunteer-distance {
-    font-size: var(--text-sm);
-    color: var(--text-secondary);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .volunteer-distance--near {
-    color: var(--color-forest-700);
-  }
-
-  .volunteer-distance--far {
-    color: var(--color-earth-700);
-  }
-
   .form__link {
     margin-block-start: var(--space-sm);
     font-size: var(--text-sm);

--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -17,6 +17,9 @@ final class VolunteerController
         private readonly Environment $twig,
     ) {}
 
+    private const int MAX_TRAVEL_FLOOR = 1;
+    private const int MAX_TRAVEL_CEILING = 1000;
+
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
     public function signupForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -49,6 +52,9 @@ final class VolunteerController
         }
         if ($phone === '') {
             $errors['phone'] = 'Phone number is required.';
+        }
+        if ($maxTravelKm !== null && ($maxTravelKm < self::MAX_TRAVEL_FLOOR || $maxTravelKm > self::MAX_TRAVEL_CEILING)) {
+            $maxTravelKm = null;
         }
 
         if ($errors !== []) {

--- a/src/Geo/VolunteerRanker.php
+++ b/src/Geo/VolunteerRanker.php
@@ -26,13 +26,15 @@ final class VolunteerRanker
      */
     public function rank(array $volunteers, ContentEntityBase $request): array
     {
-        $requestCoords = $this->resolveCoords($request);
+        /** @var array<int, array{float, float}|null> */
+        $coordsCache = [];
+        $requestCoords = $this->resolveCoords($request, $coordsCache);
 
         $withDistance = [];
         $withoutDistance = [];
 
         foreach ($volunteers as $volunteer) {
-            $volCoords = $this->resolveCoords($volunteer);
+            $volCoords = $this->resolveCoords($volunteer, $coordsCache);
 
             if ($requestCoords === null || $volCoords === null) {
                 $withoutDistance[] = new RankedVolunteer($volunteer, null);
@@ -62,9 +64,10 @@ final class VolunteerRanker
     }
 
     /**
+     * @param array<int, array{float, float}|null> $cache
      * @return array{float, float}|null [latitude, longitude] or null if missing
      */
-    private function resolveCoords(ContentEntityBase $entity): ?array
+    private function resolveCoords(ContentEntityBase $entity, array &$cache): ?array
     {
         $communityRef = $entity->get('community');
 
@@ -72,10 +75,17 @@ final class VolunteerRanker
             return null;
         }
 
+        $communityId = (int) $communityRef;
+
+        if (array_key_exists($communityId, $cache)) {
+            return $cache[$communityId];
+        }
+
         $communityStorage = $this->entityTypeManager->getStorage('community');
-        $community = $communityStorage->load((int) $communityRef);
+        $community = $communityStorage->load($communityId);
 
         if ($community === null) {
+            $cache[$communityId] = null;
             return null;
         }
 
@@ -83,9 +93,13 @@ final class VolunteerRanker
         $lon = $community->get('longitude');
 
         if ($lat === null || $lon === null) {
+            $cache[$communityId] = null;
             return null;
         }
 
-        return [(float) $lat, (float) $lon];
+        $coords = [(float) $lat, (float) $lon];
+        $cache[$communityId] = $coords;
+
+        return $coords;
     }
 }

--- a/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
+++ b/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
@@ -71,6 +71,68 @@ final class VolunteerControllerTest extends TestCase
     }
 
     #[Test]
+    public function submit_persists_max_travel_km(): void
+    {
+        $entity = $this->createMock(EntityInterface::class);
+        $entity->method('uuid')->willReturn('test-uuid');
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function (array $values): bool {
+                return $values['max_travel_km'] === 50;
+            }))
+            ->willReturn($entity);
+        $storage->expects($this->once())->method('save');
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('volunteer')
+            ->willReturn($storage);
+
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/volunteer', 'POST', [
+            'name' => 'Jane',
+            'phone' => '555-1234',
+            'max_travel_km' => '50',
+        ]);
+
+        $response = $controller->submitSignup([], [], $this->account, $request);
+
+        $this->assertSame(302, $response->statusCode);
+    }
+
+    #[Test]
+    public function submit_discards_invalid_max_travel_km(): void
+    {
+        $entity = $this->createMock(EntityInterface::class);
+        $entity->method('uuid')->willReturn('test-uuid');
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function (array $values): bool {
+                return !array_key_exists('max_travel_km', $values);
+            }))
+            ->willReturn($entity);
+        $storage->expects($this->once())->method('save');
+
+        $this->entityTypeManager->method('getStorage')
+            ->with('volunteer')
+            ->willReturn($storage);
+
+        $controller = new VolunteerController($this->entityTypeManager, $this->twig);
+        $request = HttpRequest::create('/elders/volunteer', 'POST', [
+            'name' => 'Jane',
+            'phone' => '555-1234',
+            'max_travel_km' => '-5',
+        ]);
+
+        $response = $controller->submitSignup([], [], $this->account, $request);
+
+        $this->assertSame(302, $response->statusCode);
+    }
+
+    #[Test]
     public function signup_detail_with_valid_uuid_returns_200(): void
     {
         $uuid = '550e8400-e29b-41d4-a716-446655440000';

--- a/tests/Minoo/Unit/Geo/GeoDistanceTest.php
+++ b/tests/Minoo/Unit/Geo/GeoDistanceTest.php
@@ -26,7 +26,7 @@ final class GeoDistanceTest extends TestCase
     }
 
     #[Test]
-    public function sudbury_to_sault_ste_marie_is_about_262_km(): void
+    public function sudbury_to_sault_ste_marie_is_about_257_km(): void
     {
         $distance = GeoDistance::haversine(46.49, -80.99, 46.52, -84.35);
         $this->assertEqualsWithDelta(257.0, $distance, 10.0);


### PR DESCRIPTION
## Summary
Follow-up to #80 — review fixes that were committed after the PR was merged.

- Add community coordinate cache in `VolunteerRanker` to avoid N+1 loads
- Add server-side validation clamping `max_travel_km` to 1–1000 (silently discards out-of-range)
- Add 2 tests for `max_travel_km` persistence and invalid value rejection
- Fix test name to match actual Haversine result (257 km, not 262)
- Remove unused CSS classes (`.volunteer-distance`) that can't style `<option>` elements

## Test plan
- [x] `vendor/bin/phpunit` — 208 tests, 501 assertions, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)