### PR TITLE
feat: One-sentence intros and empty-state consistency across all listings

### DIFF
--- a/templates/communities.html.twig
+++ b/templates/communities.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/communities' %}
     <div class="flow-lg">
       <h1>Communities</h1>
-      <p class="hero__subtitle">The First Nations and municipalities of northern Ontario. Each community has its own history, language, and treaty relationships. {% if location is defined and location.hasLocation() %}Showing communities nearest to {{ location.communityName }}.{% else %}Set your location to see what's nearby.{% endif %}</p>
+      <p class="hero__subtitle">The First Nations and municipalities of northern Ontario.{% if location is defined and location.hasLocation() %} Showing communities nearest to {{ location.communityName }}.{% endif %}</p>
 
       <div class="communities__filters">
         <a href="/communities" class="btn btn--sm{% if type_filter == '' %} btn--active{% endif %}">All</a>
@@ -63,7 +63,12 @@
           {% endfor %}
         </div>
       {% else %}
-        <p>No communities found.</p>
+        {% include "components/empty-state.html.twig" with {
+          heading: "No communities found",
+          body: "No communities match your current filters. Try adjusting your search or removing filters.",
+          action_url: "/communities",
+          action_label: "View all communities"
+        } %}
       {% endif %}
     </div>
   {% elseif community is defined and community %}
@@ -292,7 +297,7 @@
   {% else %}
     <div class="flow-lg">
       <h1>Community Not Found</h1>
-      <p>The community at <code>{{ path }}</code> could not be found.</p>
+      <p>We couldn't find this community. It may have been removed or the link may be outdated.</p>
       <p><a href="/communities">Browse all communities</a></p>
     </div>
   {% endif %}

--- a/templates/events.html.twig
+++ b/templates/events.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/events' %}
     <div class="flow-lg">
       <h1>Events</h1>
-      <p class="hero__subtitle">Powwows, gatherings, ceremonies, and community events happening across the region. Come learn, celebrate, and connect.</p>
+      <p class="hero__subtitle">Powwows, ceremonies, and community gatherings happening across the region.</p>
 
       {% if events is defined and events|length > 0 %}
         <div class="card-grid">
@@ -62,7 +62,7 @@
   {% else %}
     <div class="flow-lg">
       <h1>Event Not Found</h1>
-      <p>The event at <code>{{ path }}</code> could not be found.</p>
+      <p>We couldn't find this event. It may have been removed or the link may be outdated.</p>
       <p><a href="/events">Browse all events</a></p>
     </div>
   {% endif %}

--- a/templates/groups.html.twig
+++ b/templates/groups.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/groups' %}
     <div class="flow-lg">
       <h1>Groups</h1>
-      <p>Communities, organizations, and advocacy groups.</p>
+      <p class="hero__subtitle">Cultural organizations, youth programs, and advocacy groups across the region.</p>
 
       {% if groups is defined and groups|length > 0 %}
         <div class="card-grid">
@@ -58,7 +58,7 @@
   {% else %}
     <div class="flow-lg">
       <h1>Group Not Found</h1>
-      <p>The group at <code>{{ path }}</code> could not be found.</p>
+      <p>We couldn't find this group. It may have been removed or the link may be outdated.</p>
       <p><a href="/groups">Browse all groups</a></p>
     </div>
   {% endif %}

--- a/templates/language.html.twig
+++ b/templates/language.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/language' %}
     <div class="flow-lg">
       <h1>Language</h1>
-      <p class="hero__subtitle">Anishinaabemowin carries a worldview that English cannot. Explore words, meanings, and the structure of a language that has been spoken on this land for thousands of years.</p>
+      <p class="hero__subtitle">Anishinaabemowin words, meanings, and the structure of a language spoken on this land for thousands of years.</p>
 
       {% if entries is defined and entries|length > 0 %}
         <div class="card-grid">
@@ -63,7 +63,7 @@
   {% else %}
     <div class="flow-lg">
       <h1>Entry Not Found</h1>
-      <p>The dictionary entry at <code>{{ path }}</code> could not be found.</p>
+      <p>We couldn't find this dictionary entry. It may have been removed or the link may be outdated.</p>
       <p><a href="/language">Browse all entries</a></p>
     </div>
   {% endif %}

--- a/templates/people.html.twig
+++ b/templates/people.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/people' %}
     <div class="flow-lg">
       <h1>People</h1>
