### PR TITLE
feat: Enhance content tone guide with writer checklist and copy patterns

### DIFF
--- a/docs/content-tone-guide.md
+++ b/docs/content-tone-guide.md
@@ -1,36 +1,52 @@
 # Minoo Content Tone Guide
 
-## Voice
+This is the source of truth for all user-facing copy on Minoo. Every word should sound like it was written by someone who belongs to this community, because it was.
 
-First-person plural ("we," "our") when speaking as community. Second-person ("you") when addressing the visitor. Never corporate third-person.
+---
+
+## Voice Principles
+
+### 1. First Person Plural
+
+Speak as the community ("we," "our") or directly to the visitor ("you"). Never corporate third-person. Never "Minoo provides" or "the platform enables."
 
 **Yes:** "Find the people who carry our communities forward."
+**Yes:** "We can connect you with a volunteer near you."
 **No:** "Minoo provides users with access to community resource databases."
+**No:** "The platform facilitates Elder-volunteer matching."
 
-## Warmth
+### 2. Neighbor Warmth
 
-Like talking to a neighbor. Direct, honest, unhurried. Not performative warmth — genuine respect.
+Like talking to a neighbor at the band office. Direct, honest, unhurried. Not performative warmth. Genuine respect.
 
 **Yes:** "A little of your time goes a long way."
-**No:** "We're SO excited to have you join our AMAZING volunteer family!"
-
-## Cultural Respect
-
-Use Anishinaabemowin terms where natural (miigwech, manoomin, Anishinaabe) with English alongside, never as decoration. Capitalize cultural roles and concepts.
-
-**Yes:** "The word aki means earth — the physical world we are responsible for."
-**No:** "Feel the zen vibes of these ancient Indigenous teachings!"
-
-## Clarity
-
-Short sentences. Active voice. No jargon. If a 14-year-old can't understand it, simplify.
-
 **Yes:** "Need a ride to an appointment? We can help."
+**No:** "We're SO excited to have you join our AMAZING volunteer family!"
 **No:** "Leveraging our volunteer network infrastructure to facilitate Elder transportation logistics."
 
-## Accessibility
+### 3. Cultural Respect
 
-Always provide a phone/in-person alternative. Never assume digital literacy. Content works without images.
+Use Anishinaabemowin terms where they add meaning, with English context alongside. Never as decoration. Capitalize cultural roles and concepts.
+
+**Yes:** "The word aki means earth, the physical world we are responsible for."
+**Yes:** "Our Knowledge Keepers carry teachings forward."
+**No:** "Feel the zen vibes of these ancient Indigenous teachings!"
+**No:** "Experience the mystical wisdom of the ancestors."
+
+### 4. Clarity
+
+Short sentences. Active voice. No jargon. If a 14-year-old from the rez can't understand it, simplify.
+
+**Yes:** "Tell us what you need and we'll find someone nearby who can help."
+**Yes:** "Rides, groceries, yard work, or a visit."
+**No:** "Submit your service request via our intake form for coordinator triage and volunteer allocation."
+
+### 5. Accessibility
+
+Always provide a phone or in-person alternative. Never assume digital literacy. Content works without images.
+
+**Yes:** "Prefer to call? Reach your community coordinator at..."
+**No:** (form-only flow with no alternative)
 
 ---
 
@@ -45,57 +61,61 @@ Always provide a phone/in-person alternative. Never assume digital literacy. Con
 | Teachings | Capitalized when referring to cultural concept | "The Seven Grandfather Teachings" |
 | Anishinaabe | Always capitalized (proper noun) | "Anishinaabe communities" |
 | Anishinaabemowin | Always capitalized (proper noun) | "Learning Anishinaabemowin" |
-| community | Lowercase unless part of proper name | "Your community" vs "Atikameksheng Anishnawbek Community" |
+| community | Lowercase unless part of proper name | "Your community" vs "Atikameksheng Anishnawbek" |
 
 ### Anishinaabemowin Usage
 
 Use Indigenous language terms when they add meaning. Always provide English context (not necessarily a direct translation) so non-speakers aren't excluded.
 
