### PR TITLE
feat(#352): oral history navigation and seed data

### DIFF
--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -12,6 +12,7 @@ return [
     'nav.people' => 'People',
     'nav.teachings' => 'Teachings',
     'nav.events' => 'Events',
+    'nav.oral_histories' => 'Our Stories',
     'nav.programs' => 'Programs',
     'nav.elder_support' => 'Elder Support',
     'nav.volunteer' => 'Volunteer',

--- a/resources/lang/oj.php
+++ b/resources/lang/oj.php
@@ -64,6 +64,7 @@ return [
     'nav.people' => 'Anishinaabeg', // dict: anishinaabeg: plural of anishinaabe
     'nav.teachings' => 'Gikinoo\'amaadiwinan', // dict: gikinoo'amaadiwin: "teaching, education"
     'nav.events' => 'Maawanji\'idiwinan', // dict: maawanji'idiwag: "they come together, meet"
+    'nav.oral_histories' => 'Gdibaajmowinaanin', // dict: dibaajmowin: "story, narrative"; g- (our) + -aanin plural — "Our Stories"
     'nav.programs' => 'Anokiiwinan', // dict: anokii: "s/he works"; -winan nominal plural
     'nav.elder_support' => 'Gichi-aya\'aa Wiidookaagewin', // dict: gichi-aya'aa: "an elder" + wiidookaagewin: "help, assistance"
     'nav.volunteer' => 'Wiidookaage', // dict: wiidookaage: "s/he helps people"

--- a/src/Seed/ConfigSeeder.php
+++ b/src/Seed/ConfigSeeder.php
@@ -38,6 +38,18 @@ final class ConfigSeeder
         ];
     }
 
+    /** @return list<array{type: string, name: string, description: string}> */
+    public static function oralHistoryTypes(): array
+    {
+        return [
+            ['type' => 'creation_story', 'name' => 'Creation Story', 'description' => 'Origin and creation narratives.'],
+            ['type' => 'historical_account', 'name' => 'Historical Account', 'description' => 'Historical events and experiences.'],
+            ['type' => 'personal_narrative', 'name' => 'Personal Narrative', 'description' => 'Individual life stories and memories.'],
+            ['type' => 'land_teaching', 'name' => 'Land Teaching', 'description' => 'Teachings connected to specific places and the land.'],
+            ['type' => 'family_story', 'name' => 'Family Story', 'description' => 'Stories passed down within families.'],
+        ];
+    }
+
     /** @return list<array{code: string, name: string, display_name: string, language_family: string, iso_639_3: string, regions: list<string>, boundary_geojson: ?string}> */
     public static function dialectRegions(): array
     {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -35,6 +35,7 @@
             <li><a href="{{ lang_url('/people') }}"{% if path is defined and path starts with '/people' %} aria-current="page"{% endif %}>{{ trans('nav.people') }}</a></li>
             <li><a href="{{ lang_url('/teachings') }}"{% if path is defined and path starts with '/teachings' %} aria-current="page"{% endif %}>{{ trans('nav.teachings') }}</a></li>
             <li><a href="{{ lang_url('/events') }}"{% if path is defined and path starts with '/events' %} aria-current="page"{% endif %}>{{ trans('nav.events') }}</a></li>
+            <li><a href="{{ lang_url('/oral-histories') }}"{% if path is defined and path starts with '/oral-histories' %} aria-current="page"{% endif %}>{{ trans('nav.oral_histories') }}</a></li>
             <li class="site-nav__dropdown">
               <button class="site-nav__dropdown-toggle" aria-expanded="false"{% if path is defined and (path starts with '/elders' or path starts with '/volunteer') %} aria-current="true"{% endif %}>{{ trans('nav.programs') }}</button>
               <ul class="site-nav__dropdown-menu">

--- a/tests/Minoo/Unit/Seed/ConfigSeederTest.php
+++ b/tests/Minoo/Unit/Seed/ConfigSeederTest.php
@@ -65,6 +65,24 @@ final class ConfigSeederTest extends TestCase
     }
 
     #[Test]
+    public function it_provides_oral_history_types(): void
+    {
+        $types = ConfigSeeder::oralHistoryTypes();
+
+        $this->assertCount(5, $types);
+        $this->assertSame('creation_story', $types[0]['type']);
+        $this->assertSame('Creation Story', $types[0]['name']);
+        $this->assertSame('family_story', $types[4]['type']);
+
+        // All entries must have required keys
+        foreach ($types as $type) {
+            $this->assertArrayHasKey('type', $type);
+            $this->assertArrayHasKey('name', $type);
+            $this->assertArrayHasKey('description', $type);
+        }
+    }
+
+    #[Test]
     public function it_provides_dialect_regions(): void
     {
         $regions = ConfigSeeder::dialectRegions();


### PR DESCRIPTION
## Summary
- Add "Our Stories" nav link in `base.html.twig` after Events and before Programs dropdown
- Add `nav.oral_histories` translation key in English ("Our Stories") and Ojibwe ("Gdibaajmowinaanin")
- Add `ConfigSeeder::oralHistoryTypes()` with 5 oral history types (creation_story, historical_account, personal_narrative, land_teaching, family_story)
- Add unit test for oral history type seed data

Closes #352

## Test plan
- [x] All 470 tests pass (3 pre-existing skips)
- [ ] Verify nav link appears between Events and Programs in browser
- [ ] Verify Ojibwe translation renders when language is switched

🤖 Generated with [Claude Code](https://claude.com/claude-code)