### PR TITLE
fix: login wording — 'volunteer' → 'account'

### DIFF
--- a/templates/auth/login.html.twig
+++ b/templates/auth/login.html.twig
@@ -35,6 +35,6 @@
     </div>
   </form>
 
-  <p class="form__link">Don't have an account? <a href="/register">Register as a volunteer</a></p>
+  <p class="form__link">Don't have an account? <a href="/register">Create an account</a></p>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Change "Register as a volunteer" to "Create an account" on the login page

Fixes #85

## Test plan
- [x] Single-line template change, no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)