### PR TITLE
fix(i18n): add Ojibwe footer tagline

### DIFF
--- a/resources/lang/oj.php
+++ b/resources/lang/oj.php
@@ -75,7 +75,7 @@ return [
     'nav.login' => 'Biindigen', // dict: biindige: "enter, go inside"
 
     // Footer
-    'footer.tagline' => '',
+    'footer.tagline' => "Oodena mazina'igan bimaadiziwin",
     'footer.copyright' => 'Minoo', // dict: 
     'footer.license' => 'Oodena-mazina\'iganan ogii-biidoon <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" rel="external noopener">CC BY-NC-SA 4.0</a> endaad.',
     'footer.nav_label' => 'Inaakonige', // dict: inaakonige: rules, decisions


### PR DESCRIPTION
## Summary
- Add Ojibwe translation for footer.tagline — was falling back to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)