### PR TITLE
feat(#247): add waaseyaa/admin-surface and MinooSurfaceHost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "waaseyaa/typed-data": "^0.1.0-alpha.25",
         "waaseyaa/user": "^0.1.0-alpha.25",
         "waaseyaa/validation": "^0.1.0-alpha.25",
+        "waaseyaa/admin-surface": "^0.1.0-alpha.25",
         "waaseyaa/workflows": "^0.1.0-alpha.25"
     },
     "require-dev": {
@@ -71,7 +72,8 @@
                 "Minoo\\Provider\\AccountServiceProvider",
                 "Minoo\\Provider\\FlashServiceProvider",
                 "Minoo\\Provider\\ChatServiceProvider",
-                "Minoo\\Provider\\FeaturedItemServiceProvider"
+                "Minoo\\Provider\\FeaturedItemServiceProvider",
+                "Minoo\\Provider\\AdminServiceProvider"
             ]
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "945fe09bfc285d33eafa975cf90651af",
+    "content-hash": "ad42f8f9dfb8bf12b35d2da645cceea4",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2854,6 +2854,58 @@
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
                 "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.25"
+            },
+            "time": "2026-03-16T21:50:01+00:00"
+        },
+        {
+            "name": "waaseyaa/admin-surface",
+            "version": "v0.1.0-alpha.29",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/admin-surface.git",
+                "reference": "e1c3f366ea5681d9ed68e7427fc2fbd4dcb5e377"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/admin-surface/zipball/e1c3f366ea5681d9ed68e7427fc2fbd4dcb5e377",
+                "reference": "e1c3f366ea5681d9ed68e7427fc2fbd4dcb5e377",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "waaseyaa/access": "@dev",
+                "waaseyaa/entity": "@dev",
+                "waaseyaa/foundation": "@dev",
+                "waaseyaa/routing": "@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\AdminSurface\\AdminSurfaceServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\AdminSurface\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
+            "support": {
+                "issues": "https://github.com/waaseyaa/admin-surface/issues",
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.29"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
@@ -6076,6 +6128,7 @@
     "minimum-stability": "alpha",
     "stability-flags": {
         "waaseyaa/access": 15,
+        "waaseyaa/admin-surface": 15,
         "waaseyaa/api": 15,
         "waaseyaa/cache": 15,
         "waaseyaa/cli": 15,
@@ -6111,5 +6164,5 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Provider/AdminServiceProvider.php
+++ b/src/Provider/AdminServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Provider;
+
+use Minoo\Surface\MinooSurfaceHost;
+use Waaseyaa\AdminSurface\AdminSurfaceServiceProvider;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class AdminServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Host is constructed in routes() where EntityTypeManager is available.
+    }
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        if ($entityTypeManager === null) {
+            return;
+        }
+
+        $host = new MinooSurfaceHost($entityTypeManager);
+
+        AdminSurfaceServiceProvider::registerRoutes($router, $host);
+    }
+}

