### PR TITLE
fix: homepage crash when events are present

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -38,8 +38,15 @@
         {% if events is defined and events|length > 0 %}
           <h3>{{ trans('page.upcoming_events') }}</h3>
           <div class="card-grid">
-            {% for event in events %}
-              {% include "components/event-card.html.twig" with {event: event} %}
+            {% for e in events %}
+              {% include "components/event-card.html.twig" with {
+                title: e.get('title'),
+                type: e.get('type')|default('')|capitalize,
+                date: e.get('starts_at')|default(''),
+                location: e.get('location')|default(''),
+                excerpt: e.get('description')|default('')|split("\n\n")|first|length > 120 ? e.get('description')|default('')|split("\n\n")|first|slice(0, 120) ~ '…' : e.get('description')|default('')|split("\n\n")|first,
+                url: "/events/" ~ e.get('slug')
+              } only %}
             {% endfor %}
           </div>
         {% endif %}


### PR DESCRIPTION
## Summary

- Fix 500 error on minoo.live homepage caused by LocationContext object leaking into event-card template
- The event-card component tried to render `{{ location }}` as a string, but received the LocationContext object from the parent scope
- Use explicit variable passing with `only` keyword, matching the existing pattern in `events.html.twig`

## Root cause

Latent bug surfaced by content seeding (#262) — homepage now has events to display, triggering the previously-unreached code path.

## Test plan

- [x] 436 tests pass
- [ ] Verify minoo.live homepage loads without error after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)