-| Term | Meaning | Usage |
-|------|---------|-------|
-| miigwech | thank you | Natural in greetings, closings |
-| manoomin | wild rice | When discussing food, land, migration |
+| Term | Meaning | When to use |
+|------|---------|-------------|
+| miigwech | thank you | Greetings, closings, confirmation pages |
+| manoomin | wild rice | Discussing food, land, migration |
 | Anishinaabe | the people / original people | Preferred over "Ojibwe" when speaking broadly |
-| Anishinaabemowin | the Ojibwe language | When discussing the language itself |
-| aki | earth, land | When discussing land, environment |
-| nibi | water | When discussing water, ceremonies |
+| Anishinaabemowin | the Ojibwe language | Discussing the language itself |
+| aki | earth, land | Discussing land, environment, territory |
+| nibi | water | Discussing water, ceremonies |
 
-### Terms to Avoid in User-Facing Copy
+### Terms to Avoid
 
-| Avoid | Use Instead |
-|-------|-------------|
-| resource people | community leaders and Knowledge Keepers |
-| traditional (as "old") | living, passed down, carried forward |
-| users | people, visitors, community members |
-| content | teachings, stories, knowledge |
-| database | collection, directory |
+| Avoid | Use Instead | Why |
+|-------|-------------|-----|
+| resource people | community leaders and Knowledge Keepers | People are not resources |
+| traditional (as "old") | living, passed down, carried forward | Culture is not past tense |
+| users | people, visitors, community members | People are not users |
+| content | teachings, stories, knowledge | Knowledge is not content |
+| database | collection, directory | Community, not corporate |
+| stakeholders | community members, partners | Relationship, not transaction |
+| leverage | use, build on | Plain language |
+| utilize | use | Plain language |
 
 ---
 
-## SHOW + TELL + INVITE Philosophy
+## SHOW + TELL + INVITE
 
 Every page should:
 
-- **SHOW** real content, real people, real places (not generic stock imagery or placeholder text)
-- **TELL** why this matters — one sentence that connects the content to the mission
-- **INVITE** action — every page has a clear "what you can do next"
+- **SHOW** real content, real people, real places (never placeholder text or stock imagery)
+- **TELL** why this matters in one sentence that connects to the mission
+- **INVITE** action, so every page has a clear next step
 
 ### Applied Examples
 
 | Page | SHOW | TELL | INVITE |
 |------|------|------|--------|
-| Homepage | Nearby communities, events, people | "Minoo connects Indigenous communities..." | Explore communities, browse people |
+| Homepage | Nearby communities, events, people | "A living map of community" | Explore communities, browse people |
 | Communities | Real communities with treaty, language, nation data | "The First Nations and municipalities of this region" | Set your location, explore a community |
-| People | Named individuals with roles, offerings, stories | "The people who carry our communities forward" | Connect with someone, filter by need |
-| Teachings | Categorized teachings with tags, sources | "Living knowledge for today's world" | Read a teaching, explore by theme |
+| People | Named individuals with roles, offerings | "The people who carry our communities forward" | Connect with someone, filter by need |
+| Teachings | Categorized teachings with tags, sources | "Living knowledge for right now" | Read a teaching, explore by theme |
 | Events | Dated events with types, locations | "Gather, celebrate, learn, heal" | Find an event near you |
+| Language | Dictionary entries with examples | "A language spoken on this land for thousands of years" | Explore words, contribute |
 | Elder Support | How it works, request flow | "Caring for our Elders is caring for ourselves" | Request help, volunteer |
 
 ---
 
 ## Narrative Pillars
 
-Copy across the platform should connect to one or more of these four pillars:
+All copy connects to one or more of these four pillars:
 
 1. **Living Knowledge** — Teachings are practical wisdom for navigating today's world, not artifacts of the past. Use present tense. Frame culture as a way of being, not a museum exhibit.
 
@@ -104,3 +124,55 @@ Copy across the platform should connect to one or more of these four pillars:
 3. **Rooted Connection** — Community is geographic, relational, and spiritual. Location-aware features connect people to their territory. No page is a dead end.
 
 4. **Reciprocal Care** — Supporting Elders is the natural flow of intergenerational responsibility. Volunteering is an honor. Acknowledge what volunteers receive, not just what they give.
