### PR TITLE
fix: bump CSS cache version for homepage redesign

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -2056,7 +2056,7 @@
   /* ── Homepage ── */
 
   .homepage-hero {
-    background: linear-gradient(135deg, var(--color-forest-700), oklch(0.25 0.06 155));
+    background: linear-gradient(135deg, var(--color-forest-700), #1a3a0a);
     color: #fff;
     padding-block: var(--space-md);
     padding-inline: var(--gutter);

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -14,7 +14,7 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Minoo">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="/css/minoo.min.css?v=6">
+  <link rel="stylesheet" href="/css/minoo.min.css?v=7">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary

- Bump `minoo.min.css?v=6` to `?v=7` to bust the immutable cache after homepage CSS was added in #265
- Replace inline `oklch()` in hero gradient with hex fallback

Root cause: CSS files are served with `Cache-Control: immutable, max-age=31536000`. The `?v=6` param didn't change when we added homepage CSS, so browsers served the stale cached version.

## Test plan

- [ ] Homepage shows styled hero, tabs, and cards after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)