### PR TITLE
feat(i18n): add Lake Huron Ojibwe translations for homepage

### DIFF
--- a/resources/lang/oj.php
+++ b/resources/lang/oj.php
@@ -77,13 +77,13 @@ return [
     // Footer
     'footer.tagline' => '',
     'footer.copyright' => 'Minoo', // dict: 
-    'footer.license' => '',
+    'footer.license' => 'Oodena-mazina\'iganan ogii-biidoon <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" rel="external noopener">CC BY-NC-SA 4.0</a> endaad.',
     'footer.nav_label' => 'Inaakonige', // dict: inaakonige: rules, decisions
     'footer.about' => 'Dibaajimowin', // dict: dibaajimowin: "a story; a narrative; a report"
     'footer.privacy' => 'Ganawendan', // dict: ganawendan: "take care of, protect, keep it"
     'footer.terms' => 'Inaakonige', // dict: inaakonige: rules, decisions
-    'footer.accessibility' => '',
-    'footer.data_sovereignty' => '',
+    'footer.accessibility' => 'Gashkitoonendamowin',
+    'footer.data_sovereignty' => 'Doodem-mazina\'igan ogimaawin',
 
     // Location bar
     'location.set' => '',
@@ -111,8 +111,8 @@ return [
     'chat.error' => '',
 
     // Home page
-    'page.title' => '',
-    'page.subtitle' => '',
+    'page.title' => "Gikinoo'amaadiwin Mazina'igan O'ow Akiing",
+    'page.subtitle' => "Naanagidoon anishinaabeg, gikinoo'amaagewinan, maawanji'idiwinan, miinawaa onaakonigewinan gaa-mino-ayaawiyaang endaayang. Bizindan oodenaying miinawaa gichi-oodena endaayang.",
     'page.communities_button' => 'Oodenawinan', // dict: oodena: "town" (plural)
     'page.people_button' => 'Anishinaabeg', // dict: anishinaabeg: people (plural)
     'page.nearby_heading' => '',
@@ -120,24 +120,24 @@ return [
     'page.upcoming_events' => '',
     'page.view_all_communities' => '',
     'page.view_all_events' => '',
-    'page.explore_heading' => '',
-    'page.communities_desc' => '',
-    'page.people_desc' => '',
-    'page.teachings_desc' => '',
-    'page.events_desc' => '',
-    'page.elder_support_desc' => '',
+    'page.explore_heading' => 'Bizindaw Minoo',
+    'page.communities_desc' => 'Ogimaawi-anishinaabeg miinawaa onjibaa-onaakonigewinan giiwedin Ontarioing — naanagidoon gid-oodena miinawaa gaye gichi-oodena endaayang.',
+    'page.people_desc' => "Gichi-aya'aag, Gikendaasowininiwag, Anishinaabemowin-ikidowag, odaminowag, miinawaa ogimaawi-anishinaabeg — ogii-aya'aag gaa-ozhitoowaad omaa bimaadiziwin.",
+    'page.teachings_desc' => "Bimaadiziwin gikendaasowin — izhinamowin, dibaajimowin, miinawaa anishinaabemowin. Gikinoo'amaagewinan gaa-izhi-bimaadiziyang noongom.",
+    'page.events_desc' => "Niimi'idiwinan, maawanji'idiwinan, anami'egiwinan, miinawaa oodena-giizhigadwinan gaye endaayang.",
+    'page.elder_support_desc' => "Wiidookaage gichi-aya'aag omaa oodenaying — gaa-izhi-bagidinang wiidookawishin. Apane apii apane mino-ayaawiyaang.",
     'page.who_for_heading' => '',
     'page.who_for_intro' => '',
     'page.audience.elders' => 'Gichi-aya\'aag', // dict: gichi-aya'aa: "an elder" (plural)
-    'page.audience.elders_desc' => '',
+    'page.audience.elders_desc' => "Gagwe-gashkitoon gaye anooj wiidookaagewin — bimibatooyan, bagidinowin, gitigaan-onaabaniwin, miinawaa gaye ozhiwebad — ogii-aya'aag wiidookaagewin dazhi-izhiwebad.",
     'page.audience.young_people' => 'Oshki-bimaadizijig', // dict: oshki-: "new" + bimaadizi: "s/he lives"
-    'page.audience.young_people_desc' => '',
+    'page.audience.young_people_desc' => "Naanagidoon ogimaawi-bimaadizijig, gikinoo'amaagewinan, miinawaa maawanji'idiwinan oodenaying. Waa-ayaa'aag gaa-ozhitoowaad oodenaang — miinawaa bizindan gid-izhi-bimaadiziyan.",
     'page.audience.knowledge_keepers' => 'Gekinoo\'amaagedijig', // dict: gikinoo'amaage: "s/he teaches"
-    'page.audience.knowledge_keepers_desc' => '',
+    'page.audience.knowledge_keepers_desc' => "Biidoon gikinoo'amaagewinan, anishinaabemowin, miinawaa gashkitoonaanan ogii-izhi-gikendangig. Gid-ozhibii'igan wiikaa ogii-naanagidoowaag.",
     'page.audience.families' => 'Odinawemaaganag', // dict: inawemaagan: "a relative" (plural)
-    'page.audience.families_desc' => '',
+    'page.audience.families_desc' => "Nandawenjige maawanji'idiwinan, izhinamowin-onaakonigewinan, miinawaa oodena-onaakonigewinan endaayang. Gashkitoon wiikaa gii-izhiwebad.",
     'page.audience.volunteers' => 'Wiidookaagejig', // dict: wiidookaage: "s/he helps people" (plural)
-    'page.audience.volunteers_desc' => '',
+    'page.audience.volunteers_desc' => "Biinish apii apane wiidookaage gichi-aya'aag. Mii eta go gichi-mino-ayaawiyaang gaa-izhiwebad.",
 
     // Events
     'events.title' => 'Maawanji\'idiwinan', // dict: maawanji'idiwag: "they come together, meet"


### PR DESCRIPTION
## Summary

- Human-provided Ojibwe translations (Lake Huron dialect) for homepage content
- Covers: hero title/subtitle, explore heading, all section descriptions, audience cards, footer terms
- 108 keys now translated (up from 92), 483 remaining fall back to English

## Test plan

- [x] 410 PHPUnit tests passing
- [x] Valid PHP syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)