### PR TITLE
feat: update favicon for Regalia design

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="oklch(0.55 0.10 155)"/>
-  <text x="16" y="24" text-anchor="middle" font-family="Charter, serif" font-size="22" font-weight="700" fill="white">M</text>
+  <rect width="32" height="32" rx="6" fill="#0a0a0a"/>
+  <rect y="0" width="32" height="3" rx="0" fill="url(#ribbon)"/>
+  <text x="16" y="24" text-anchor="middle" font-family="Fraunces, Charter, serif" font-size="22" font-weight="900" fill="#f0ece6">M</text>
+  <defs>
+    <linearGradient id="ribbon" x1="0" y1="0" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#e63946"/>
+      <stop offset="20%" stop-color="#e63946"/>
+      <stop offset="20%" stop-color="#f4a261"/>
+      <stop offset="40%" stop-color="#f4a261"/>
+      <stop offset="40%" stop-color="#2a9d8f"/>
+      <stop offset="60%" stop-color="#2a9d8f"/>
+      <stop offset="60%" stop-color="#6a9caf"/>
+      <stop offset="80%" stop-color="#6a9caf"/>
+      <stop offset="80%" stop-color="#8338ec"/>
+      <stop offset="100%" stop-color="#8338ec"/>
+    </linearGradient>
+  </defs>
 </svg>


### PR DESCRIPTION
## Summary

- Dark background with ceremony-color ribbon stripe across the top
- Fraunces "M" in warm white (#f0ece6)
- Matches the new Regalia visual identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)