### PR TITLE
feat(#380): add consent cascade to business owner query

### DIFF
--- a/src/Controller/BusinessController.php
+++ b/src/Controller/BusinessController.php
@@ -80,13 +80,14 @@ final class BusinessController
             }
         }
 
-        // Load linked owner (ResourcePerson)
+        // Load linked owner (ResourcePerson) — only if consented
         $owner = null;
         if ($business !== null) {
             $personStorage = $this->entityTypeManager->getStorage('resource_person');
             $ownerIds = $personStorage->getQuery()
                 ->condition('linked_group_id', $business->id())
                 ->condition('status', 1)
+                ->condition('consent_public', 1)
                 ->execute();
             $owner = $ownerIds !== [] ? $personStorage->load(reset($ownerIds)) : null;
         }

--- a/tests/Minoo/Unit/Controller/BusinessControllerConsentTest.php
+++ b/tests/Minoo/Unit/Controller/BusinessControllerConsentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class BusinessControllerConsentTest extends TestCase
+{
+    private string $controllerSource;
+
+    protected function setUp(): void
+    {
+        $path = dirname(__DIR__, 4) . '/src/Controller/BusinessController.php';
+        $contents = file_get_contents($path);
+        self::assertIsString($contents, "Controller file not found at {$path}");
+        $this->controllerSource = $contents;
+    }
+
+    #[Test]
+    public function consentConditionExistsInController(): void
+    {
+        self::assertStringContainsString(
+            "condition('consent_public', 1)",
+            $this->controllerSource,
+            'BusinessController must filter resource_person by consent_public',
+        );
+    }
+
+    #[Test]
+    public function consentConditionAppliedWithStatusCondition(): void
+    {
+        self::assertStringContainsString(
+            "condition('status', 1)",
+            $this->controllerSource,
+            'BusinessController must filter resource_person by status',
+        );
+        self::assertStringContainsString(
+            "condition('consent_public', 1)",
+            $this->controllerSource,
+            'BusinessController must filter resource_person by consent_public',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Added `consent_public` condition to the owner query in `BusinessController::show()` so non-consented person data never enters the template context
- Created source-level verification tests confirming the consent condition exists

## Test plan
- [x] All 478 MinooUnit tests pass (1151 assertions)
- [ ] Verify business page still shows consented owner (Larissa Toulouse)
- [ ] Verify non-consented owners are hidden

Closes #380 (Unit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)