### PR TITLE
feat(#380): add geo foundation for business pages

### DIFF
--- a/bin/geocode-businesses
+++ b/bin/geocode-businesses
@@ -1,0 +1,155 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Geocode business entities that lack coordinates.
+ *
+ * Usage: bin/geocode-businesses [--apply] [--verbose]
+ *
+ * --apply    Write coordinates to the database (default is dry-run).
+ * --verbose  Print detailed progress for each entity.
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Minoo\Support\GeocodingService;
+
+$kernel = new Waaseyaa\Foundation\Kernel\ConsoleKernel(dirname(__DIR__));
+
+(new ReflectionMethod($kernel, 'boot'))->invoke($kernel);
+
+$entityTypeManager = $kernel->getEntityTypeManager();
+
+$apply   = in_array('--apply', $argv, true);
+$verbose = in_array('--verbose', $argv, true);
+
+if (!$apply) {
+    fprintf(STDOUT, "DRY RUN — pass --apply to write changes.\n\n");
+}
+
+$geocoder = new GeocodingService();
+$groupStorage = $entityTypeManager->getStorage('group');
+$ids = $groupStorage->getQuery()->execute();
+
+$geocoded = 0;
+$fallback = 0;
+$skipped  = 0;
+$failed   = 0;
+
+// Pre-load community storage for fallback lookups.
+$communityStorage = null;
+try {
+    $communityStorage = $entityTypeManager->getStorage('community');
+} catch (\Throwable) {
+    // Community entity type may not exist in all environments.
+}
+
+foreach ($ids as $id) {
+    $entity = $groupStorage->load($id);
+    if ($entity === null) {
+        continue;
+    }
+
+    $type = (string) ($entity->get('type') ?? '');
+    $status = $entity->get('status');
+
+    // Only geocode published business entities.
+    if ($type !== 'business' || (int) $status !== 1) {
+        continue;
+    }
+
+    $name = (string) ($entity->get('name') ?? '(unnamed)');
+
+    // Skip entities that already have coordinates.
+    $lat = $entity->get('latitude');
+    $lng = $entity->get('longitude');
+    if ($lat !== null && $lng !== null && (float) $lat !== 0.0) {
+        if ($verbose) {
+            fprintf(STDOUT, "  [SKIP] %s — already has coordinates.\n", $name);
+        }
+        $skipped++;
+        continue;
+    }
+
+    // Try geocoding from the address field.
+    $address = (string) ($entity->get('address') ?? '');
+    $coords = null;
+    $source = null;
+
+    if ($address !== '') {
+        $coords = $geocoder->geocode($address);
+        if ($coords !== null) {
+            $source = 'address';
+        }
+        // Rate limit: 1 request per second (Nominatim policy).
+        usleep(1_000_000);
+    }
+
+    // Fallback: use community coordinates.
+    if ($coords === null && $communityStorage !== null) {
+        $communityId = $entity->get('community_id');
+        if ($communityId !== null) {
+            $community = $communityStorage->load((int) $communityId);
+            if ($community !== null) {
+                $cLat = $community->get('latitude');
+                $cLng = $community->get('longitude');
+                if ($cLat !== null && $cLng !== null && (float) $cLat !== 0.0) {
+                    $coords = ['lat' => (float) $cLat, 'lng' => (float) $cLng];
+                    $source = 'community';
+                }
+            }
+        }
+    }
+
+    if ($coords === null) {
+        if ($verbose) {
+            fprintf(STDOUT, "  [FAILED] %s — no address and no community fallback.\n", $name);
+        }
+        $failed++;
+        continue;
+    }
+
+    $tag = $source === 'address' ? 'GEOCODED' : 'FALLBACK';
+
+    if ($verbose) {
+        fprintf(
+            STDOUT,
+            "  [%s] %s — %.4f, %.4f (source: %s)\n",
+            $tag,
+            $name,
+            $coords['lat'],
+            $coords['lng'],
+            $source,
+        );
+    }
+
+    if ($apply) {
+        $entity->set('latitude', $coords['lat']);
+        $entity->set('longitude', $coords['lng']);
+        $entity->set('coordinate_source', $source);
+        $groupStorage->save($entity);
+    }
+
+    if ($source === 'address') {
+        $geocoded++;
+    } else {
+        $fallback++;
+    }
+}
+
+fprintf(STDOUT, "\n");
+
+if (!$apply) {
+    fprintf(STDOUT, "DRY RUN — no changes written.\n");
+}
+
+fprintf(
+    STDOUT,
+    "Done: %d geocoded, %d community fallback, %d skipped, %d failed.\n",
+    $geocoded,
+    $fallback,
+    $skipped,
+    $failed,
+);

--- a/migrations/20260321_160000_add_coordinates_to_group.php
+++ b/migrations/20260321_160000_add_coordinates_to_group.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Add latitude, longitude, and coordinate_source columns to the group table.
+ *
+ * These columns support map integration for business pages.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        if (!$schema->hasTable('group')) {
+            return;
+        }
+
+        $connection = $schema->getConnection();
+
+        if (!$schema->hasColumn('group', 'latitude')) {
+            $connection->executeStatement(
+                'ALTER TABLE "group" ADD COLUMN latitude REAL',
+            );
+        }
+
+        if (!$schema->hasColumn('group', 'longitude')) {
+            $connection->executeStatement(
+                'ALTER TABLE "group" ADD COLUMN longitude REAL',
+            );
+        }
+
+        if (!$schema->hasColumn('group', 'coordinate_source')) {
+            $connection->executeStatement(
+                'ALTER TABLE "group" ADD COLUMN coordinate_source TEXT',
+            );
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // SQLite does not support DROP COLUMN before 3.35.0.
+        // For safety, this is a no-op.
+    }
+};