-      <p class="hero__subtitle">The Elders, Knowledge Keepers, language speakers, makers, and community leaders who carry our communities forward. Find someone near you — or discover what people in your region have to offer.</p>
+      <p class="hero__subtitle">The Elders, Knowledge Keepers, language speakers, makers, and community leaders who carry our communities forward.</p>
 
       {% if location is defined and location.hasLocation() %}
         <p class="text-secondary">Showing results near {{ location.communityName }}. <a href="/people?all=1">Show all</a></p>
@@ -141,7 +141,7 @@
   {% else %}
     <div class="flow-lg">
       <h1>Person Not Found</h1>
-      <p>The person at <code>{{ path }}</code> could not be found.</p>
+      <p>We couldn't find this person. Their profile may have been removed or the link may be outdated.</p>
       <p><a href="/people">Browse all people</a></p>
     </div>
   {% endif %}

--- a/templates/teachings.html.twig
+++ b/templates/teachings.html.twig
@@ -14,7 +14,7 @@
   {% if path == '/teachings' %}
     <div class="flow-lg">
       <h1>Teachings</h1>
-      <p class="hero__subtitle">Living knowledge passed down through generations — culture, history, and language Teachings that guide how we live, relate, and care for the land. These aren't lessons from the past. They're wisdom for right now.</p>
+      <p class="hero__subtitle">Living knowledge passed down through generations, for right now.</p>
 
       {% if teachings is defined and teachings|length > 0 %}
         <div class="card-grid">
@@ -54,8 +54,8 @@
   {% else %}
     <div class="flow-lg">
       <h1>Teaching Not Found</h1>
-      <p>The teaching at <code>{{ path }}</code> could not be found.</p>
-      <p><a href="/teachings">Browse all teachings</a></p>
+      <p>We couldn't find this teaching. It may have been removed or the link may be outdated.</p>
+      <p><a href="/teachings">Browse all Teachings</a></p>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/playwright/content-pages.spec.ts
+++ b/tests/playwright/content-pages.spec.ts
@@ -33,3 +33,48 @@ test('404 for invalid language slug', async ({ page }) => {
   const response = await page.goto('/language/nonexistent-slug-xyz');
   expect(response?.status()).toBe(404);
 });
+
+test.describe('Listing page intros follow one-sentence rule', () => {
+  const pages = [
+    { path: '/events', intro: /region/ },
+    { path: '/groups', intro: /region/ },
+    { path: '/teachings', intro: /right now/ },
+    { path: '/language', intro: /thousands of years/ },
+    { path: '/people', intro: /carry our communities forward/ },
+    { path: '/communities', intro: /northern Ontario/ },
+  ];
+
+  for (const { path, intro } of pages) {
+    test(`${path} has concise intro`, async ({ page }) => {
+      await page.goto(path);
+      const subtitle = page.locator('.hero__subtitle');
+      await expect(subtitle).toContainText(intro);
+    });
+  }
+});
+
+test.describe('Listing pages use empty-state or card-grid', () => {
+  const pages = ['/events', '/groups', '/teachings', '/language', '/people', '/communities'];
+
+  for (const path of pages) {
+    test(`${path} has empty-state component or card-grid`, async ({ page }) => {
+      await page.goto(path);
+      const hasCards = await page.locator('.card-grid').count() > 0;
+      const hasEmptyState = await page.locator('.empty-state').count() > 0;
+      expect(hasCards || hasEmptyState).toBeTruthy();
+    });
+  }
+});
+
+test.describe('Not-found pages use warm copy', () => {
+  const slugs = ['/events/nonexistent', '/groups/nonexistent', '/teachings/nonexistent', '/language/nonexistent', '/people/nonexistent', '/communities/nonexistent'];
+
+  for (const slug of slugs) {
+    test(`${slug} uses friendly not-found message`, async ({ page }) => {
+      await page.goto(slug);
+      const body = await page.locator('.flow-lg').textContent();
+      expect(body).not.toContain('<code>');
+      expect(body).toContain("couldn't find");
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Tighten all 6 listing page intros to single concise sentences
- Remove em-dashes per voice guidelines
- Replace raw `<p>` empty state in communities with empty-state component
- Replace technical `<code>` not-found messages with warm community copy
- Add Playwright tests for intro conciseness, empty-state presence, and friendly not-found messages

## Test plan
- [ ] PHPUnit full suite passes
- [ ] Playwright content-pages tests pass (18 new assertions)
- [ ] Visual check: all listing pages render intro + empty-state or card-grid

Rollback: `git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)