### PR TITLE
feat: CSS tightening, date formatting helper, and component audit

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -376,6 +376,7 @@
   .site-main {
     padding-block: var(--space-lg);
     padding-inline: var(--gutter);
+    min-block-size: 60vh;
   }
 
   .site-main__inner {
@@ -1071,6 +1072,10 @@
     display: grid;
     gap: var(--space-sm);
     max-inline-size: 40rem;
+  }
+
+  .form--centered {
+    margin-inline: auto;
   }
 
   .form__field {

--- a/src/Provider/FlashServiceProvider.php
+++ b/src/Provider/FlashServiceProvider.php
@@ -6,6 +6,7 @@ namespace Minoo\Provider;
 
 use Minoo\Service\FlashMessageService;
 use Minoo\Support\Flash;
+use Minoo\Twig\DateTwigExtension;
 use Minoo\Twig\FlashTwigExtension;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\SSR\ThemeServiceProvider;
@@ -27,5 +28,6 @@ final class FlashServiceProvider extends ServiceProvider
         $service = new FlashMessageService();
         Flash::setService($service);
         $twig->addExtension(new FlashTwigExtension($service));
+        $twig->addExtension(new DateTwigExtension());
     }
 }

--- a/src/Twig/DateTwigExtension.php
+++ b/src/Twig/DateTwigExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class DateTwigExtension extends AbstractExtension
+{
+    /** @return TwigFilter[] */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('friendly_date', $this->friendlyDate(...)),
+        ];
+    }
+
+    public function friendlyDate(?string $dateString): string
+    {
+        if ($dateString === null || $dateString === '') {
+            return '';
+        }
+
+        try {
+            $date = new \DateTimeImmutable($dateString);
+        } catch (\Exception) {
+            return $dateString;
+        }
+
+        $now = new \DateTimeImmutable();
+        $today = $now->format('Y-m-d');
+        $tomorrow = $now->modify('+1 day')->format('Y-m-d');
+        $dateDay = $date->format('Y-m-d');
+
+        if ($dateDay === $today) {
+            return 'Today, ' . $date->format('g:i A');
+        }
+
+        if ($dateDay === $tomorrow) {
+            return 'Tomorrow, ' . $date->format('g:i A');
+        }
+
+        if ($date->format('Y') === $now->format('Y')) {
+            return $date->format('M j, g:i A');
+        }
+
+        return $date->format('M j, Y');
+    }
+}

--- a/tests/Minoo/Unit/Twig/DateTwigExtensionTest.php
+++ b/tests/Minoo/Unit/Twig/DateTwigExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Twig;
+
+use Minoo\Twig\DateTwigExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DateTwigExtension::class)]
+final class DateTwigExtensionTest extends TestCase
+{
+    private DateTwigExtension $ext;
+
+    protected function setUp(): void
+    {
+        $this->ext = new DateTwigExtension();
+    }
+
+    #[Test]
+    public function registersFilterNamedFriendlyDate(): void
+    {
+        $filters = $this->ext->getFilters();
+
+        self::assertCount(1, $filters);
+        self::assertSame('friendly_date', $filters[0]->getName());
+    }
+
+    #[Test]
+    public function returnsEmptyStringForNull(): void
+    {
+        self::assertSame('', $this->ext->friendlyDate(null));
+    }
+
+    #[Test]
+    public function returnsEmptyStringForEmptyString(): void
+    {
+        self::assertSame('', $this->ext->friendlyDate(''));
+    }
+
+    #[Test]
+    public function returnsOriginalStringForInvalidDate(): void
+    {
+        self::assertSame('not-a-date', $this->ext->friendlyDate('not-a-date'));
+    }
+
+    #[Test]
+    public function formatsTodayWithTime(): void
+    {
+        $today = (new \DateTimeImmutable())->format('Y-m-d') . ' 14:30:00';
+
+        $result = $this->ext->friendlyDate($today);
+
+        self::assertStringStartsWith('Today, ', $result);
+        self::assertStringContainsString('2:30 PM', $result);
+    }
+
+    #[Test]
+    public function formatsTomorrowWithTime(): void
+    {
+        $tomorrow = (new \DateTimeImmutable('+1 day'))->format('Y-m-d') . ' 09:00:00';
+
+        $result = $this->ext->friendlyDate($tomorrow);
+
+        self::assertStringStartsWith('Tomorrow, ', $result);
+    }
+
+    #[Test]
+    public function formatsSameYearWithoutYear(): void
+    {
+        $date = (new \DateTimeImmutable())->format('Y') . '-06-15 10:00:00';
+
+        $result = $this->ext->friendlyDate($date);
+
+        self::assertStringContainsString('Jun 15', $result);
+        self::assertStringNotContainsString((new \DateTimeImmutable())->format('Y'), $result);
+    }
+
+    #[Test]
+    public function formatsDifferentYearWithYear(): void
+    {
+        $result = $this->ext->friendlyDate('2020-03-15 10:00:00');
+
+        self::assertSame('Mar 15, 2020', $result);
+    }
+}

--- a/tests/playwright/empty-states.spec.ts
+++ b/tests/playwright/empty-states.spec.ts
@@ -70,6 +70,18 @@ test.describe('Empty state component', () => {
     }
   });
 
+  test('empty state has correct visual styling', async ({ page }) => {
+    await page.goto('/events');
+    const emptyState = page.locator('.empty-state');
+
+    if (await emptyState.count() > 0) {
+      const bgColor = await emptyState.evaluate(el => getComputedStyle(el).backgroundColor);
+      const borderLeft = await emptyState.evaluate(el => getComputedStyle(el).borderInlineStartWidth);
+      expect(bgColor).not.toBe('rgba(0, 0, 0, 0)');
+      expect(parseFloat(borderLeft)).toBeGreaterThan(0);
+    }
+  });
+
   test('empty state action links are valid', async ({ page }) => {
     // Check all pages for empty states with working action links
     const pages = ['/events', '/groups', '/teachings', '/language', '/people'];


### PR DESCRIPTION
## Summary
- Add min-block-size to main content area for consistent page height
- Add `.form--centered` utility class for centered form layouts
- Add `friendly_date` Twig filter for human-readable date formatting
- Playwright test for empty-state visual styling
- Component audit confirmed all cards and partials are clean

## Test plan
- [x] DateTwigExtension unit tests pass (8 tests, 11 assertions)
- [ ] PHPUnit full suite passes
- [ ] Playwright empty-state styling test passes

Rollback: `git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)