--- a/src/Provider/GroupServiceProvider.php
+++ b/src/Provider/GroupServiceProvider.php
@@ -128,6 +128,24 @@ final class GroupServiceProvider extends ServiceProvider
                     'description' => 'JSON array of recent social media posts.',
                     'weight' => 97,
                 ],
+                'latitude' => [
+                    'type' => 'float',
+                    'label' => 'Latitude',
+                    'description' => 'Geocoded from address, or community fallback.',
+                    'weight' => 98,
+                ],
+                'longitude' => [
+                    'type' => 'float',
+                    'label' => 'Longitude',
+                    'description' => 'Geocoded from address, or community fallback.',
+                    'weight' => 99,
+                ],
+                'coordinate_source' => [
+                    'type' => 'string',
+                    'label' => 'Coordinate Source',
+                    'description' => 'How coordinates were obtained: address or community.',
+                    'weight' => 100,
+                ],
                 'status' => [
                     'type' => 'boolean',
                     'label' => 'Published',

--- a/src/Support/GeocodingService.php
+++ b/src/Support/GeocodingService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+/**
+ * Geocodes addresses via the Nominatim (OpenStreetMap) API.
+ */
+final class GeocodingService
+{
+    private const USER_AGENT = 'Minoo/1.0 (https://minoo.live; russell@minoo.live)';
+
+    private const TIMEOUT = 10;
+
+    private const BASE_URL = 'https://nominatim.openstreetmap.org/search';
+
+    /**
+     * Geocode an address string to lat/lng coordinates.
+     *
+     * @return array{lat: float, lng: float}|null
+     */
+    public function geocode(string $address): ?array
+    {
+        $url = self::buildUrl($address);
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => self::TIMEOUT,
+                'ignore_errors' => true,
+                'header' => 'User-Agent: ' . self::USER_AGENT . "\r\n",
+            ],
+        ]);
+
+        $attempt = 0;
+
+        while ($attempt < 2) {
+            $json = @file_get_contents($url, false, $context);
+
+            if ($json === false) {
+                $attempt++;
+                if ($attempt < 2) {
+                    usleep(2_000_000);
+                }
+                continue;
+            }
+
+            // Check for retry-worthy HTTP status codes.
+            $statusCode = $this->extractStatusCode($http_response_header ?? []);
+            if ($statusCode === 429 || $statusCode === 503) {
+                $attempt++;
+                if ($attempt < 2) {
+                    usleep(2_000_000);
+                }
+                continue;
+            }
+
+            return self::parseResponse($json);
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the Nominatim search URL for a given address.
+     */
+    public static function buildUrl(string $address): string
+    {
+        return self::BASE_URL . '?' . http_build_query([
+            'q' => $address,
+            'format' => 'json',
+            'limit' => 1,
+        ]);
+    }
+
+    /**
+     * Parse a Nominatim JSON response into lat/lng.
+     *
+     * @return array{lat: float, lng: float}|null
+     */
+    public static function parseResponse(string $json): ?array
+    {
+        $data = json_decode($json, true);
+
+        if (!is_array($data) || $data === []) {
+            return null;
+        }
+
+        $first = $data[0] ?? null;
+
+        if (!is_array($first) || !isset($first['lat'], $first['lon'])) {
+            return null;
+        }
+
+        $lat = (float) $first['lat'];
+        $lng = (float) $first['lon'];
+
+        if ($lat === 0.0 && $lng === 0.0) {
+            return null;
+        }
+
+        return ['lat' => $lat, 'lng' => $lng];
+    }
+
+    /**
+     * Extract the HTTP status code from response headers.
+     *
+     * @param list<string> $headers
+     */
+    private function extractStatusCode(array $headers): int
+    {
+        if ($headers === []) {
+            return 0;
+        }
+
+        // The first header line is like "HTTP/1.1 200 OK".
+        if (preg_match('/HTTP\/\S+\s+(\d{3})/', $headers[0], $matches)) {
+            return (int) $matches[1];
+        }
+
+        return 0;
+    }
+}

