### PR TITLE
fix: correct JS property access for browser geolocation response

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -196,7 +196,7 @@
             body: JSON.stringify({latitude: pos.coords.latitude, longitude: pos.coords.longitude})
           });
           const data = await res.json();
-          if (data.success) render({communityName: data.community.name, source: 'browser'});
+          if (data.success) render({communityName: data.communityName, source: 'browser'});
         } catch {}
       }, () => {}, {timeout: 10000, maximumAge: 300000});
     }


### PR DESCRIPTION
## Summary
- Browser geolocation detection was silently failing on minoo.live because the JS accessed `data.community.name` but the `/api/location/update` endpoint returns flat keys (`data.communityName`)
- The TypeError was swallowed by an empty `catch {}`, so the location bar never updated after successful geolocation
- Also confirmed: the MaxMind GeoIP database is not deployed to production, so IP-based fallback also returns `none` (separate infrastructure task)

## Test plan
- [ ] Deploy and verify browser geolocation prompt appears on minoo.live
- [ ] After allowing geolocation, confirm location bar updates to show nearest community
- [ ] Verify cookie is set and persists across page loads
- [ ] Confirm IP-based detection still needs GeoIP DB deployment (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)