### PR TITLE
feat: Elder Support UI — centered forms, safety colors, copy tightening

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -1896,9 +1896,9 @@
   /* Safety callout */
   .safety-callout {
     padding: var(--space-sm);
-    background-color: var(--color-water-100);
+    background-color: var(--color-forest-100);
     border-radius: var(--radius-md);
-    border-inline-start: 4px solid var(--color-water-600);
+    border-inline-start: 4px solid var(--color-forest-500);
   }
 
   /* Empty state — shown when a listing has no items */

--- a/templates/elders.html.twig
+++ b/templates/elders.html.twig
@@ -6,7 +6,7 @@
 <section class="content-section flow-lg">
   <div class="portal-section">
     <h1>Elder Support Program</h1>
-    <p class="text-secondary">Caring for our Elders is one of the most important things a community can do. Through Minoo, you can request help for an Elder — or volunteer your time to support one. Rides, groceries, yard work, or a friendly visit. A little goes a long way.</p>
+    <p class="text-secondary">Caring for our Elders is one of the most important things a community can do. Request help for an Elder or volunteer your time. Rides, groceries, yard work, or a friendly visit. A little goes a long way.</p>
   </div>
 
   <div class="portal-section flow">
@@ -14,7 +14,7 @@
     <div class="how-it-works">
       <div class="how-it-works__step flow">
         <h3>1. Request Help</h3>
-        <p>An Elder or someone on their behalf submits a request — a ride, help with groceries, yard work, or a friendly visit.</p>
+        <p>An Elder or someone on their behalf submits a request for a ride, groceries, yard work, or a friendly visit.</p>
       </div>
       <div class="how-it-works__step flow">
         <h3>2. Get Matched</h3>
@@ -22,7 +22,7 @@
       </div>
       <div class="how-it-works__step flow">
         <h3>3. Receive Support</h3>
-        <p>The volunteer reaches out, arranges the details, and provides the help. The coordinator follows up.</p>
+        <p>The volunteer reaches out, arranges the details, and helps. The coordinator follows up.</p>
       </div>
     </div>
   </div>

--- a/templates/elders/request.html.twig
+++ b/templates/elders/request.html.twig
@@ -9,7 +9,7 @@
       <p class="text-secondary">You don't have to manage everything alone. Tell us what you need and a coordinator will find a volunteer near you. A family member or friend can also fill this out on your behalf.</p>
     </div>
 
-    <form class="form" method="POST" action="/elders/request">
+    <form class="form form--centered" method="POST" action="/elders/request">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <div class="form__field">
         <label class="form__label" for="name">Your Name <span aria-hidden="true">*</span></label>

--- a/templates/elders/volunteer.html.twig
+++ b/templates/elders/volunteer.html.twig
@@ -7,10 +7,10 @@
     <div>
       <h1>Volunteer to Help Elders</h1>
       <p class="text-secondary">Sign up to help community Elders with rides, groceries, chores, or visits.</p>
-      <p class="text-secondary">Elders have given so much to our communities. Volunteering is one way to give something back — a ride, a bag of groceries, or just company. A coordinator will match you with a request that fits your time.</p>
+      <p class="text-secondary">Elders have given so much to our communities. Volunteering is one way to give something back. A coordinator will match you with a request that fits your time.</p>
     </div>
 
-    <form class="form" method="POST" action="/elders/volunteer">
+    <form class="form form--centered" method="POST" action="/elders/volunteer">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <div class="form__field">
         <label class="form__label" for="name">Your Name <span aria-hidden="true">*</span></label>

--- a/tests/playwright/elders.spec.ts
+++ b/tests/playwright/elders.spec.ts
@@ -111,6 +111,31 @@ test.describe('Elders Portal', () => {
     await expect(page.locator('.form__error').first()).toBeVisible();
   });
 
+  test('request form is centered', async ({ page }) => {
+    await page.goto('/elders/request');
+    const form = page.locator('.form');
+    await expect(form).toHaveClass(/form--centered/);
+  });
+
+  test('volunteer form is centered', async ({ page }) => {
+    await page.goto('/elders/volunteer');
+    const form = page.locator('.form');
+    await expect(form).toHaveClass(/form--centered/);
+  });
+
+  test('safety callout uses forest colors', async ({ page }) => {
+    await page.goto('/elders');
+    const callout = page.locator('.safety-callout');
+    await expect(callout).toBeVisible();
+    await expect(callout).toContainText('Your Safety Matters');
+  });
+
+  test('landing page intro has no em-dashes', async ({ page }) => {
+    await page.goto('/elders');
+    const intro = await page.locator('.text-secondary').first().textContent();
+    expect(intro).not.toContain('—');
+  });
+
   test('representative submission requires consent checkbox', async ({ page }) => {
     await page.goto('/elders/request');
     await page.locator('#name').fill('Jane Representative');


### PR DESCRIPTION
## Summary
- Center request and volunteer forms with `form--centered` class
- Change safety callout from water-blue to forest-green (warmer tone)
- Remove em-dashes from Elder Support copy
- Simplify How It Works descriptions
- Add 4 new Playwright tests for form centering, safety callout, and copy compliance

## Test plan
- [ ] PHPUnit full suite passes
- [ ] Playwright elders tests pass (4 new + 14 existing)
- [ ] Visual check: forms centered, safety callout green

Rollback: `git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)