--- a/src/Surface/MinooSurfaceHost.php
+++ b/src/Surface/MinooSurfaceHost.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Surface;
+
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\AdminSurface\Catalog\CatalogBuilder;
+use Waaseyaa\AdminSurface\Host\AbstractAdminSurfaceHost;
+use Waaseyaa\AdminSurface\Host\AdminSurfaceResultData;
+use Waaseyaa\AdminSurface\Host\AdminSurfaceSessionData;
+use Waaseyaa\Entity\EntityTypeManager;
+
+final class MinooSurfaceHost extends AbstractAdminSurfaceHost
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {}
+
+    public function resolveSession(Request $request): ?AdminSurfaceSessionData
+    {
+        $account = $request->attributes->get('account');
+
+        if (!$account instanceof AccountInterface) {
+            return null;
+        }
+
+        if (!$account->hasPermission('administer content')) {
+            return null;
+        }
+
+        return new AdminSurfaceSessionData(
+            accountId: (string) $account->id(),
+            accountName: 'Admin',
+            roles: $account->getRoles(),
+            policies: [],
+            tenantId: 'minoo',
+            tenantName: 'Minoo',
+        );
+    }
+
+    public function buildCatalog(AdminSurfaceSessionData $session): CatalogBuilder
+    {
+        $catalog = new CatalogBuilder();
+
+        foreach ($this->entityTypeManager->getDefinitions() as $definition) {
+            $entity = $catalog->defineEntity($definition->id(), $definition->getLabel());
+
+            $group = $definition->getGroup();
+            if ($group !== null) {
+                $entity->group($group);
+            }
+
+            foreach ($definition->getFieldDefinitions() as $name => $fieldDef) {
+                $entity->field(
+                    $name,
+                    $fieldDef['label'] ?? $name,
+                    $fieldDef['type'] ?? 'string',
+                );
+            }
+
+            $entity->action('delete', 'Delete')
+                ->confirm('Are you sure you want to delete this item?')
+                ->dangerous();
+        }
+
+        return $catalog;
+    }
+
+    public function list(string $type, array $query = []): AdminSurfaceResultData
+    {
+        if (!$this->entityTypeManager->hasDefinition($type)) {
+            return AdminSurfaceResultData::error(404, 'Unknown entity type', "Type '{$type}' is not registered.");
+        }
+
+        $storage = $this->entityTypeManager->getStorage($type);
+        $entities = $storage->loadMultiple();
+        $items = array_map(fn($e) => $e->toArray(), $entities);
+
+        return AdminSurfaceResultData::success($items, [
+            'type' => $type,
+            'total' => count($items),
+        ]);
+    }
+
+    public function get(string $type, string $id): AdminSurfaceResultData
+    {
+        if (!$this->entityTypeManager->hasDefinition($type)) {
+            return AdminSurfaceResultData::error(404, 'Unknown entity type', "Type '{$type}' is not registered.");
+        }
+
+        $storage = $this->entityTypeManager->getStorage($type);
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return AdminSurfaceResultData::error(404, 'Not found', "Entity '{$type}/{$id}' does not exist.");
+        }
+
+        return AdminSurfaceResultData::success($entity->toArray());
+    }
+
+    public function action(string $type, string $action, array $payload = []): AdminSurfaceResultData
+    {
+        if (!$this->entityTypeManager->hasDefinition($type)) {
+            return AdminSurfaceResultData::error(404, 'Unknown entity type', "Type '{$type}' is not registered.");
+        }
+
+        $storage = $this->entityTypeManager->getStorage($type);
+
+        return match ($action) {
+            'delete' => $this->handleDelete($storage, $type, $payload),
+            default => AdminSurfaceResultData::error(400, 'Unknown action', "Action '{$action}' is not supported."),
+        };
+    }
+
+    private function handleDelete(
+        \Waaseyaa\Entity\Storage\EntityStorageInterface $storage,
+        string $type,
+        array $payload,
+    ): AdminSurfaceResultData {
+        $id = $payload['id'] ?? null;
+
+        if ($id === null) {
+            return AdminSurfaceResultData::error(400, 'Missing ID', 'Payload must include an id field.');
+        }
+
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return AdminSurfaceResultData::error(404, 'Not found', "Entity '{$type}/{$id}' does not exist.");
+        }
+
+        $storage->delete([$entity]);
+
+        return AdminSurfaceResultData::success(['deleted' => true]);
+    }
+}

