### PR TITLE
fix(#124): add .render() to login and register POST routes

### DIFF
--- a/src/Provider/AuthServiceProvider.php
+++ b/src/Provider/AuthServiceProvider.php
@@ -32,6 +32,7 @@ final class AuthServiceProvider extends ServiceProvider
             RouteBuilder::create('/login')
                 ->controller('Minoo\Controller\AuthController::submitLogin')
                 ->allowAll()
+                ->render()
                 ->methods('POST')
                 ->build(),
         );
@@ -51,6 +52,7 @@ final class AuthServiceProvider extends ServiceProvider
             RouteBuilder::create('/register')
                 ->controller('Minoo\Controller\AuthController::submitRegister')
                 ->allowAll()
+                ->render()
                 ->methods('POST')
                 ->build(),
         );


### PR DESCRIPTION
## Summary

- Add `.render()` to `auth.login_submit` POST route
- Add `.render()` to `auth.register_submit` POST route

Without `.render()`, the framework routes form POSTs through the JSON:API handler, which rejects `application/x-www-form-urlencoded` bodies with a 400 "Invalid JSON in request body" error. The fix marks both routes as SSR routes so they dispatch to `AuthController` as intended.

Closes #124

## Test plan

- [ ] `POST /register` with valid data redirects to `/dashboard/volunteer`
- [ ] `POST /register` with missing fields re-renders form with errors
- [ ] `POST /login` with valid credentials redirects to dashboard
- [ ] `POST /login` with invalid credentials re-renders form with error
- [ ] All 238 PHPUnit tests pass
- [ ] Playwright smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)