### PR TITLE
chore: add v1 release tooling, consent migration, and gitignore .build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules/
 test-results/
 playwright-report/
 .superpowers/
+.build/

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -1,0 +1,209 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * V1 Release Smoke Test Suite
+ * Validates all critical paths are functional.
+ *
+ * Usage: bin/smoke-test
+ *
+ * Exit code 0 if all pass, 1 if any fail.
+ */
+
+$projectRoot = dirname(__DIR__);
+
+$passed = 0;
+$failed = 0;
+
+function pass(string $name): void
+{
+    global $passed;
+    fprintf(STDOUT, "[PASS] %s\n", $name);
+    $passed++;
+}
+
+function fail(string $name, string $reason = ''): void
+{
+    global $failed;
+    $msg = $reason !== '' ? sprintf('%s — %s', $name, $reason) : $name;
+    fprintf(STDOUT, "[FAIL] %s\n", $msg);
+    $failed++;
+}
+
+// ─── 1. Entity consent fields ───────────────────────────────────────────────
+
+$consentEntityTypes = [
+    'EventServiceProvider' => 'event',
+    'GroupServiceProvider' => 'group',
+    'CulturalGroupServiceProvider' => 'cultural_group',
+    'CulturalCollectionServiceProvider' => 'cultural_collection',
+    'PeopleServiceProvider' => 'resource_person',
+    'LeaderServiceProvider' => 'leader',
+    'LanguageServiceProvider' => 'dictionary_entry',
+    'TeachingServiceProvider' => 'teaching',
+];
+
+$providerDir = $projectRoot . '/src/Provider';
+
+foreach ($consentEntityTypes as $providerFile => $entityLabel) {
+    $filePath = $providerDir . '/' . $providerFile . '.php';
+    $testName = sprintf('Consent fields in %s (%s)', $providerFile, $entityLabel);
+
+    if (!is_file($filePath)) {
+        fail($testName, 'provider file not found');
+        continue;
+    }
+
+    $content = file_get_contents($filePath);
+    $hasPublic = str_contains($content, "'consent_public'");
+    $hasAi = str_contains($content, "'consent_ai_training'");
+
+    if ($hasPublic && $hasAi) {
+        pass($testName);
+    } else {
+        $missing = [];
+        if (!$hasPublic) {
+            $missing[] = 'consent_public';
+        }
+        if (!$hasAi) {
+            $missing[] = 'consent_ai_training';
+        }
+        fail($testName, 'missing: ' . implode(', ', $missing));
+    }
+}
+
+// ─── 2. NorthCloud API connectivity ─────────────────────────────────────────
+
+$configFile = $projectRoot . '/config/waaseyaa.php';
+$config = file_exists($configFile) ? require $configFile : [];
+$ncBaseUrl = rtrim((string) ($config['northcloud']['base_url'] ?? ''), '/');
+
+if ($ncBaseUrl === '') {
+    fail('NorthCloud API connectivity', 'base_url not configured');
+} else {
+    $healthUrl = $ncBaseUrl . '/health';
+    $ctx = stream_context_create(['http' => ['method' => 'GET', 'timeout' => 5, 'ignore_errors' => true]]);
+    $response = @file_get_contents($healthUrl, false, $ctx);
+
+    if ($response === false) {
+        fprintf(STDOUT, "[SKIP] NorthCloud API connectivity — %s unreachable (non-blocking)\n", $healthUrl);
+    } else {
+        pass('NorthCloud API connectivity (' . $healthUrl . ')');
+    }
+}
+
+// ─── 3. Dictionary sync dry-run (structural check) ──────────────────────────
+
+$syncScript = $projectRoot . '/bin/sync-dictionary';
+if (is_file($syncScript)) {
+    pass('Dictionary sync script exists');
+} else {
+    fail('Dictionary sync script exists', 'bin/sync-dictionary not found');
+}
+
+// ─── 4. Leadership pipeline ────────────────────────────────────────────────
+
+$leaderProvider = $providerDir . '/LeaderServiceProvider.php';
+$leaderMapper = $projectRoot . '/src/Ingestion/EntityMapper/LeaderMapper.php';
+
+if (is_file($leaderProvider)) {
+    pass('Leader entity type registered (LeaderServiceProvider)');
+} else {
+    fail('Leader entity type registered', 'LeaderServiceProvider.php not found');
+}
+
+if (is_file($leaderMapper)) {
+    pass('LeaderMapper exists');
+} else {
+    fail('LeaderMapper exists', 'src/Ingestion/EntityMapper/LeaderMapper.php not found');
+}
+
+// ─── 5. Export governance ───────────────────────────────────────────────────
+
+$exportScript = $projectRoot . '/bin/export-communities';
+if (is_file($exportScript)) {
+    $exportContent = file_get_contents($exportScript);
+    if (str_contains($exportContent, '--confirm')) {
+        pass('Export governance — requires --confirm flag');
+    } else {
+        fail('Export governance', 'export-communities does not check for --confirm');
+    }
+} else {
+    fail('Export governance', 'bin/export-communities not found');
+}
+
+// ─── 6. Robots.txt ─────────────────────────────────────────────────────────
+
+$robotsFile = $projectRoot . '/public/robots.txt';
+if (is_file($robotsFile)) {
+    $robotsContent = file_get_contents($robotsFile);
+    $blocksApi = str_contains($robotsContent, 'Disallow: /api/');
+    $blocksDashboard = str_contains($robotsContent, 'Disallow: /dashboard/');
+
+    if ($blocksApi && $blocksDashboard) {
+        pass('robots.txt blocks /api/ and /dashboard/');
+    } else {
+        $missing = [];
+        if (!$blocksApi) {
+            $missing[] = '/api/';
+        }
+        if (!$blocksDashboard) {
+            $missing[] = '/dashboard/';
+        }
+        fail('robots.txt', 'missing disallow for: ' . implode(', ', $missing));
+    }
+} else {
+    fail('robots.txt', 'public/robots.txt not found');
+}
+
+// ─── 7. License ────────────────────────────────────────────────────────────
+
+$composerJson = $projectRoot . '/composer.json';
+if (is_file($composerJson)) {
+    $composer = json_decode(file_get_contents($composerJson), true);
+    $license = $composer['license'] ?? '';
+
+    if (strcasecmp($license, 'MIT') === 0) {
+        pass('composer.json license is MIT');
+    } else {
+        fail('composer.json license', sprintf('expected MIT, got "%s"', $license));
+    }
+} else {
+    fail('composer.json license', 'composer.json not found');
+}
+
+// ─── 8. Copyright filtering in controllers ──────────────────────────────────
+
+$controllerDir = $projectRoot . '/src/Controller';
+$controllersToCheck = [
+    'EventController.php',
+    'GroupController.php',
+    'TeachingController.php',
+    'HomeController.php',
+];
+
+foreach ($controllersToCheck as $controllerFile) {
+    $filePath = $controllerDir . '/' . $controllerFile;
+    $testName = sprintf('Copyright filtering in %s', $controllerFile);
+
+    if (!is_file($filePath)) {
+        fail($testName, 'file not found');
+        continue;
+    }
+
+    $content = file_get_contents($filePath);
+    if (str_contains($content, 'copyright_status')) {
+        pass($testName);
+    } else {
+        fail($testName, 'no copyright_status check found');
+    }
+}
+
+// ─── Summary ────────────────────────────────────────────────────────────────
+
+fprintf(STDOUT, "\n");
+fprintf(STDOUT, "Smoke test complete: %d passed, %d failed.\n", $passed, $failed);
+
+exit($failed > 0 ? 1 : 0);

