### PR TITLE
feat(#248): define admin catalog with capabilities per entity type

### DIFF
--- a/src/Surface/MinooSurfaceHost.php
+++ b/src/Surface/MinooSurfaceHost.php
@@ -40,6 +40,8 @@ final class MinooSurfaceHost extends AbstractAdminSurfaceHost
         );
     }
 
+    private const array READ_ONLY_TYPES = ['ingest_log'];
+
     public function buildCatalog(AdminSurfaceSessionData $session): CatalogBuilder
     {
         $catalog = new CatalogBuilder();
@@ -60,9 +62,20 @@ final class MinooSurfaceHost extends AbstractAdminSurfaceHost
                 );
             }
 
-            $entity->action('delete', 'Delete')
-                ->confirm('Are you sure you want to delete this item?')
-                ->dangerous();
+            $isConfig = is_subclass_of($definition->getClass(), \Waaseyaa\Entity\ConfigEntityBase::class);
+            $isReadOnly = $isConfig || in_array($definition->id(), self::READ_ONLY_TYPES, true);
+
+            if ($isReadOnly) {
+                $entity->capabilities([
+                    'create' => false,
+                    'update' => false,
+                    'delete' => false,
+                ]);
+            } else {
+                $entity->action('delete', 'Delete')
+                    ->confirm('Are you sure you want to delete this item?')
+                    ->dangerous();
+            }
         }
 
         return $catalog;

--- a/tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php
+++ b/tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php
@@ -99,6 +99,95 @@ final class MinooSurfaceHostTest extends TestCase
     }
 
     #[Test]
+    public function build_catalog_marks_config_entities_read_only(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getDefinitions')->willReturn([
+            new EntityType(
+                id: 'event_type',
+                label: 'Event Type',
+                class: \Minoo\Entity\EventType::class,
+                keys: ['id' => 'type'],
+                group: 'events',
+            ),
+        ]);
+
+        $host = new MinooSurfaceHost($etm);
+        $session = new AdminSurfaceSessionData(
+            accountId: '1',
+            accountName: 'Admin',
+            roles: ['administrator'],
+            policies: [],
+        );
+
+        $built = $host->buildCatalog($session)->build();
+
+        $this->assertFalse($built[0]['capabilities']['create']);
+        $this->assertFalse($built[0]['capabilities']['update']);
+        $this->assertFalse($built[0]['capabilities']['delete']);
+        $this->assertTrue($built[0]['capabilities']['list']);
+        $this->assertTrue($built[0]['capabilities']['get']);
+    }
+
+    #[Test]
+    public function build_catalog_marks_ingest_log_read_only(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getDefinitions')->willReturn([
+            new EntityType(
+                id: 'ingest_log',
+                label: 'Ingestion Log',
+                class: \stdClass::class,
+                keys: ['id' => 'ilid'],
+                group: 'ingestion',
+            ),
+        ]);
+
+        $host = new MinooSurfaceHost($etm);
+        $session = new AdminSurfaceSessionData(
+            accountId: '1',
+            accountName: 'Admin',
+            roles: ['administrator'],
+            policies: [],
+        );
+
+        $built = $host->buildCatalog($session)->build();
+
+        $this->assertFalse($built[0]['capabilities']['create']);
+        $this->assertFalse($built[0]['capabilities']['delete']);
+    }
+
+    #[Test]
+    public function build_catalog_adds_delete_action_for_content_entities(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getDefinitions')->willReturn([
+            new EntityType(
+                id: 'event',
+                label: 'Event',
+                class: \stdClass::class,
+                keys: ['id' => 'eid'],
+                group: 'events',
+            ),
+        ]);
+
+        $host = new MinooSurfaceHost($etm);
+        $session = new AdminSurfaceSessionData(
+            accountId: '1',
+            accountName: 'Admin',
+            roles: ['administrator'],
+            policies: [],
+        );
+
+        $built = $host->buildCatalog($session)->build();
+
+        $this->assertTrue($built[0]['capabilities']['delete']);
+        $this->assertCount(1, $built[0]['actions']);
+        $this->assertSame('delete', $built[0]['actions'][0]['id']);
+        $this->assertTrue($built[0]['actions'][0]['dangerous']);
+    }
+
+    #[Test]
     public function list_returns_error_for_unknown_type(): void
     {
         $etm = $this->createMock(EntityTypeManager::class);


### PR DESCRIPTION
## Summary

Enhances the admin surface catalog to properly categorize all 19 entity types:

- **Config entities** (event_type, group_type, teaching_type): read-only (no create/update/delete)
- **System entities** (ingest_log): read-only (system-generated)
- **Content entities** (16 types): full CRUD with delete action + confirmation

## Changes

- `src/Surface/MinooSurfaceHost.php` — capabilities logic based on entity class + READ_ONLY_TYPES constant
- `tests/Minoo/Unit/Surface/MinooSurfaceHostTest.php` — 3 new tests (config read-only, ingest_log read-only, content delete action)

## Test plan

- [x] 10 unit tests, 25 assertions (Surface)
- [x] Full suite: 452 tests, 1032 assertions
- [ ] CI pipeline green

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)