### PR TITLE
docs: V1.0.2 release notes + changelog + deploy runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to the Minoo project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.2] — 2026-03-14
+
+### Added
+- Leadership pipeline integration with NorthCloud (#189, #190, #191)
+  - Community source linking via NC API
+  - Leadership scrape job creation
+  - Leader entity type with ingestion pipeline
+- Dictionary source switched to NorthCloud API (#203)
+  - Paginated sync with dry-run mode
+  - Dual-format mapper (OPD + NC API)
+  - Attribution tracking
+- Consent fields (`consent_public`, `consent_ai_training`) on all content entities (#202 Gate 3)
+- Copyright filtering on HomeController and PeopleController (#202 Gate 2)
+- Export governance: `bin/export-communities` requires `--confirm` flag (#202 Gate 4)
+- Migration runner with transaction wrapping and deploy integration
+- Initial schema migration (001) for community tables
+- Dry-run flag for `bin/backfill-nc-ids` (#186)
+
+### Changed
+- `composer.json` license corrected from GPL-2.0-or-later to MIT (#202 Gate 1)
+
+### Fixed
+- Migration runner: transaction wrapping to prevent partial applies
+- Migration runner: source `shared/.env` before running `bin/migrate` in deploy
+- Migration 001: removed community_type backfill that caused issues on fresh installs
+
+## [1.0.1] — 2026-03-13
+
+### Added
+- Community registry sync with NorthCloud (#135, #177)
+
+### Changed
+- Added `.superpowers/` to `.gitignore`
+
+## [1.0.0] — 2026-03-12
+
+### Added
+- Initial V1 release of Minoo Indigenous knowledge platform
+- Elder Support Program with 6-state volunteer matching workflow
+- Community Registry with 637 First Nations communities from CIRNAC open data
+- Anishinaabemowin dictionary with entries, example sentences, word parts, and speaker data
+- Teachings and Events browsing with card-based layouts
+- Full-text search across all content types
+- Server-side rendered Twig templates with vanilla CSS design system
+- 252+ PHPUnit tests and Playwright e2e suite
+- Deployer-based deployment with instant rollback
+- AI chat feature (disabled by default)

--- a/docs/releases/v1-deploy-runbook.md
+++ b/docs/releases/v1-deploy-runbook.md
@@ -1,0 +1,191 @@
+# V1 Deployment Runbook
+
+This runbook covers deploying Minoo V1.0.2 to staging and production.
+
+---
+
+## Prerequisites
+
+- PHP 8.4+ with extensions: `pdo_sqlite`, `sqlite3`, `mbstring`, `xml`
+- Composer 2.x
+- [PHP Deployer](https://deployer.org/) installed (`composer global require deployer/deployer`)
+- SSH access to target server (`minoo.live`)
+- GitHub CLI (`gh`) for workflow dispatch
+
+---
+
+## Pre-deploy Checklist
+
+1. Verify CI is green on `main`:
+   ```bash
+   gh run list --branch main --limit 5
+   ```
+
+2. Run smoke tests locally:
+   ```bash
+   bin/smoke-test
+   ```
+
+3. Run release validation:
+   ```bash
+   bin/validate-release
+   ```
+
+4. Verify production `.env` has all required NorthCloud variables:
+   ```
+   NC_API_URL=https://api.northcloud.one
+   NC_API_TOKEN=<token>
+   ```
+
+5. Verify production `.env` has database and app configuration:
+   ```
+   APP_ENV=production
+   APP_DEBUG=false
+   WAASEYAA_DB=/path/to/production.sqlite
+   ```
+
+---
+
+## Deploy to Staging
+
+```bash
+dep deploy staging
+```
+
+### Staging Verification
+
+1. Check health endpoint responds:
+   ```bash
+   curl -s https://staging.minoo.live/health
+   ```
+
+2. Verify dictionary entries load on `/language` page
+
+3. Verify community pages show leadership data
+
+4. Verify consent fields are present on content entities
+
+5. Run smoke tests against staging:
+   ```bash
+   MINOO_BASE_URL=https://staging.minoo.live bin/smoke-test
+   ```
+
+---
+
+## Deploy to Production
+
+### Option 1: GitHub Actions (Recommended)
+
+```bash
+gh workflow run deploy-production.yml -f confirm=deploy-v1
+```
+
+Monitor the run:
+```bash
+gh run watch
+```
+
+### Option 2: Manual Deploy
+
+```bash
+dep deploy production --no-interaction
+```
+
+### What the Deploy Does
+
+1. Checks out `minoo` and `waaseyaa/framework` repositories
+2. Installs production dependencies (`composer install --no-dev`)
+3. Assembles build artifact (excludes tests, docs, dev files)
+4. Deploys via PHP Deployer (rsync to server, symlink swap)
+5. Runs migrations (`bin/migrate`)
+
+---
+
+## Post-deploy Verification
+
+Run these checks immediately after deployment:
+
+1. **Health endpoint:**
+   ```bash
+   curl -s https://minoo.live/health
+   ```
+
+2. **Dictionary entries load:**
+   Visit `https://minoo.live/language` -- verify entries display with OPD attribution.
+
+3. **Community pages show leadership:**
+   Visit any community detail page -- verify leadership section renders.
+
+4. **Robots.txt blocks sensitive paths:**
+   ```bash
+   curl -s https://minoo.live/robots.txt
+   ```
+   Verify `/api/` and `/dashboard/` are disallowed.
+
+5. **Footer attribution:**
+   Check page footer displays CC BY-NC-SA 4.0 notice and OPD attribution link.
+
+6. **Consent fields active:**
+   Verify content with `consent_public = false` does not appear on public pages.
+
+7. **Export governance:**
+   ```bash
+   ssh deployer@minoo.live "cd /opt/minoo/current && bin/export-communities"
+   ```
+   Should fail without `--confirm` flag.
+
+---
+
+## Rollback
+
+If issues are discovered post-deploy, rollback immediately:
+
+```bash
+dep rollback production
+```
+
+This performs an instant symlink swap to the previous release. No data loss occurs because:
+- All schema migrations are additive (no destructive changes)
+- SQLite database lives outside the release directory
+- Environment files are in `shared/` (not part of the release)
+
+### Rollback Verification
+
+After rollback, repeat the post-deploy verification steps above to confirm the previous release is serving correctly.
+
+---
+
+## Troubleshooting
+
+### Migration fails during deploy
+
+Migrations run in transactions. If one fails, it rolls back cleanly. Check logs:
+```bash
+ssh deployer@minoo.live "cat /opt/minoo/current/storage/logs/*.log | tail -50"
+```
+
+### NorthCloud API connection fails
+
+Verify environment variables:
+```bash
+ssh deployer@minoo.live "cd /opt/minoo/current && source shared/.env && echo \$NC_API_URL"
+```
+
+Check NC API is reachable from the server:
+```bash
+ssh deployer@minoo.live "curl -s -o /dev/null -w '%{http_code}' https://api.northcloud.one/health"
+```
+
+### Dictionary entries missing after deploy
+
+The dictionary sync runs as a scheduled job, not during deploy. Trigger manually if needed:
+```bash
+ssh deployer@minoo.live "cd /opt/minoo/current && bin/waaseyaa sync:dictionary"
+```
+
+### Deployer permission errors
+
+Ensure the `deployer` user has write access to `/opt/minoo/` and the SSH key is authorized:
+```bash
+ssh deployer@minoo.live "ls -la /opt/minoo/"
+```

--- a/docs/releases/v1.0.2-release-notes.md
+++ b/docs/releases/v1.0.2-release-notes.md
@@ -1,0 +1,96 @@
+# Minoo V1.0.2 Release Notes
+
+**Release Date:** 2026-03-14
+**Platform:** [minoo.live](https://minoo.live)
+
+---
+
+## Executive Summary
+
+Minoo V1.0.2 completes the NorthCloud integration layer and adds governance controls required for a responsible V1 launch. This release delivers two major data pipelines (leadership and dictionary), consent-based content filtering, and export governance -- establishing Minoo as a consumer of NorthCloud's canonical community dataset while enforcing Indigenous data sovereignty principles.
+
+---
+
+## Key Features
+
+### Leadership Pipeline (#189, #190, #191)
+
+Community pages now display leadership and band office information sourced from NorthCloud. The pipeline links Minoo communities to their NorthCloud source, creates leadership scrape jobs, and ingests leader entities through a dedicated ingestion pipeline.
+
+### Dictionary Source Migration (#203)
+
+The Anishinaabemowin dictionary has been migrated from static OPD imports to paginated NorthCloud API sync. A dual-format mapper handles both legacy OPD data and the NC API format. Dry-run mode allows previewing sync operations before committing. All dictionary entries carry attribution metadata linking back to The Ojibwe People's Dictionary.
+
+### Governance Controls (#202)
+
+Four governance gates shipped in this release:
+
+1. **License correction (Gate 1):** `composer.json` license updated from GPL-2.0-or-later to MIT, matching the project's actual licensing intent.
+2. **Copyright filtering (Gate 2):** HomeController and PeopleController now filter content based on copyright status, preventing display of unapproved media.
+3. **Consent fields (Gate 3):** All content entities now carry `consent_public` and `consent_ai_training` fields, defaulting to restrictive values.
+4. **Export governance (Gate 4):** `bin/export-communities` requires an explicit `--confirm` flag to prevent accidental data export.
+
+### Migration Runner
+
+A new migration runner with transaction wrapping prevents partial schema applies. Each migration runs in its own transaction and rolls back cleanly on failure. The deploy pipeline sources `shared/.env` before running migrations.
+
+---
+
+## NorthCloud Integration Summary
+
+Minoo consumes community data from NorthCloud as its upstream source of truth:
+
+- **Community registry:** 637 First Nations communities synced via NC API
+- **Leadership data:** Band council leadership sourced through NC scrape jobs
+- **Dictionary entries:** Paginated sync from NC API with OPD attribution preserved
+- **Backfill tooling:** `bin/backfill-nc-ids` links existing communities to NC source IDs
+
+Required environment variables for NC integration:
+- `NC_API_URL` -- NorthCloud API base URL
+- `NC_API_TOKEN` -- Authentication token for NC API access
+
+---
+
+## Deployment
+
+See [V1 Deployment Runbook](v1-deploy-runbook.md) for full instructions.
+
+Quick deploy:
+```bash
+gh workflow run deploy-production.yml -f confirm=deploy-v1
+```
+
+Rollback:
+```bash
+dep rollback production
+```
+
+---
+
+## Known Limitations
+
+- Content authoring is CLI/admin only -- no public content submission yet
+- Grandparent Program (structured elder profiles, onboarding) is planned for a future release
+- Multi-community coordinator scoping is planned for a future release
+- Leadership data requires manual or semi-automated scraping via NorthCloud
+- Dictionary sync is one-directional (NC to Minoo); no write-back
+
+---
+
+## Attribution and Licensing
+
+**Project License:** MIT
+
+**Dictionary Content:** Copyrighted by [The Ojibwe People's Dictionary](http://ojibwe.lib.umn.edu), used under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+**Community Data:** Sourced from Crown-Indigenous Relations and Northern Affairs Canada (CIRNAC) open data and the NorthCloud content platform.
+
+**Community-Contributed Content:** Licensed under CC BY-NC-SA 4.0.
+
+---
+
+## Acknowledgments
+
+Minoo is built on the traditional territories of the Anishinaabe people. We acknowledge the Knowledge Keepers and Elders whose teachings this platform is designed to honor and preserve.
+
+*Built by and for Indigenous communities. Miigwech.*


### PR DESCRIPTION
## Summary
- Added `CHANGELOG.md` with entries for v1.0.0, v1.0.1, and v1.0.2 (populated from git history)
- Added `docs/releases/v1.0.2-release-notes.md` with executive summary, key features (leadership pipeline, dictionary migration, governance controls), NorthCloud integration details, known limitations, and attribution/licensing
- Added `docs/releases/v1-deploy-runbook.md` with pre-deploy checklist, staging/production deploy steps, post-deploy verification, rollback procedure, and troubleshooting guide

## Test plan
- [ ] Review changelog entries match actual git log (`git log v1.0.1..HEAD --oneline`)
- [ ] Verify release notes accurately describe shipped features
- [ ] Verify deploy runbook commands match actual deploy workflow (`.github/workflows/deploy-production.yml`)
- [ ] Confirm environment variable names match production `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)