### PR TITLE
feat(#250): expose admin surface endpoints and serve SPA entry

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Controller;
+
+use Waaseyaa\SSR\SsrResponse;
+
+final class AdminController
+{
+    private readonly string $projectRoot;
+
+    public function __construct()
+    {
+        $this->projectRoot = dirname(__DIR__, 2);
+    }
+
+    public function spa(): SsrResponse
+    {
+        $spaIndex = $this->projectRoot . '/public/admin/index.html';
+
+        if (file_exists($spaIndex)) {
+            return new SsrResponse(content: file_get_contents($spaIndex), statusCode: 200);
+        }
+
+        $html = <<<'HTML'
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Admin — Minoo</title>
+            <style>
+                body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; }
+                h1 { font-size: 1.5rem; }
+                code { background: #f3f4f6; padding: 0.2em 0.4em; border-radius: 4px; font-size: 0.9em; }
+                .endpoints { margin-block: 1rem; }
+                .endpoints dt { font-weight: 600; margin-block-start: 0.5rem; }
+                .endpoints dd { margin-inline-start: 1rem; color: #6b7280; }
+            </style>
+        </head>
+        <body>
+            <h1>Minoo Admin Surface</h1>
+            <p>The admin SPA is not yet built. API endpoints are active:</p>
+            <dl class="endpoints">
+                <dt>GET /admin/surface/session</dt>
+                <dd>Session resolution (requires authentication)</dd>
+                <dt>GET /admin/surface/catalog</dt>
+                <dd>Entity type catalog</dd>
+                <dt>GET /admin/surface/{type}</dt>
+                <dd>Entity listing</dd>
+                <dt>GET /admin/surface/{type}/{id}</dt>
+                <dd>Entity detail</dd>
+                <dt>POST /admin/surface/{type}/action/{action}</dt>
+                <dd>Action dispatch</dd>
+            </dl>
+            <p>To run the admin SPA in development:</p>
+            <pre><code>cd ../waaseyaa/packages/admin && npm run dev</code></pre>
+        </body>
+        </html>
+        HTML;
+
+        return new SsrResponse(content: $html, statusCode: 200);
+    }
+}

--- a/src/Provider/AdminServiceProvider.php
+++ b/src/Provider/AdminServiceProvider.php
@@ -8,6 +8,7 @@ use Minoo\Surface\MinooSurfaceHost;
 use Waaseyaa\AdminSurface\AdminSurfaceServiceProvider;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class AdminServiceProvider extends ServiceProvider
@@ -26,5 +27,24 @@ final class AdminServiceProvider extends ServiceProvider
         $host = new MinooSurfaceHost($entityTypeManager);
 
         AdminSurfaceServiceProvider::registerRoutes($router, $host);
+
+        $router->addRoute(
+            'admin.spa',
+            RouteBuilder::create('/admin')
+                ->controller('Minoo\\Controller\\AdminController::spa')
+                ->requireAuthentication()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'admin.spa.catchall',
+            RouteBuilder::create('/admin/{path}')
+                ->controller('Minoo\\Controller\\AdminController::spa')
+                ->requireAuthentication()
+                ->methods('GET')
+                ->requirement('path', '.+')
+                ->build(),
+        );
     }
 }

--- a/tests/playwright/admin-surface.spec.ts
+++ b/tests/playwright/admin-surface.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin Surface API', () => {
+  test('session endpoint returns 401 for unauthenticated request', async ({ request }) => {
+    const response = await request.get('/admin/surface/session');
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.errors[0].status).toBe('401');
+  });
+
+  test('catalog endpoint returns 401 for unauthenticated request', async ({ request }) => {
+    const response = await request.get('/admin/surface/catalog');
+    expect(response.status()).toBe(401);
+  });
+
+  test('entity list endpoint returns 401 for unauthenticated request', async ({ request }) => {
+    const response = await request.get('/admin/surface/event');
+    expect(response.status()).toBe(401);
+  });
+
+  test('admin SPA entry returns 401 for unauthenticated request', async ({ request }) => {
+    const response = await request.get('/admin');
+    expect(response.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `AdminController::spa()` to serve the admin SPA entry page
- `/admin` and `/admin/{path}` catch-all routes (authentication required)
- When `public/admin/index.html` exists (built Nuxt output), serves it directly
- Falls back to an endpoint documentation page when SPA not built
- CORS already configured for `localhost:3000` (Nuxt dev server)
- 4 Playwright smoke tests verifying admin API returns 401 for unauthenticated requests

## Changes

- `src/Controller/AdminController.php` — SPA entry controller
- `src/Provider/AdminServiceProvider.php` — catch-all routes for `/admin` and `/admin/{path}`
- `tests/playwright/admin-surface.spec.ts` — 4 endpoint smoke tests

## Admin Surface Status (full milestone)

| Issue | Status | PR |
|-------|--------|----|
| #247 Host scaffold | Merged | #319 |
| #248 Catalog capabilities | Merged | #323 |
| #249 Access policies | Merged | #324 |
| #250 Endpoints + SPA | **This PR** | — |

## Test plan

- [x] PHPUnit: 455 tests, 1041 assertions
- [x] Local: `/admin` returns 401 (correct), API endpoints functional
- [ ] CI pipeline green
- [ ] Playwright admin-surface.spec.ts passes in CI

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)