+
+---
+
+## Writer Checklist
+
+Before publishing any copy, check:
+
+- [ ] Does it sound like a community member wrote it, not a consultant?
+- [ ] Is it first-person plural ("we") or second-person ("you"), never third-person?
+- [ ] Are cultural terms (Elder, Knowledge Keeper, Teachings) capitalized?
+- [ ] Are Anishinaabemowin terms used meaningfully with English context?
+- [ ] Could a 14-year-old understand it?
+- [ ] Does the page SHOW something real, TELL why it matters, and INVITE action?
+- [ ] Is there a phone or in-person alternative where applicable?
+- [ ] Are there no terms from the "Avoid" list?
+- [ ] Is it free of performative warmth or corporate speak?
+- [ ] Does it connect to at least one narrative pillar?
+
+---
+
+## Page Copy Patterns
+
+### Listing Page Intro
+
+One sentence. Direct. Says what the visitor will find and why it matters.
+
+**Pattern:** "[What this page shows]. [Why it matters or what you can do.]"
+
+**Examples:**
+- Events: "Powwows, ceremonies, and community gatherings happening across the region."
+- Teachings: "Living knowledge passed down through generations, for right now."
+- People: "The Elders, Knowledge Keepers, and community leaders who carry our communities forward."
+
+### Empty States
+
+When a listing has no content yet, acknowledge it honestly and point somewhere useful. Never apologize. Never say "coming soon."
+
+**Pattern:** "[What will appear here] as [how it gets here]. [Redirect to something useful.]"
+
+**Example:** "Anishinaabemowin words and meanings will appear here as speakers and language learners contribute."
+
+### Confirmation Pages
+
+After form submission, confirm what happened, say what comes next, and give a timeline.
+
+**Pattern:** "Miigwech, [name]. [What happens next]. [When to expect it]. [What to do if plans change]."
+
+### Error States
+
+Be honest. Don't blame the visitor. Offer a way forward.
+
+**Pattern:** "[What went wrong in plain language]. [What the visitor can do about it]."

--- a/templates/404.html.twig
+++ b/templates/404.html.twig
@@ -4,8 +4,8 @@
 
 {% block content %}
   <div class="flow-lg">
-    <h1>Not Found</h1>
-    <p>The page <code>{{ path }}</code> could not be found.</p>
-    <p><a href="/">Return to the homepage</a></p>
+    <h1>Page Not Found</h1>
+    <p>We couldn't find what you're looking for. It may have moved or been removed.</p>
+    <p><a href="/">Go back to the homepage</a></p>
   </div>
 {% endblock %}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -7,7 +7,7 @@
     <section class="hero hero--home">
       <div class="hero__inner">
         <h1 class="hero__title">Minoo: A <em>Living</em> Map of Community</h1>
-        <p class="hero__subtitle">Find the people, teachings, events, and programs that strengthen where you live. Explore your community — and the communities around you.</p>
+        <p class="hero__subtitle">Find the people, teachings, events, and programs that strengthen where you live. Explore your community and the communities around you.</p>
         <div class="hero__actions">
           <a href="/communities" class="btn btn--primary btn--lg">Explore Communities</a>
           <a href="/people" class="btn btn--secondary btn--lg">Browse People</a>

--- a/tests/playwright/homepage.spec.ts
+++ b/tests/playwright/homepage.spec.ts
@@ -44,4 +44,14 @@ test.describe('Homepage', () => {
     await expect(page.locator('.site-nav a[href="/teachings"]')).toBeVisible();
     await expect(page.locator('.site-nav a[href="/events"]')).toBeVisible();
   });
+
+  test('homepage copy follows tone guide', async ({ page }) => {
+    await page.goto('/');
+    const subtitle = page.locator('.hero__subtitle');
+    await expect(subtitle).toContainText('Find the people, teachings, events, and programs');
+    await expect(subtitle).not.toContainText('Minoo provides');
+    await expect(subtitle).not.toContainText('users');
+    await expect(page.locator('.audience-grid')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Who is Minoo for?' })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Restructured tone guide with numbered voice principles and expanded examples
- Added writer checklist for pre-publish copy review
- Added page copy patterns (listing intros, empty states, confirmations, errors)
- Fixed homepage hero em-dash, warmed 404 copy
- Added Playwright test for homepage copy tone compliance

## Test plan
- [ ] PHPUnit full suite passes
- [ ] Playwright homepage copy test passes
- [ ] Visual review of 404 page copy

Rollback: `git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)