### PR TITLE
chore(#271): add PHPStan static analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,38 @@ jobs:
       - name: Check PHP syntax
         run: find src -name '*.php' -print0 | xargs -0 -n1 php -l
 
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout minoo
+        uses: actions/checkout@v4
+        with:
+          path: minoo
+
+      - name: Checkout waaseyaa framework
+        uses: actions/checkout@v4
+        with:
+          repository: waaseyaa/framework
+          ref: main
+          path: waaseyaa
+          token: ${{ secrets.WAASEYAA_PAT }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_sqlite, sqlite3, mbstring, xml
+          coverage: none
+
+      - name: Install dependencies
+        working-directory: minoo
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        working-directory: minoo
+        run: ./vendor/bin/phpstan analyse --no-progress
+
   test:
     name: PHPUnit
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env
 storage/geoip/
 .phpunit.cache/
+storage/phpstan/
 .playwright-mcp/
 /*.png
 mcp/node_modules/

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,10 @@
         "waaseyaa/workflows": "^0.1.0-alpha.25"
     },
     "require-dev": {
-        "waaseyaa/testing": "^0.1.0-alpha.25",
-        "phpunit/phpunit": "^10.5"
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^10.5",
+        "waaseyaa/testing": "^0.1.0-alpha.25"
     },
     "autoload": {
         "psr-4": {
@@ -79,7 +81,10 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     },
     "scripts": {
         "post-create-project-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad42f8f9dfb8bf12b35d2da645cceea4",
+    "content-hash": "49f58bb720940538041c14155ea9ac67",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2859,7 +2859,7 @@
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.29",
+            "version": "v0.1.0-alpha.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
@@ -2905,7 +2905,7 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.29"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.30"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
@@ -4648,6 +4648,107 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.42",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-17T14:58:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,211 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/CulturalCollectionAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/CulturalGroupAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/ElderSupportAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/EventAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/FeaturedItemAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/GroupAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/LanguageAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/PeopleAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Access/TeachingAccessPolicy.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 11
+			path: src/Controller/BusinessController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 17
+			path: src/Controller/CommunityController.php
+
+		-
+			message: '#^Parameter \#1 \$community of method Minoo\\Controller\\CommunityController\:\:findNearbyCommunities\(\) expects Waaseyaa\\Entity\\ContentEntityBase, Waaseyaa\\Entity\\EntityInterface given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CommunityController.php
+
+		-
+			message: '#^Parameter \#2 \$communities of method Minoo\\Service\\LocationResolver\:\:resolveNearbyCommunities\(\) expects array\<Waaseyaa\\Entity\\ContentEntityBase\>, list\<Waaseyaa\\Entity\\EntityInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CommunityController.php
+
+		-
+			message: '#^Parameter \#3 \$communities of method Minoo\\Domain\\Geo\\Service\\CommunityFinder\:\:findNearby\(\) expects array\<Waaseyaa\\Entity\\ContentEntityBase\>, list\<Waaseyaa\\Entity\\EntityInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CommunityController.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Waaseyaa\\Entity\\EntityInterface and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: src/Controller/CommunityController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Controller/CoordinatorDashboardController.php
+
+		-
+			message: '#^Parameter \#1 \$entities of method Minoo\\Controller\\CoordinatorDashboardController\:\:buildCommunityNameMap\(\) expects array\<Waaseyaa\\Entity\\ContentEntityBase\>, array\<int\|string, Waaseyaa\\Entity\\EntityInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CoordinatorDashboardController.php
+
+		-
+			message: '#^Parameter \#2 \$openRequests of method Minoo\\Controller\\CoordinatorDashboardController\:\:buildRankedMap\(\) expects array\<Waaseyaa\\Entity\\ContentEntityBase\>, list\<Waaseyaa\\Entity\\EntityInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CoordinatorDashboardController.php
+
+		-
+			message: '#^Parameter \#3 \$volunteers of method Minoo\\Controller\\CoordinatorDashboardController\:\:buildRankedMap\(\) expects array\<Waaseyaa\\Entity\\ContentEntityBase\>, array\<int\|string, Waaseyaa\\Entity\\EntityInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/CoordinatorDashboardController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 8
+			path: src/Controller/ElderSupportWorkflowController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:set\(\)\.$#'
+			identifier: method.notFound
+			count: 22
+			path: src/Controller/ElderSupportWorkflowController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 13
+			path: src/Controller/EventController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 6
+			path: src/Controller/GroupController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 6
+			path: src/Controller/HomeController.php
+
+		-
+			message: '#^Method Minoo\\Controller\\HomeController\:\:loadFeaturedItems\(\) should return list\<array\{featured\: array\<string, mixed\>, entity\: mixed, url\: string\}\> but returns list\<array\{featured\: Waaseyaa\\Entity\\EntityInterface, entity\: Waaseyaa\\Entity\\EntityInterface, url\: non\-falsy\-string\}\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Controller/HomeController.php
+
+		-
+			message: '#^Property Minoo\\Controller\\LocationController\:\:\$twig is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Controller/LocationController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 15
+			path: src/Controller/PeopleController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 8
+			path: src/Controller/TeachingController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Controller/VolunteerDashboardController.php
+
+		-
+			message: '#^Method Minoo\\Controller\\VolunteerDashboardController\:\:findVolunteerByAccount\(\) should return Waaseyaa\\Entity\\ContentEntityBase\|null but returns Waaseyaa\\Entity\\EntityInterface\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Controller/VolunteerDashboardController.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 5
+			path: src/Domain/Geo/Service/LocationService.php
+
+		-
+			message: '#^Method Minoo\\Domain\\Geo\\Service\\LocationService\:\:loadAllCommunities\(\) should return array\<Waaseyaa\\Entity\\ContentEntityBase\> but returns array\<int\|string, Waaseyaa\\Entity\\EntityInterface\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Domain/Geo/Service/LocationService.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Domain/Geo/Service/VolunteerRanker.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: src/Support/CommunityLookup.php
+
+		-
+			message: '#^Call to an undefined method Waaseyaa\\Entity\\EntityInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Support/FixtureResolver.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src/
+    scanDirectories:
+        - vendor/waaseyaa/
+    tmpDir: storage/phpstan


### PR DESCRIPTION
## Summary

- Adds PHPStan level 5 static analysis to CI pipeline
- Generates baseline with 141 existing errors so they don't block CI
- New errors introduced in PRs will fail the phpstan job

## Changes

- `phpstan.neon` — level 5, scans `src/`, uses baseline
- `phpstan-baseline.neon` — 141 baselined errors
- `.github/workflows/ci.yml` — new `phpstan` job
- `composer.json` — added `phpstan/phpstan` and `phpstan/extension-installer` to require-dev
- `.gitignore` — added `storage/phpstan/`

## Test plan

- [x] PHPUnit: 442 tests pass
- [x] PHPStan runs clean against baseline
- [ ] CI pipeline green

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)