### PR TITLE
feat(#380): add Leaflet map to business detail pages

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -3918,6 +3918,14 @@
     color: var(--text-muted);
   }
 
+  /* Business detail map */
+  .business-detail-map {
+    block-size: 200px;
+    border-radius: var(--radius-md);
+    margin-block-end: var(--space-xs);
+    background: var(--surface-raised);
+  }
+
   /* Community detail map */
   .community-detail-map {
     block-size: 200px;

--- a/public/js/business-map.js
+++ b/public/js/business-map.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var el = document.getElementById('business-detail-map');
+    if (!el) return;
+
+    var lat = parseFloat(el.dataset.lat);
+    var lng = parseFloat(el.dataset.lng);
+    var name = el.dataset.name || '';
+    var address = el.dataset.address || '';
+    var precision = el.dataset.precision || 'community';
+    var zoom = precision === 'address' ? 15 : 12;
+
+    var map = L.map('business-detail-map').setView([lat, lng], zoom);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        maxZoom: 18
+    }).addTo(map);
+
+    var popupContent = '<strong>' + name + '</strong>';
+    if (address) {
+        popupContent += '<br>' + address;
+    }
+
+    L.marker([lat, lng])
+        .addTo(map)
+        .bindPopup(popupContent)
+        .openPopup();
+});

--- a/templates/businesses.html.twig
+++ b/templates/businesses.html.twig
@@ -10,6 +10,13 @@
   {%- endif -%}
 {% endblock %}
 
+{% block head %}
+  {% if path starts with '/businesses/' and business is defined and business.get('latitude') and business.get('longitude') %}
+    <link rel="stylesheet" href="/css/leaflet.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/css/leaflet.css"></noscript>
+  {% endif %}
+{% endblock %}
+
 {% block og_type %}{% if path starts with '/businesses/' and business is defined %}article{% else %}website{% endif %}{% endblock %}
 {% block og_description %}{% if path starts with '/businesses/' and business is defined %}{{ business.get('description')|default('')|striptags|slice(0, 160) }}{% else %}{{ parent() }}{% endif %}{% endblock %}
 
@@ -126,6 +133,16 @@
       {% if business.get('address') is not empty or business.get('city') is not empty %}
         <section class="business-location">
           <h2>{{ trans('businesses.location') }}</h2>
+          {% if business.get('latitude') and business.get('longitude') %}
+            <div id="business-detail-map"
+                 class="business-detail-map"
+                 data-lat="{{ business.get('latitude') }}"
+                 data-lng="{{ business.get('longitude') }}"
+                 data-name="{{ business.get('name') }}"
+                 data-address="{{ business.get('address') ?? '' }}"
+                 data-precision="{{ business.get('coordinate_source') ?? 'community' }}">
+            </div>
+          {% endif %}
           <address class="business-address">
             {% if business.get('address') is not empty %}
               <p>{{ business.get('address') }}</p>
@@ -158,6 +175,11 @@
             {{ community.get('name') }}
           </a>
         </section>
+      {% endif %}
+
+      {% if business.get('latitude') and business.get('longitude') %}
+        <script src="/js/leaflet.js"></script>
+        <script src="/js/business-map.js"></script>
       {% endif %}
     </div>
 


### PR DESCRIPTION
Adds a Leaflet map to business detail pages showing a pin at the business location when lat/lng coordinates are available. Zoom adjusts based on coordinate precision. Leaflet CSS loaded per-page. Closes #380