### PR TITLE
fix(communities): restore vertical scroll on mobile

### DIFF
--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -1,9 +1,4 @@
 /* Atlas Communities Redesign */
-[x-data="atlasDiscovery()"] {
-  overflow-x: hidden;
-  max-width: 100vw;
-}
-
 :root {
   --atlas-deep: #2d4a3e;
   --atlas-forest: #3d6b5a;


### PR DESCRIPTION
## Summary
- Remove `overflow-x: hidden` from `[x-data="atlasDiscovery()"]` wrapper — browsers implicitly set `overflow-y: auto` when `overflow-x` is set, creating a nested scroll container that traps vertical scroll
- Body `overflow-x: hidden` and `.atlas-map overflow: hidden` are sufficient

## Test plan
- [ ] Verify vertical scroll works on mobile at /communities
- [ ] Verify no horizontal scroll on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)