### PR TITLE
feat(#318): add Get Involved page with contribution paths

### DIFF
--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -707,6 +707,31 @@ return [
     // Breadcrumb
     'breadcrumb.home' => 'Home',
 
+    // Get Involved
+    'get_involved.title' => 'Get Involved',
+    'get_involved.subtitle' => 'Minoo grows because people show up. There are many ways to contribute — pick the one that fits your time, your skills, and your heart.',
+    'get_involved.intro_heading' => 'How You Can Help',
+    'get_involved.intro_text' => 'Whether you have an afternoon or an ongoing commitment, there\'s a place for you. Every contribution strengthens the community.',
+    'get_involved.elder_title' => 'Start an Elder Support Program',
+    'get_involved.elder_text' => 'Become a coordinator in your region. You\'ll connect Elders who need help with volunteers who can provide it — rides, groceries, yard work, or a friendly visit. Coordinators are the backbone of the program.',
+    'get_involved.elder_link' => 'Learn about Elder Support',
+    'get_involved.volunteer_title' => 'Volunteer for an Existing Program',
+    'get_involved.volunteer_text' => 'If there\'s already a coordinator in your area, sign up as a volunteer. Set your availability, choose the kinds of help you can offer, and a coordinator will match you with an Elder nearby.',
+    'get_involved.volunteer_link' => 'Sign up to volunteer',
+    'get_involved.teachings_title' => 'Share Teachings',
+    'get_involved.teachings_text' => 'If you carry knowledge — culture, history, ceremony, or lived experience — you can share it here. Teachings on Minoo are living knowledge passed down for the next generation. You decide what to share and how.',
+    'get_involved.teachings_link' => 'Sign in to contribute Teachings',
+    'get_involved.language_title' => 'Contribute Language Resources',
+    'get_involved.language_text' => 'Help grow the Anishinaabemowin collection. Add words, phrases, example sentences, or audio recordings. Every entry helps keep the language alive and accessible to learners.',
+    'get_involved.language_link' => 'Sign in to add language entries',
+    'get_involved.events_title' => 'Add Events',
+    'get_involved.events_text' => 'Know about an upcoming powwow, gathering, ceremony, or community program? Add it to Minoo so people in the area can find it. Events help people stay connected to what\'s happening around them.',
+    'get_involved.events_link' => 'Sign in to add events',
+    'get_involved.feedback_title' => 'Give Feedback',
+    'get_involved.feedback_text' => 'Tell us what\'s working and what isn\'t. If something is missing, confusing, or could be better, we want to hear it. Reach out through your community coordinator or email us at hello@minoo.live.',
+    'get_involved.no_wrong_heading' => 'No Wrong Way to Start',
+    'get_involved.no_wrong_text' => 'You don\'t need special skills or a big time commitment. If you care about your community, you\'re already qualified. Start with whatever feels right and go from there.',
+
     // Open Graph
     'og.default_description' => 'Connecting Indigenous communities, Elders, and volunteers across Turtle Island.',
 ];

--- a/templates/get-involved.html.twig
+++ b/templates/get-involved.html.twig
@@ -1,0 +1,58 @@
+{% extends "base.html.twig" %}
+
+{% block title %}{{ trans('get_involved.title') }} — Minoo{% endblock %}
+
+{% block content %}
+  <div class="content-well content-well--full">
+  <div class="flow-lg">
+    <section class="hero">
+      <h1 class="hero__title">{{ trans('get_involved.title') }}</h1>
+      <p class="hero__subtitle">{{ trans('get_involved.subtitle') }}</p>
+    </section>
+
+    <section class="portal-section flow">
+      <h2>{{ trans('get_involved.intro_heading') }}</h2>
+      <p>{{ trans('get_involved.intro_text') }}</p>
+    </section>
+
+    <section class="portal-section flow">
+      <div class="how-it-works">
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.elder_title') }}</h3>
+          <p>{{ trans('get_involved.elder_text') }}</p>
+          <p><a href="{{ lang_url('/elders') }}">{{ trans('get_involved.elder_link') }}</a></p>
+        </div>
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.volunteer_title') }}</h3>
+          <p>{{ trans('get_involved.volunteer_text') }}</p>
+          <p><a href="{{ lang_url('/volunteer') }}">{{ trans('get_involved.volunteer_link') }}</a></p>
+        </div>
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.teachings_title') }}</h3>
+          <p>{{ trans('get_involved.teachings_text') }}</p>
+          <p><a href="{{ lang_url('/login') }}">{{ trans('get_involved.teachings_link') }}</a></p>
+        </div>
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.language_title') }}</h3>
+          <p>{{ trans('get_involved.language_text') }}</p>
+          <p><a href="{{ lang_url('/login') }}">{{ trans('get_involved.language_link') }}</a></p>
+        </div>
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.events_title') }}</h3>
+          <p>{{ trans('get_involved.events_text') }}</p>
+          <p><a href="{{ lang_url('/login') }}">{{ trans('get_involved.events_link') }}</a></p>
+        </div>
+        <div class="how-it-works__step flow">
+          <h3>{{ trans('get_involved.feedback_title') }}</h3>
+          <p>{{ trans('get_involved.feedback_text') }}</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="portal-section flow">
+      <h2>{{ trans('get_involved.no_wrong_heading') }}</h2>
+      <p>{{ trans('get_involved.no_wrong_text') }}</p>
+    </section>
+  </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary

New page at `/get-involved` presenting 6 clear paths for community participation:
Elder Support coordination, volunteering, sharing Teachings, language resources, events, and feedback.

## Changes

- `templates/get-involved.html.twig` — new page extending base template
- `resources/lang/en.php` — `get_involved.*` translation keys

## Test plan

- [x] PHPUnit tests pass
- [ ] CI pipeline green
- [ ] Page accessible at /get-involved

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)