### PR TITLE
fix: serve minoo.css directly, drop stale minoo.min.css

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -14,7 +14,7 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Minoo">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="/css/minoo.min.css?v=7">
+  <link rel="stylesheet" href="/css/minoo.css?v=7">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary

- Reference `minoo.css` instead of `minoo.min.css` in base template
- Caddy already gzips responses (~70KB → ~10KB over wire)
- Eliminates the stale cache bug from #265 where `minoo.min.css` was never regenerated

## Test plan

- [ ] Homepage loads with full styling via `/css/minoo.css?v=7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)