--- a/bin/validate-release
+++ b/bin/validate-release
@@ -1,0 +1,232 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * V1 Release Checklist Validator
+ * Outputs a YAML-formatted report with pass/fail per check.
+ *
+ * Usage: bin/validate-release
+ *
+ * Exit code 0 if all pass, 1 if any fail.
+ */
+
+$projectRoot = dirname(__DIR__);
+
+$results = [];
+$anyFailed = false;
+
+function addResult(string $name, bool $pass, string $detail = ''): void
+{
+    global $results, $anyFailed;
+    $results[] = ['name' => $name, 'status' => $pass ? 'pass' : 'fail', 'detail' => $detail];
+    if (!$pass) {
+        $anyFailed = true;
+    }
+}
+
+// --- 1. composer audit ---
+
+$auditOutput = [];
+$auditExitCode = 0;
+$auditCmd = sprintf('cd %s && composer audit --format=json 2>&1', escapeshellarg($projectRoot));
+$auditRaw = shell_exec($auditCmd);
+$auditJson = $auditRaw !== null ? json_decode($auditRaw, true) : null;
+
+$criticalHigh = 0;
+if (is_array($auditJson) && isset($auditJson['advisories']) && is_array($auditJson['advisories'])) {
+    foreach ($auditJson['advisories'] as $advisories) {
+        foreach ($advisories as $advisory) {
+            $severity = strtolower((string) ($advisory['severity'] ?? ''));
+            if ($severity === 'critical' || $severity === 'high') {
+                $criticalHigh++;
+            }
+        }
+    }
+}
+
+addResult(
+    'composer_audit',
+    $criticalHigh === 0,
+    $criticalHigh > 0
+        ? sprintf('%d critical/high vulnerabilities', $criticalHigh)
+        : 'no critical/high vulnerabilities',
+);
+
+// --- 2. All entity types have consent fields ---
+
+$consentProviders = [
+    'EventServiceProvider',
+    'GroupServiceProvider',
+    'CulturalGroupServiceProvider',
+    'CulturalCollectionServiceProvider',
+    'PeopleServiceProvider',
+    'LeaderServiceProvider',
+    'LanguageServiceProvider',
+    'TeachingServiceProvider',
+];
+
+$consentMissing = [];
+foreach ($consentProviders as $provider) {
+    $filePath = $projectRoot . '/src/Provider/' . $provider . '.php';
+    if (!is_file($filePath)) {
+        $consentMissing[] = $provider . ' (missing)';
+        continue;
+    }
+    $content = file_get_contents($filePath);
+    if (!str_contains($content, "'consent_public'") || !str_contains($content, "'consent_ai_training'")) {
+        $consentMissing[] = $provider;
+    }
+}
+
+addResult(
+    'consent_fields',
+    $consentMissing === [],
+    $consentMissing !== []
+        ? 'missing in: ' . implode(', ', $consentMissing)
+        : 'all providers have consent fields',
+);
+
+// --- 3. robots.txt ---
+
+$robotsFile = $projectRoot . '/public/robots.txt';
+$robotsOk = false;
+$robotsDetail = '';
+if (is_file($robotsFile)) {
+    $robotsContent = file_get_contents($robotsFile);
+    $robotsOk = str_contains($robotsContent, 'Disallow: /api/')
+        && str_contains($robotsContent, 'Disallow: /dashboard/');
+    $robotsDetail = $robotsOk ? '/api/ and /dashboard/ blocked' : 'missing disallow rules';
+} else {
+    $robotsDetail = 'robots.txt not found';
+}
+
+addResult('robots_txt', $robotsOk, $robotsDetail);
+
+// --- 4. License ---
+
+$composerJsonPath = $projectRoot . '/composer.json';
+$licenseOk = false;
+$licenseDetail = '';
+if (is_file($composerJsonPath)) {
+    $composer = json_decode(file_get_contents($composerJsonPath), true);
+    $license = $composer['license'] ?? '';
+    $licenseOk = strcasecmp($license, 'MIT') === 0;
+    $licenseDetail = $licenseOk ? 'MIT' : sprintf('got "%s"', $license);
+} else {
+    $licenseDetail = 'composer.json not found';
+}
+
+addResult('license_mit', $licenseOk, $licenseDetail);
+
+// --- 5. No commercial-use keywords ---
+
+$commercialKeywords = ['stripe', 'payment', 'subscription', 'paywall'];
+$foundCommercial = [];
+
+$scanDirs = ['src', 'config', 'templates'];
+foreach ($scanDirs as $dir) {
+    $fullDir = $projectRoot . '/' . $dir;
+    if (!is_dir($fullDir)) {
+        continue;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($fullDir, RecursiveDirectoryIterator::SKIP_DOTS),
+    );
+
+    foreach ($iterator as $file) {
+        if (!$file->isFile()) {
+            continue;
+        }
+        $ext = $file->getExtension();
+        if (!in_array($ext, ['php', 'twig', 'yml', 'yaml', 'json'], true)) {
+            continue;
+        }
+
+        $content = file_get_contents($file->getPathname());
+        $contentLower = strtolower($content);
+        foreach ($commercialKeywords as $keyword) {
+            if (str_contains($contentLower, $keyword)) {
+                $relative = str_replace($projectRoot . '/', '', $file->getPathname());
+                $foundCommercial[] = sprintf('%s (%s)', $relative, $keyword);
+            }
+        }
+    }
+}
+
+addResult(
+    'no_commercial_keywords',
+    $foundCommercial === [],
+    $foundCommercial !== []
+        ? 'found: ' . implode(', ', $foundCommercial)
+        : 'clean',
+);
+
+// --- 6. .env.example has required NC variables ---
+
+$envExample = $projectRoot . '/.env.example';
+$requiredVars = ['NORTHCLOUD_BASE_URL', 'NORTHCLOUD_API_TOKEN', 'NORTHCLOUD_SEARCH_URL'];
+$envOk = false;
+$envDetail = '';
+
+if (is_file($envExample)) {
+    $envContent = file_get_contents($envExample);
+    $envMissing = [];
+    foreach ($requiredVars as $var) {
+        if (!str_contains($envContent, $var)) {
+            $envMissing[] = $var;
+        }
+    }
+    $envOk = $envMissing === [];
+    $envDetail = $envOk
+        ? 'all NC variables present'
+        : 'missing: ' . implode(', ', $envMissing);
+} else {
+    $envDetail = '.env.example not found -- consider creating one';
+}
+
+addResult('env_example', $envOk, $envDetail);
+
+// --- 7. All bin/ scripts are executable ---
+
+$binDir = $projectRoot . '/bin';
+$nonExecutable = [];
+if (is_dir($binDir)) {
+    $binFiles = scandir($binDir);
+    foreach ($binFiles as $binFile) {
+        if ($binFile === '.' || $binFile === '..') {
+            continue;
+        }
+        $binPath = $binDir . '/' . $binFile;
+        if (is_file($binPath) && !is_executable($binPath)) {
+            $nonExecutable[] = $binFile;
+        }
+    }
+}
+
+addResult(
+    'bin_executable',
+    $nonExecutable === [],
+    $nonExecutable !== []
+        ? 'not executable: ' . implode(', ', $nonExecutable)
+        : 'all scripts executable',
+);
+
+// --- Output YAML report ---
+
+fprintf(STDOUT, "release_validation:\n");
+fprintf(STDOUT, "  date: \"%s\"\n", date('Y-m-d'));
+fprintf(STDOUT, "  overall: %s\n", $anyFailed ? 'fail' : 'pass');
+fprintf(STDOUT, "  checks:\n");
+
+foreach ($results as $result) {
+    fprintf(STDOUT, "    - name: %s\n", $result['name']);
+    fprintf(STDOUT, "      status: %s\n", $result['status']);
+    if ($result['detail'] !== '') {
+        fprintf(STDOUT, "      detail: \"%s\"\n", addcslashes($result['detail'], '"'));
+    }
+}
+
+exit($anyFailed ? 1 : 0);