--- a/tests/Minoo/Unit/Support/GeocodingServiceTest.php
+++ b/tests/Minoo/Unit/Support/GeocodingServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Support;
+
+use Minoo\Support\GeocodingService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GeocodingService::class)]
+final class GeocodingServiceTest extends TestCase
+{
+    #[Test]
+    public function parsesValidNominatimResponse(): void
+    {
+        $json = json_encode([
+            ['lat' => '46.5107', 'lon' => '-81.0021', 'display_name' => 'Sagamok'],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = GeocodingService::parseResponse($json);
+
+        $this->assertNotNull($result);
+        $this->assertEqualsWithDelta(46.5107, $result['lat'], 0.0001);
+        $this->assertEqualsWithDelta(-81.0021, $result['lng'], 0.0001);
+    }
+
+    #[Test]
+    public function returnsNullForEmptyResponse(): void
+    {
+        $result = GeocodingService::parseResponse('[]');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function returnsNullForMalformedJson(): void
+    {
+        $result = GeocodingService::parseResponse('{not valid json');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function returnsNullForMissingCoordinates(): void
+    {
+        $json = json_encode([
+            ['display_name' => 'Somewhere'],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = GeocodingService::parseResponse($json);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function buildUrlEncodesAddress(): void
+    {
+        $url = GeocodingService::buildUrl('123 Main St, Sudbury ON');
+
+        $this->assertStringContainsString('nominatim.openstreetmap.org/search', $url);
+        $this->assertStringContainsString('q=123+Main+St', $url);
+        $this->assertStringContainsString('format=json', $url);
+        $this->assertStringContainsString('limit=1', $url);
+    }
+}


### PR DESCRIPTION
## Summary
- Add latitude, longitude, coordinate_source fields to Group entity (migration + field definitions)
- Create GeocodingService — Nominatim API client with retry logic and fallback support
- Create bin/geocode-businesses script — backfills coordinates on business entities
- Add 5 unit tests for GeocodingService

## Test plan
- [x] MinooUnit — 481 tests, 1156 assertions, all pass
- [x] geocode-businesses dry-run boots cleanly
- [ ] bin/waaseyaa migrate — apply migration on dev DB
- [ ] bin/waaseyaa schema:check — verify no drift
- [ ] geocode-businesses --apply --verbose on production data