### PR TITLE
feat: add feed sidebar, create-post, and engagement templates

### DIFF
--- a/templates/components/feed-create-post.html.twig
+++ b/templates/components/feed-create-post.html.twig
@@ -1,0 +1,26 @@
+{# Create-post box — authenticated users see form, guests see CTA #}
+<div class="feed-create">
+  {% if account is defined and account.isAuthenticated() %}
+    <div class="feed-create__prompt">
+      <span class="feed-create__avatar">{{ account_initial|default('?') }}</span>
+      <span class="feed-create__placeholder">{{ trans('feed.whats_happening') }}</span>
+    </div>
+    <form class="feed-create__form" method="post" action="{{ lang_url('/feed/post') }}" hidden>
+      <textarea class="feed-create__textarea" name="body" rows="3" placeholder="{{ trans('feed.whats_happening') }}" required></textarea>
+      {% if user_communities|default([])|length > 0 %}
+        <select class="feed-create__community" name="community">
+          <option value="">{{ trans('feed.select_community') }}</option>
+          {% for community in user_communities %}
+            <option value="{{ community.slug }}">{{ community.name }}</option>
+          {% endfor %}
+        </select>
+      {% endif %}
+      <button type="submit" class="btn btn--primary">{{ trans('feed.post') }}</button>
+    </form>
+  {% else %}
+    <div class="feed-create__guest">
+      <p class="feed-create__guest-text">{{ trans('feed.join_conversation') }}</p>
+      <a href="{{ lang_url('/login') }}" class="btn btn--primary">{{ trans('feed.login') }}</a>
+    </div>
+  {% endif %}
+</div>

--- a/templates/components/feed-engagement.html.twig
+++ b/templates/components/feed-engagement.html.twig
@@ -1,0 +1,30 @@
+{# Engagement row — included in each feed card for reactions, comments, sharing #}
+<div class="feed-card__engagement">
+  {% if (item.reactionCount is defined and item.reactionCount > 0) or (item.commentCount is defined and item.commentCount > 0) %}
+    <p class="feed-card__counts">
+      {% if item.reactionCount is defined and item.reactionCount > 0 %}
+        <span class="feed-card__count feed-card__count--reactions">{{ item.reactionCount }} {{ trans('feed.interested') }}</span>
+      {% endif %}
+      {% if (item.reactionCount is defined and item.reactionCount > 0) and (item.commentCount is defined and item.commentCount > 0) %}
+        <span class="feed-card__count-separator">&middot;</span>
+      {% endif %}
+      {% if item.commentCount is defined and item.commentCount > 0 %}
+        <span class="feed-card__count feed-card__count--comments">{{ item.commentCount }} {{ trans('feed.comments') }}</span>
+      {% endif %}
+    </p>
+  {% endif %}
+
+  <div class="feed-card__actions">
+    <button type="button" class="feed-card__action feed-card__action--react" data-action="react" data-type="{{ item.type }}" data-id="{{ item.id }}">
+      {{ trans('feed.action_' ~ item.type) }}
+    </button>
+    <button type="button" class="feed-card__action feed-card__action--comment" data-action="comment" data-type="{{ item.type }}" data-id="{{ item.id }}">
+      {{ trans('feed.comment') }}
+    </button>
+    <button type="button" class="feed-card__action feed-card__action--share" data-action="share" data-url="{{ lang_url(item.url) }}" data-title="{{ item.title }}">
+      {{ trans('feed.share') }}
+    </button>
+  </div>
+
+  <div class="feed-card__comments" data-type="{{ item.type }}" data-id="{{ item.id }}" hidden></div>
+</div>

--- a/templates/components/feed-sidebar-left.html.twig
+++ b/templates/components/feed-sidebar-left.html.twig
@@ -1,0 +1,41 @@
+{# Left navigation sidebar for the social feed layout #}
+<aside class="feed-sidebar feed-sidebar--left">
+  <nav class="sidebar-nav" aria-label="{{ trans('feed.navigation') }}">
+    <ul class="sidebar-nav__list">
+      <li class="sidebar-nav__item sidebar-nav__item--events">
+        <a href="{{ lang_url('/events') }}">{{ trans('nav.events') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--communities">
+        <a href="{{ lang_url('/communities') }}">{{ trans('nav.communities') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--teachings">
+        <a href="{{ lang_url('/teachings') }}">{{ trans('nav.teachings') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--people">
+        <a href="{{ lang_url('/people') }}">{{ trans('nav.people') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--businesses">
+        <a href="{{ lang_url('/businesses') }}">{{ trans('nav.businesses') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--volunteer">
+        <a href="{{ lang_url('/volunteer') }}">{{ trans('nav.volunteer') }}</a>
+      </li>
+      <li class="sidebar-nav__item sidebar-nav__item--elder-support">
+        <a href="{{ lang_url('/elder-support') }}">{{ trans('nav.elder_support') }}</a>
+      </li>
+    </ul>
+  </nav>
+
+  {% if followed_communities|default([])|length > 0 %}
+    <section class="sidebar-communities">
+      <h4 class="sidebar-communities__heading">{{ trans('feed.your_communities') }}</h4>
+      <ul class="sidebar-communities__list">
+        {% for community in followed_communities %}
+          <li class="sidebar-communities__item">
+            <a href="{{ lang_url('/communities/' ~ community.slug) }}">{{ community.name }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+</aside>

--- a/templates/components/feed-sidebar-right.html.twig
+++ b/templates/components/feed-sidebar-right.html.twig
@@ -1,0 +1,49 @@
+{# Right sidebar with trending, events, and suggested communities widgets #}
+<aside class="feed-sidebar feed-sidebar--right">
+  {% if trending|default([])|length > 0 %}
+    <section class="sidebar-widget sidebar-widget--trending">
+      <h4 class="sidebar-widget__heading">{{ trans('feed.trending') }}</h4>
+      <ul class="sidebar-widget__list">
+        {% for item in trending %}
+          <li class="sidebar-widget__item">
+            <span class="feed-badge feed-badge--{{ item.type }}">{{ item.badge }}</span>
+            <a href="{{ lang_url(item.url) }}">{{ item.title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="{{ lang_url('/trending') }}" class="sidebar-widget__see-all">{{ trans('feed.see_all') }}</a>
+    </section>
+  {% endif %}
+
+  {% if upcoming_events|default([])|length > 0 %}
+    <section class="sidebar-widget sidebar-widget--events">
+      <h4 class="sidebar-widget__heading">{{ trans('feed.upcoming_events') }}</h4>
+      <ul class="sidebar-widget__list">
+        {% for event in upcoming_events %}
+          <li class="sidebar-widget__item">
+            <a href="{{ lang_url(event.url) }}">
+              <span class="sidebar-widget__event-date">{{ event.date }}</span>
+              <span class="sidebar-widget__event-title">{{ event.title }}</span>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if suggested_communities|default([])|length > 0 %}
+    <section class="sidebar-widget sidebar-widget--communities">
+      <h4 class="sidebar-widget__heading">{{ trans('feed.suggested_communities') }}</h4>
+      <ul class="sidebar-widget__list">
+        {% for community in suggested_communities %}
+          <li class="sidebar-widget__item">
+            <a href="{{ lang_url('/communities/' ~ community.slug) }}">{{ community.name }}</a>
+            {% if community.distance is defined and community.distance is not null %}
+              <span class="sidebar-widget__distance">{{ community.distance|round(1) }} km</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+</aside>


### PR DESCRIPTION
## Summary
- Added `feed-sidebar-left.html.twig` — nav shortcuts (Events, Communities, Teachings, People, Businesses, Volunteer, Elder Support) + followed communities section
- Added `feed-sidebar-right.html.twig` — trending items, upcoming events, and suggested communities widgets
- Added `feed-create-post.html.twig` — authenticated create-post form with guest CTA fallback
- Added `feed-engagement.html.twig` — reaction counts, action buttons (react/comment/share), hidden comments container

## Test plan
- [x] PHPUnit: 534 tests pass, 1357 assertions (no regressions)
- [x] Valid Twig syntax: matching `{% %}` blocks, proper nesting
- [x] All user-facing text uses `trans()` for i18n
- [x] All links use `lang_url()` for i18n routing
- [x] Optional variables guarded with `|default([])` or `is defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)