--- a/tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php
+++ b/tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Surface;
+
+use Minoo\Surface\MinooSurfaceHost;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\AdminSurface\Catalog\CatalogBuilder;
+use Waaseyaa\AdminSurface\Host\AdminSurfaceSessionData;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+#[CoversClass(MinooSurfaceHost::class)]
+final class MinooSurfaceHostTest extends TestCase
+{
+    #[Test]
+    public function resolve_session_returns_null_for_unauthenticated_request(): void
+    {
+        $host = new MinooSurfaceHost($this->createMock(EntityTypeManager::class));
+        $request = Request::create('/admin/surface/session');
+
+        $this->assertNull($host->resolveSession($request));
+    }
+
+    #[Test]
+    public function resolve_session_returns_null_for_non_admin(): void
+    {
+        $account = $this->createStub(AccountInterface::class);
+        $account->method('id')->willReturn(1);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('getRoles')->willReturn(['authenticated']);
+
+        $host = new MinooSurfaceHost($this->createMock(EntityTypeManager::class));
+        $request = Request::create('/admin/surface/session');
+        $request->attributes->set('account', $account);
+
+        $this->assertNull($host->resolveSession($request));
+    }
+
+    #[Test]
+    public function resolve_session_returns_data_for_admin(): void
+    {
+        $account = $this->createStub(AccountInterface::class);
+        $account->method('id')->willReturn(42);
+        $account->method('hasPermission')->willReturn(true);
+        $account->method('getRoles')->willReturn(['administrator']);
+
+        $host = new MinooSurfaceHost($this->createMock(EntityTypeManager::class));
+        $request = Request::create('/admin/surface/session');
+        $request->attributes->set('account', $account);
+
+        $session = $host->resolveSession($request);
+
+        $this->assertNotNull($session);
+        $this->assertSame('42', $session->accountId);
+        $this->assertSame('minoo', $session->tenantId);
+        $this->assertContains('administrator', $session->roles);
+    }
+
+    #[Test]
+    public function build_catalog_returns_entity_definitions(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getDefinitions')->willReturn([
+            new EntityType(
+                id: 'event',
+                label: 'Event',
+                class: \stdClass::class,
+                keys: ['id' => 'eid'],
+                group: 'events',
+                fieldDefinitions: [
+                    'title' => ['type' => 'string', 'label' => 'Title'],
+                ],
+            ),
+        ]);
+
+        $host = new MinooSurfaceHost($etm);
+        $session = new AdminSurfaceSessionData(
+            accountId: '1',
+            accountName: 'Admin',
+            roles: ['administrator'],
+            policies: [],
+        );
+
+        $catalog = $host->buildCatalog($session);
+
+        $this->assertInstanceOf(CatalogBuilder::class, $catalog);
+        $built = $catalog->build();
+        $this->assertCount(1, $built);
+        $this->assertSame('event', $built[0]['id']);
+        $this->assertSame('Event', $built[0]['label']);
+        $this->assertSame('events', $built[0]['group']);
+    }
+
+    #[Test]
+    public function list_returns_error_for_unknown_type(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(false);
+
+        $host = new MinooSurfaceHost($etm);
+        $result = $host->list('nonexistent');
+
+        $this->assertFalse($result->ok);
+    }
+
+    #[Test]
+    public function get_returns_error_for_unknown_type(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(false);
+
+        $host = new MinooSurfaceHost($etm);
+        $result = $host->get('nonexistent', '123');
+
+        $this->assertFalse($result->ok);
+    }
+
+    #[Test]
+    public function action_returns_error_for_unknown_action(): void
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(true);
+        $etm->method('getStorage')->willReturn($storage);
+
+        $host = new MinooSurfaceHost($etm);
+        $result = $host->action('event', 'nonexistent');
+
+        $this->assertFalse($result->ok);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `waaseyaa/admin-surface` package dependency (alpha.25+)
- Scaffolds `MinooSurfaceHost` extending `AbstractAdminSurfaceHost`
- Wires admin surface routes via `AdminServiceProvider`
- Auto-generates entity catalog from `EntityTypeManager` definitions

## Implementation

- `src/Surface/MinooSurfaceHost.php` — resolveSession (permission check), buildCatalog (auto from ETM), list/get/action (storage delegation)
- `src/Provider/AdminServiceProvider.php` — registers routes via `AdminSurfaceServiceProvider::registerRoutes()`
- `tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php` — 7 tests, 14 assertions

## Endpoints (via framework registerRoutes)

| Method | Path | Behavior |
|--------|------|----------|
| GET | /admin/surface/session | Returns 401 or session data |
| GET | /admin/surface/catalog | Entity type catalog |
| GET | /admin/surface/{type} | Entity listing |
| GET | /admin/surface/{type}/{id} | Entity detail |
| POST | /admin/surface/{type}/action/{action} | Action dispatch |

## Test plan

- [x] 7 unit tests pass (session auth, catalog build, CRUD errors)
- [x] Full suite: 449 tests, 1021 assertions
- [x] Local verification: homepage 200, /admin/surface/session 401 (correct)
- [ ] CI pipeline green

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)