### PR TITLE
fix(i18n): update framework for route prefix stripping

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2810,7 +2810,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
@@ -2851,13 +2851,13 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-agent.git",
@@ -2895,13 +2895,13 @@
             "description": "AI agent orchestration and tool execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-agent/issues",
-                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-schema.git",
@@ -2938,13 +2938,13 @@
             "description": "AI-friendly schema definitions and entity metadata for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-schema/issues",
-                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
@@ -2985,13 +2985,13 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
@@ -3031,13 +3031,13 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
@@ -3079,13 +3079,13 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
@@ -3127,13 +3127,13 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
@@ -3171,13 +3171,13 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
@@ -3213,13 +3213,13 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
@@ -3264,13 +3264,13 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
@@ -3311,13 +3311,13 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
@@ -3356,22 +3356,22 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "cc2938b027b87ee20ab7e891a02a8fabdf679da0"
+                "reference": "3087d836f0491739674534e2983aa9f989d87c30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/cc2938b027b87ee20ab7e891a02a8fabdf679da0",
-                "reference": "cc2938b027b87ee20ab7e891a02a8fabdf679da0",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/3087d836f0491739674534e2983aa9f989d87c30",
+                "reference": "3087d836f0491739674534e2983aa9f989d87c30",
                 "shasum": ""
             },
             "require": {
@@ -3405,13 +3405,13 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.7"
             },
-            "time": "2026-03-15T03:34:57+00:00"
+            "time": "2026-03-15T16:00:19+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.6",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
@@ -3448,13 +3448,13 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.6"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T15:16:19+00:00"
         },
         {
             "name": "waaseyaa/mcp",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mcp.git",
@@ -3499,13 +3499,13 @@
             "description": "Remote MCP server endpoint for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mcp/issues",
-                "source": "https://github.com/waaseyaa/mcp/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/mcp/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/media",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/media.git",
@@ -3547,13 +3547,13 @@
             "description": "Media entity type and file management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/media/issues",
-                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/menu",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/menu.git",
@@ -3595,13 +3595,13 @@
             "description": "Menu and navigation link management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/menu/issues",
-                "source": "https://github.com/waaseyaa/menu/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/menu/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/node",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/node.git",
@@ -3644,13 +3644,13 @@
             "description": "Content node entity type for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/node/issues",
-                "source": "https://github.com/waaseyaa/node/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/node/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/path",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/path.git",
@@ -3692,13 +3692,13 @@
             "description": "URL path aliases and routing integration for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/path/issues",
-                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
@@ -3735,13 +3735,13 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
@@ -3778,13 +3778,13 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
@@ -3824,7 +3824,7 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
@@ -3868,16 +3868,16 @@
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ssr.git",
-                "reference": "cf893ed57575458fcd305efd0dd62b237d2cbf86"
+                "reference": "23cbf18bc5df7ee8a9246a01575e491e303cd93e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/cf893ed57575458fcd305efd0dd62b237d2cbf86",
-                "reference": "cf893ed57575458fcd305efd0dd62b237d2cbf86",
+                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/23cbf18bc5df7ee8a9246a01575e491e303cd93e",
+                "reference": "23cbf18bc5df7ee8a9246a01575e491e303cd93e",
                 "shasum": ""
             },
             "require": {
@@ -3917,13 +3917,13 @@
             "description": "Server-side rendering with Twig templates for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ssr/issues",
-                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.7"
             },
-            "time": "2026-03-15T14:45:02+00:00"
+            "time": "2026-03-15T16:00:19+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
@@ -3960,13 +3960,13 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/taxonomy.git",
@@ -4009,13 +4009,13 @@
             "description": "Taxonomy vocabulary and term entity types for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/taxonomy/issues",
-                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
@@ -4052,13 +4052,13 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
@@ -4103,13 +4103,13 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.6",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
@@ -4147,13 +4147,13 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.6"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
@@ -4196,7 +4196,7 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:16:09+00:00"
         }
@@ -5873,7 +5873,7 @@
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.5",
+            "version": "v0.1.0-alpha.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
@@ -5907,7 +5907,7 @@
             "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.5"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.7"
             },
             "time": "2026-03-15T03:34:57+00:00"
         }


### PR DESCRIPTION
## Summary

- Update waaseyaa packages to v0.1.0-alpha.7
- Fixes /oj/communities (and all /oj/* paths) returning 404
- Framework now strips language prefix before route matching

## Test plan

- [x] 410 PHPUnit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)