### PR TITLE
fix(css): bump cache-busters for deployed CSS changes

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,7 +6,7 @@
   <link rel="preload" href="/fonts/atkinson-hyperlegible-next-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/fonts/atkinson-hyperlegible-next-700.woff2" as="font" type="font/woff2" crossorigin>
   <title>{% block title %}Minoo{% endblock %}</title>
-  <link rel="stylesheet" href="/css/minoo.css?v=3">
+  <link rel="stylesheet" href="/css/minoo.css?v=4">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
 </head>

--- a/templates/communities/detail.html.twig
+++ b/templates/communities/detail.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ community.get('name') }} — Minoo{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/atlas.css" />
+  <link rel="stylesheet" href="/css/atlas.css?v=2" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 {% endblock %}
 

--- a/templates/communities/list.html.twig
+++ b/templates/communities/list.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ trans('communities.all_communities') }}{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/atlas.css">
+  <link rel="stylesheet" href="/css/atlas.css?v=2">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />


### PR DESCRIPTION
## Summary
- Bump `minoo.css?v=3` → `?v=4` and add `atlas.css?v=2`
- Previous deploys shipped updated CSS but browsers served stale cached versions
- Fixes: horizontal scroll fix (`overflow-x: hidden` on body) and atlas map overflow weren't taking effect

## Test plan
- [ ] Verify `minoo.css?v=4` and `atlas.css?v=2` are loaded on `/communities`
- [ ] No horizontal scroll on mobile (375px viewport)
- [ ] Vertical scroll works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)