### PR TITLE
fix(i18n): replace hardcoded km away with trans()

### DIFF
--- a/templates/communities/detail.html.twig
+++ b/templates/communities/detail.html.twig
@@ -103,7 +103,7 @@
         <div class="atlas-nearby-card__name">{{ item.community.get('name') }}</div>
         <div class="atlas-nearby-card__meta">
           {{ item.community.get('is_municipality') ? trans('community.municipality') : item.community.get('nation') ?: trans('community.first_nation') }}
-          · {{ item.distanceKm|number_format(0) }} km
+          · {{ item.distanceKm|number_format(0) }} {{ trans('community.km_away') }}
         </div>
       </a>
       {% endfor %}

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -28,7 +28,7 @@
               <a href="{{ lang_url('/communities/' ~ item.community.get('slug')) }}" class="card card--community">
                 <div class="card__body">
                   <h4 class="card__title">{{ item.community.get('name') }}</h4>
-                  <p class="card__meta">{{ item.distanceKm|round }} km away</p>
+                  <p class="card__meta">{{ item.distanceKm|round }} {{ trans('community.km_away') }}</p>
                 </div>
               </a>
             {% endfor %}


### PR DESCRIPTION
## Summary
- Replace hardcoded 'km away' / 'km' in page.html.twig and communities/detail.html.twig with `trans('community.km_away')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)