--- a/migrations/002_add_consent_fields.sql
+++ b/migrations/002_add_consent_fields.sql
@@ -1,0 +1,27 @@
+-- Add consent_public and consent_ai_training to entity types missing them.
+-- Default: consent_public=1 (public), consent_ai_training=0 (opt-in only).
+--
+-- Entity types affected: event, group, cultural_group,
+-- cultural_collection, resource_person, leader
+--
+-- Waaseyaa's entity storage auto-creates columns for NEW tables from
+-- field definitions, but does NOT alter existing tables (schema drift).
+-- These ALTER TABLE statements provision the columns on existing databases.
+
+ALTER TABLE event ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE event ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "group" ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE "group" ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE cultural_group ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE cultural_group ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE cultural_collection ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE cultural_collection ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE resource_person ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE resource_person ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE leader ADD COLUMN consent_public INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE leader ADD COLUMN consent_ai_training INTEGER NOT NULL DEFAULT 0;

--- a/tests/Minoo/Unit/Provider/ConsentFieldsTest.php
+++ b/tests/Minoo/Unit/Provider/ConsentFieldsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Provider;
+
+use Minoo\Provider\CulturalCollectionServiceProvider;
+use Minoo\Provider\CulturalGroupServiceProvider;
+use Minoo\Provider\EventServiceProvider;
+use Minoo\Provider\GroupServiceProvider;
+use Minoo\Provider\LanguageServiceProvider;
+use Minoo\Provider\LeaderServiceProvider;
+use Minoo\Provider\PeopleServiceProvider;
+use Minoo\Provider\TeachingServiceProvider;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+#[CoversNothing]
+final class ConsentFieldsTest extends TestCase
+{
+    /**
+     * @return array<string, array{ServiceProvider, string}>
+     */
+    public static function contentProviderDataProvider(): array
+    {
+        return [
+            'teaching' => [new TeachingServiceProvider(), 'teaching'],
+            'event' => [new EventServiceProvider(), 'event'],
+            'group' => [new GroupServiceProvider(), 'group'],
+            'cultural_group' => [new CulturalGroupServiceProvider(), 'cultural_group'],
+            'cultural_collection' => [new CulturalCollectionServiceProvider(), 'cultural_collection'],
+            'resource_person' => [new PeopleServiceProvider(), 'resource_person'],
+            'leader' => [new LeaderServiceProvider(), 'leader'],
+            'dictionary_entry' => [new LanguageServiceProvider(), 'dictionary_entry'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('contentProviderDataProvider')]
+    public function all_content_providers_define_consent_public(ServiceProvider $provider, string $entityTypeId): void
+    {
+        $provider->register();
+
+        $fields = $this->getFieldDefinitions($provider, $entityTypeId);
+
+        self::assertArrayHasKey('consent_public', $fields, sprintf(
+            'Entity type "%s" is missing the consent_public field definition.',
+            $entityTypeId,
+        ));
+        self::assertSame('boolean', $fields['consent_public']['type']);
+    }
+
+    #[Test]
+    #[DataProvider('contentProviderDataProvider')]
+    public function all_content_providers_define_consent_ai_training(ServiceProvider $provider, string $entityTypeId): void
+    {
+        $provider->register();
+
+        $fields = $this->getFieldDefinitions($provider, $entityTypeId);
+
+        self::assertArrayHasKey('consent_ai_training', $fields, sprintf(
+            'Entity type "%s" is missing the consent_ai_training field definition.',
+            $entityTypeId,
+        ));
+        self::assertSame('boolean', $fields['consent_ai_training']['type']);
+    }
+
+    #[Test]
+    #[DataProvider('contentProviderDataProvider')]
+    public function consent_public_defaults_to_true(ServiceProvider $provider, string $entityTypeId): void
+    {
+        $provider->register();
+
+        $fields = $this->getFieldDefinitions($provider, $entityTypeId);
+
+        self::assertSame(1, $fields['consent_public']['default'], sprintf(
+            'Entity type "%s" consent_public should default to 1 (public).',
+            $entityTypeId,
+        ));
+    }
+
+    #[Test]
+    #[DataProvider('contentProviderDataProvider')]
+    public function consent_ai_training_defaults_to_false(ServiceProvider $provider, string $entityTypeId): void
+    {
+        $provider->register();
+
+        $fields = $this->getFieldDefinitions($provider, $entityTypeId);
+
+        self::assertSame(0, $fields['consent_ai_training']['default'], sprintf(
+            'Entity type "%s" consent_ai_training should default to 0 (opt-in only).',
+            $entityTypeId,
+        ));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function getFieldDefinitions(ServiceProvider $provider, string $entityTypeId): array
+    {
+        $types = $provider->getEntityTypes();
+
+        foreach ($types as $type) {
+            if ($type->id() === $entityTypeId) {
+                return $type->getFieldDefinitions();
+            }
+        }
+
+        self::fail(sprintf('Entity type "%s" not found in provider.', $entityTypeId));
+    }
+}

--- a/tools/release/v1-checklist.yml
+++ b/tools/release/v1-checklist.yml
@@ -1,0 +1,44 @@
+release: v1.0.2
+target_date: "2026-04-22"
+gates:
+  ci:
+    - name: PHPUnit tests pass
+      command: "vendor/bin/phpunit"
+      status: automated
+    - name: Playwright E2E pass
+      command: "npx playwright test"
+      status: automated
+    - name: Lint pass
+      command: "vendor/bin/phpcs"
+      status: automated
+    - name: Security audit clean
+      command: "composer audit"
+      status: automated
+    - name: Commercial use check
+      command: "bin/validate-release"
+      status: automated
+  governance:
+    - name: License attribution
+      gate: 1
+      status: approved
+      approved_by: "project owner"
+      approved_date: "2026-03-14"
+    - name: Media copyright
+      gate: 2
+      status: approved
+    - name: Data sovereignty
+      gate: 3
+      status: approved
+    - name: Community governance
+      gate: 4
+      status: approved
+    - name: Security review
+      gate: 5
+      status: approved
+  deployment:
+    - name: Staging deploy
+      command: "dep deploy staging"
+      status: pending
+    - name: Production deploy
+      command: "gh workflow run deploy-production.yml -f confirm=deploy-v1"
+      status: pending


### PR DESCRIPTION
## Summary
- Add `bin/smoke-test` and `bin/validate-release` release validation scripts
- Add `migrations/002_add_consent_fields.sql` consent field schema migration
- Add `tests/Minoo/Unit/Provider/ConsentFieldsTest.php` for consent field coverage
- Add `tools/release/v1-checklist.yml` release checklist config
- Gitignore `.build/` directory

## Test plan
- [ ] CI passes (PHPUnit + Playwright + Lint)
- [ ] `bin/smoke-test` runs without errors
- [ ] `bin/validate-release` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)