### PR TITLE
fix(communities): constrain card width on mobile

### DIFF
--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -9,6 +9,11 @@
   --atlas-chip-bg: #c8d6c4;
 }
 
+/* --- Page Wrapper (clip Leaflet overflow without breaking vertical scroll) --- */
+[x-data="atlasDiscovery()"] {
+  overflow-x: clip;
+}
+
 /* --- Contextual Header --- */
 .atlas-header {
   background: linear-gradient(135deg, var(--atlas-deep) 0%, var(--atlas-forest) 100%);

--- a/templates/communities/detail.html.twig
+++ b/templates/communities/detail.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ community.get('name') }} — Minoo{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/atlas.css?v=2" />
+  <link rel="stylesheet" href="/css/atlas.css?v=3" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 {% endblock %}
 

--- a/templates/communities/list.html.twig
+++ b/templates/communities/list.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ trans('communities.all_communities') }}{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/atlas.css?v=2">
+  <link rel="stylesheet" href="/css/atlas.css?v=3">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />


### PR DESCRIPTION
## Summary
- Add `overflow-x: clip` to the atlas wrapper div to constrain Leaflet map overflow
- Unlike `overflow-x: hidden`, `clip` doesn't create a scroll container so vertical scroll is unaffected
- Bump `atlas.css` cache-buster to `?v=3`

## Test plan
- [ ] Cards fit within viewport on mobile (375px)
- [ ] Vertical scroll works normally
- [ ] No horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)