### PR TITLE
fix(#241,#245,#270,#278): deploy, final, hook, mobile responsive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
             --exclude='phpunit.xml.dist' \
             --exclude='deploy.php' \
             --exclude='ops/' \
-            --exclude='*.png' \
+            --exclude='tests/screenshots/' \
             minoo/ minoo/.build/
 
       # -----------------------------------------------------------------------

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,14 +14,18 @@ if [ $? -ne 0 ]; then
 fi
 echo "✓ Integration tests passed"
 
-# Playwright smoke tests
-echo "Running Playwright tests..."
-npx playwright test 2>&1
-if [ $? -ne 0 ]; then
-  echo "❌ Playwright tests failed — push aborted"
-  exit 1
+# Playwright smoke tests (skip in pre-push — requires running server; runs in CI)
+if [[ -n "${CI:-}" ]]; then
+  echo "Running Playwright tests..."
+  npx playwright test 2>&1
+  if [ $? -ne 0 ]; then
+    echo "❌ Playwright tests failed — push aborted"
+    exit 1
+  fi
+  echo "✓ Playwright tests passed"
+else
+  echo "⏭ Playwright tests skipped (no server available; runs in CI)"
 fi
-echo "✓ Playwright tests passed"
 
 # Security audit
 composer audit --no-interaction 2>/dev/null

--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -2794,22 +2794,58 @@
         border-inline-end: none;
         border-block-end: 1px solid var(--border-subtle);
         inline-size: 100%;
+        padding-block: var(--space-sm);
       }
 
       & .homepage-hero-input {
         flex: 1 1 auto;
+        padding-block: var(--space-sm);
       }
 
       & .homepage-hero-submit {
         border-start-end-radius: 0;
         border-end-start-radius: 0;
         border-end-end-radius: var(--radius-md);
+        inline-size: 100%;
+        padding-block: var(--space-sm);
+        border-end-start-radius: var(--radius-md);
       }
     }
 
     .homepage-tabs {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
       -webkit-mask-image: linear-gradient(to right, black 85%, transparent);
       mask-image: linear-gradient(to right, black 85%, transparent);
+    }
+
+    .homepage-tabs::-webkit-scrollbar {
+      display: none;
+    }
+
+    .homepage-tabs [role="tab"],
+    .homepage-tab {
+      padding-inline: var(--space-sm);
+      font-size: var(--text-sm);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .homepage-title {
+      font-size: var(--text-base);
+    }
+  }
+
+  @media (max-width: 23.4375em) {
+    .homepage-tabs [role="tab"],
+    .homepage-tab {
+      padding-inline: var(--space-xs);
+      font-size: var(--text-xs);
+    }
+
+    .homepage-title {
+      font-size: var(--text-sm);
     }
   }
 }

--- a/src/Controller/CommunityController.php
+++ b/src/Controller/CommunityController.php
@@ -14,11 +14,12 @@ use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\SsrResponse;
 use Minoo\Support\GeoDistance;
 
-class CommunityController
+final class CommunityController
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly Environment $twig,
+        private readonly ?NorthCloudClient $northCloudClient = null,
     ) {}
 
     /** @param array<string, mixed> $params */
@@ -123,7 +124,7 @@ class CommunityController
             $ncId = $community->get('nc_id');
             if ($ncId !== null && $ncId !== '') {
                 try {
-                    $ncClient = $this->createNorthCloudClient();
+                    $ncClient = $this->resolveNorthCloudClient();
                     $people = $ncClient->getPeople((string) $ncId);
                     $bandOffice = $ncClient->getBandOffice((string) $ncId);
                 } catch (\Throwable) {
@@ -269,8 +270,12 @@ class CommunityController
         return new JsonResponse($results);
     }
 
-    protected function createNorthCloudClient(): NorthCloudClient
+    private function resolveNorthCloudClient(): NorthCloudClient
     {
+        if ($this->northCloudClient !== null) {
+            return $this->northCloudClient;
+        }
+
         $configPath = dirname(__DIR__, 2) . '/config/waaseyaa.php';
         $config = file_exists($configPath) ? (require $configPath)['northcloud'] ?? [] : [];
 

--- a/tests/Minoo/Unit/Controller/CommunityControllerTest.php
+++ b/tests/Minoo/Unit/Controller/CommunityControllerTest.php
@@ -6,6 +6,7 @@ namespace Minoo\Tests\Unit\Controller;
 
 use Minoo\Controller\CommunityController;
 use Minoo\Entity\Community;
+use Minoo\Support\NorthCloudClient;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -148,12 +149,13 @@ final class CommunityControllerTest extends TestCase
         $this->query->method('execute')->willReturn([1]);
         $this->storage->method('load')->with(1)->willReturn($sagamok);
 
-        $controller = new class($this->entityTypeManager, $this->twig) extends CommunityController {
-            protected function createNorthCloudClient(): \Minoo\Support\NorthCloudClient
-            {
-                throw new \RuntimeException('NorthCloud unavailable');
-            }
-        };
+        $failingClient = new NorthCloudClient(
+            baseUrl: 'https://invalid.test',
+            timeout: 1,
+            httpClient: static function () { throw new \RuntimeException('NorthCloud unavailable'); },
+        );
+
+        $controller = new CommunityController($this->entityTypeManager, $this->twig, $failingClient);
 
         $response = $controller->show(['slug' => 'sagamok-anishnawbek'], [], $this->account, $this->request);
 


### PR DESCRIPTION
## Summary

Batch of 4 stabilization fixes for v0.9:

- **#241**: Replaced blanket `*.png` exclusion in deploy with targeted `tests/screenshots/` exclusion
- **#245**: Restored `final` on CommunityController with constructor-injected NorthCloudClient
- **#270**: Playwright tests now skip in local pre-push (only run in CI)
- **#278**: Mobile responsive fixes: search bar padding, tab horizontal scroll with fade, card title scaling

## Test plan
- [x] 423 unit tests passing (929 assertions)
- [x] Pre-commit hooks pass
- [ ] Visual check of homepage at 375px viewport
- [ ] Verify deploy includes og-default.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)