### PR TITLE
fix(seo): add consistent — Minoo suffix to all page titles

### DIFF
--- a/templates/about.html.twig
+++ b/templates/about.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ trans('about.title') }}{% endblock %}
+{% block title %}{{ trans('about.title') }} — Minoo{% endblock %}
 
 {% block content %}
   <div class="flow-lg">

--- a/templates/communities/list.html.twig
+++ b/templates/communities/list.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}{{ trans('communities.all_communities') }}{% endblock %}
+{% block title %}{{ trans('communities.all_communities') }} — Minoo{% endblock %}
 
 {% block head %}
   <link rel="stylesheet" href="/css/atlas.css?v=4">

--- a/templates/data-sovereignty.html.twig
+++ b/templates/data-sovereignty.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ trans('data.title') }}{% endblock %}
+{% block title %}{{ trans('data.title') }} — Minoo{% endblock %}
 
 {% block content %}
   <div class="content-section flow-lg">

--- a/templates/how-it-works.html.twig
+++ b/templates/how-it-works.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ trans('how.title') }}{% endblock %}
+{% block title %}{{ trans('how.title') }} — Minoo{% endblock %}
 
 {% block content %}
   <div class="content-section flow-lg">

--- a/templates/legal.html.twig
+++ b/templates/legal.html.twig
@@ -4,13 +4,13 @@
 
 {% block title %}
   {%- if page_path == '/legal/privacy' -%}
-    {{ trans('legal.privacy_title') }}
+    {{ trans('legal.privacy_title') }} — Minoo
   {%- elseif page_path == '/legal/terms' -%}
-    {{ trans('legal.terms_title') }}
+    {{ trans('legal.terms_title') }} — Minoo
   {%- elseif page_path == '/legal/accessibility' -%}
-    {{ trans('legal.accessibility_title') }}
+    {{ trans('legal.accessibility_title') }} — Minoo
   {%- else -%}
-    {{ trans('legal.main_title') }}
+    {{ trans('legal.main_title') }} — Minoo
   {%- endif -%}
 {% endblock %}
 

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ trans('page.title') }}{% endblock %}
+{% block title %}{{ trans('page.title') }} — Minoo{% endblock %}
 
 {% block content %}
   <div class="flow-lg">

--- a/templates/safety.html.twig
+++ b/templates/safety.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ trans('safety.title') }}{% endblock %}
+{% block title %}{{ trans('safety.title') }} — Minoo{% endblock %}
 
 {% block content %}
   <div class="content-section flow-lg">


### PR DESCRIPTION
## Summary
- Add missing `— Minoo` suffix to 7 templates that were inconsistent
- All pages now follow `Page Title — Minoo` pattern for SEO branding
- Fixed: communities list, about, safety, how it works, data sovereignty, page, legal (all 4 branches)

## Test plan
- [ ] Verify page titles include `— Minoo` on all affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)