### PR TITLE
fix(#241): replace blanket *.png exclusion in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,8 @@ jobs:
             --exclude='phpunit.xml.dist' \
             --exclude='deploy.php' \
             --exclude='ops/' \
-            --exclude='*.png' \
+            --exclude='test-results/' \
+            --exclude='playwright-report/' \
             minoo/ minoo/.build/
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace blanket `*.png` rsync exclusion with targeted `test-results/` and `playwright-report/` exclusions
- Fixes `og-default.png` (OG meta image) and Leaflet marker PNGs being dropped from production builds

## Test plan

- [ ] Verify deploy workflow completes successfully
- [ ] Confirm `public/img/og-default.png` exists in deployed release
- [ ] Confirm `public/css/images/*.png` (Leaflet markers) exist in deployed release

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)