### PR TITLE
feat: Center auth forms, welcoming copy, and updated account home

### DIFF
--- a/templates/account/home.html.twig
+++ b/templates/account/home.html.twig
@@ -3,8 +3,11 @@
 {% block title %}Your Account — Minoo{% endblock %}
 
 {% block content %}
-<section class="account-home">
-  <h1>Your Account</h1>
+<section class="account-home flow-lg">
+  <div>
+    <h1>Welcome back{% if account is defined and account.getName() %}, {{ account.getName() }}{% endif %}</h1>
+    <p class="text-secondary">This is your home on Minoo. From here you can manage your account and access community tools.</p>
+  </div>
 
   <div class="actions">
     <h2>Profile</h2>
@@ -16,6 +19,7 @@
   {% if 'volunteer' in roles %}
   <div class="actions">
     <h2>Elder Support Program</h2>
+    <p class="text-secondary">You're a registered volunteer. Check your assignments and update your availability.</p>
     <ul class="links">
       <li><a href="/dashboard/volunteer">My Assignments</a></li>
     </ul>
@@ -25,6 +29,7 @@
   {% if 'elder_coordinator' in roles %}
   <div class="actions">
     <h2>Coordination</h2>
+    <p class="text-secondary">Manage Elder Support requests and coordinate volunteers in your community.</p>
     <ul class="links">
       <li><a href="/dashboard/coordinator">Coordinator Dashboard</a></li>
     </ul>

--- a/templates/auth/forgot-password.html.twig
+++ b/templates/auth/forgot-password.html.twig
@@ -18,7 +18,7 @@
     </div>
   {% endif %}
 
-  <form class="form" method="post" action="/forgot-password">
+  <form class="form form--centered" method="post" action="/forgot-password">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <div class="form__field">
       <label class="form__label" for="email">Email</label>

--- a/templates/auth/login.html.twig
+++ b/templates/auth/login.html.twig
@@ -4,9 +4,10 @@
 
 {% block content %}
 <section class="content-section flow-lg">
-  <h1>Sign in to your account</h1>
+  <h1>Sign In</h1>
+  <p class="text-secondary">Welcome back. Sign in to access your account and community tools.</p>
 
-  <form class="form" method="post" action="/login">
+  <form class="form form--centered" method="post" action="/login">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     {% if redirect is defined and redirect %}
       <input type="hidden" name="redirect" value="{{ redirect|e('html_attr') }}">

--- a/templates/auth/register.html.twig
+++ b/templates/auth/register.html.twig
@@ -5,8 +5,9 @@
 {% block content %}
 <section class="content-section flow-lg">
   <h1>Create Account</h1>
+  <p class="text-secondary">Join Minoo to connect with your community, volunteer, or access Elder Support.</p>
 
-  <form class="form" method="post" action="/register">
+  <form class="form form--centered" method="post" action="/register">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <div class="form__field">
       <label class="form__label" for="name">Name</label>

--- a/tests/playwright/account.spec.ts
+++ b/tests/playwright/account.spec.ts
@@ -14,7 +14,10 @@ test.describe('Account Home — member user', () => {
     await page.fill('input[name="password"]', 'MemberPass123!');
     await page.click('button[type="submit"]');
     await page.waitForURL('/account');
-    await expect(page.locator('h1')).toContainText('Your Account');
+    await expect(page.locator('h1')).toContainText('Welcome back');
+
+    // Verify welcoming description
+    await expect(page.locator('.text-secondary').first()).toContainText('your home on Minoo');
 
     // Also verify within same session: sign out link, no volunteer links, nav
     await expect(page.locator('.account-home a[href="/logout"]')).toBeVisible();

--- a/tests/playwright/auth.spec.ts
+++ b/tests/playwright/auth.spec.ts
@@ -132,6 +132,23 @@ test.describe('Auth flows', () => {
     await expect(page).toHaveURL(/\/login\?redirect=/);
   });
 
+  test('login form is centered with welcoming copy', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('.form')).toHaveClass(/form--centered/);
+    await expect(page.locator('.text-secondary')).toContainText('Welcome back');
+  });
+
+  test('register form is centered with welcoming copy', async ({ page }) => {
+    await page.goto('/register');
+    await expect(page.locator('.form')).toHaveClass(/form--centered/);
+    await expect(page.locator('.text-secondary')).toContainText('Join Minoo');
+  });
+
+  test('forgot-password form is centered', async ({ page }) => {
+    await page.goto('/forgot-password');
+    await expect(page.locator('.form')).toHaveClass(/form--centered/);
+  });
+
   test('login page has link to register', async ({ page }) => {
     await page.goto('/login');
     await expect(page.locator('a[href="/register"]')).toBeVisible();


### PR DESCRIPTION
## Summary
- Center login, register, and forgot-password forms with `form--centered`
- Add welcoming intro lines to login ("Welcome back") and register ("Join Minoo")
- Update account home with personalized greeting and role descriptions
- Add 3 new Playwright auth tests + update account home test

## Test plan
- [ ] PHPUnit full suite passes
- [ ] Playwright auth + account tests pass
- [ ] Visual check: forms centered, welcoming copy visible

Rollback: `git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)