### PR TITLE
feat: social feed CSS — layout, cards, sidebars, engagement UI

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -3234,4 +3234,717 @@
       grid-template-columns: 1fr;
     }
   }
+
+  /* ══════════════════════════════════════════════════════════
+     Social Feed — Three-Column Layout
+     ══════════════════════════════════════════════════════════ */
+
+  /* ── Feed Layout (three-column grid) ── */
+  .feed-layout {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 600px) 260px;
+    gap: var(--space-md);
+    max-inline-size: 1200px;
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    padding-block-start: var(--space-md);
+  }
+
+  .feed-main {
+    min-inline-size: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .feed-sidebar {
+    position: sticky;
+    top: var(--space-md);
+    align-self: start;
+    max-block-size: calc(100vh - var(--space-lg));
+    overflow-y: auto;
+  }
+
+  @media (max-width: 1199px) {
+    .feed-layout {
+      grid-template-columns: 220px minmax(0, 1fr);
+    }
+    .feed-sidebar--right {
+      display: none;
+    }
+  }
+
+  @media (max-width: 1023px) {
+    .feed-layout {
+      grid-template-columns: 1fr;
+    }
+    .feed-sidebar--left {
+      display: none;
+    }
+  }
+
+  /* ── Left Sidebar Navigation ── */
+  .sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
+  }
+
+  .sidebar-nav__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    padding: var(--space-2xs) var(--space-xs);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+  }
+
+  .sidebar-nav__item:hover {
+    background-color: var(--surface-raised);
+    color: var(--text-primary);
+  }
+
+  .sidebar-nav__item--events:hover { color: var(--color-events); }
+  .sidebar-nav__item--communities:hover { color: var(--color-communities); }
+  .sidebar-nav__item--teachings:hover { color: var(--color-teachings); }
+  .sidebar-nav__item--people:hover { color: var(--color-people); }
+  .sidebar-nav__item--businesses:hover { color: var(--color-businesses); }
+  .sidebar-nav__item--language:hover { color: var(--color-language); }
+
+  .sidebar-nav__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 24px;
+    block-size: 24px;
+    font-size: 1rem;
+    flex-shrink: 0;
+  }
+
+  .sidebar-nav__divider {
+    block-size: 1px;
+    background-color: var(--border-subtle);
+    margin-block: var(--space-2xs);
+  }
+
+  /* ── Right Sidebar Widgets ── */
+  .sidebar-widget {
+    background-color: var(--surface-card);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-subtle);
+    padding: var(--space-sm);
+    margin-block-end: var(--space-sm);
+  }
+
+  .sidebar-widget__title {
+    font-family: var(--font-heading);
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-block-end: var(--space-2xs);
+    padding-block-end: var(--space-3xs);
+    border-block-end: 1px solid var(--border-subtle);
+  }
+
+  .sidebar-widget__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2xs);
+    padding: var(--space-3xs) 0;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.85rem;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .sidebar-widget__item:hover {
+    color: var(--text-primary);
+  }
+
+  .sidebar-widget__item strong {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .sidebar-widget__meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .sidebar-widget__link {
+    display: block;
+    margin-block-start: var(--space-2xs);
+    font-size: 0.8rem;
+    color: var(--color-communities);
+    text-decoration: none;
+  }
+
+  .sidebar-widget__link:hover {
+    text-decoration: underline;
+  }
+
+  /* ── Create Post Box ── */
+  .feed-create {
+    background-color: var(--surface-card);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-subtle);
+    padding: var(--space-sm);
+  }
+
+  .feed-create__prompt {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    cursor: pointer;
+  }
+
+  /* Shared avatar base for feed avatars */
+  .feed-create__avatar,
+  .feed-card__avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 40px;
+    block-size: 40px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    flex-shrink: 0;
+  }
+
+  .feed-create__avatar {
+    background-color: var(--color-communities);
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  .feed-create__placeholder {
+    flex: 1;
+    padding: var(--space-2xs) var(--space-xs);
+    border-radius: var(--radius-full);
+    background-color: var(--surface-raised);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    border: 1px solid var(--border-subtle);
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-create__prompt:hover .feed-create__placeholder {
+    background-color: var(--surface-card);
+    color: var(--text-secondary);
+  }
+
+  .feed-create__form {
+    margin-block-start: var(--space-xs);
+  }
+
+  .feed-create__textarea {
+    inline-size: 100%;
+    min-block-size: 80px;
+    padding: var(--space-xs);
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    resize: vertical;
+    transition: border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-create__textarea:focus {
+    outline: none;
+    border-color: var(--color-communities);
+  }
+
+  .feed-create__actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-xs);
+    margin-block-start: var(--space-2xs);
+  }
+
+  .feed-create__community {
+    padding: var(--space-3xs) var(--space-2xs);
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-family: var(--font-body);
+  }
+
+  .feed-create__guest {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-xs);
+  }
+
+  .feed-create__guest p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0;
+  }
+
+  /* ── Feed Cards — Community-Attributed Design ── */
+  .feed-card {
+    background-color: var(--surface-card);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-subtle);
+    border-block-start: 3px solid var(--card-accent, var(--border-subtle));
+    overflow: hidden;
+  }
+
+  .feed-card--event { --card-accent: var(--color-events); }
+  .feed-card--teaching { --card-accent: var(--color-teachings); }
+  .feed-card--business { --card-accent: var(--color-businesses); }
+  .feed-card--group { --card-accent: var(--color-communities); }
+  .feed-card--contributor { --card-accent: var(--color-people); }
+  .feed-card--featured { --card-accent: var(--color-teachings); }
+  .feed-card--post { --card-accent: var(--color-communities); }
+  .feed-card--communities { --card-accent: var(--color-communities); }
+  .feed-card--language { --card-accent: var(--color-language); }
+
+  .feed-card__body {
+    padding: var(--space-sm);
+  }
+
+  /* Attribution row */
+  .feed-card__attribution {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    margin-block-end: var(--space-2xs);
+  }
+
+  .feed-card__avatar {
+    background-color: var(--card-accent, var(--color-communities));
+    font-size: 1.1rem;
+  }
+
+  .feed-card__attribution-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-inline-size: 0;
+  }
+
+  .feed-card__community-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--card-accent, var(--color-communities));
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .feed-card__community-name:hover {
+    text-decoration: underline;
+  }
+
+  .feed-card__meta {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  /* Card title */
+  .feed-card__title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1.1rem;
+    line-height: 1.3;
+    margin-block-end: var(--space-3xs);
+  }
+
+  .feed-card__title a {
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .feed-card__title a:hover {
+    color: var(--card-accent, var(--color-events));
+    text-decoration: underline;
+  }
+
+  /* Card description */
+  .feed-card__description {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    margin-block-end: var(--space-2xs);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  /* Detail box — structured data (date, location, etc.) */
+  .feed-card__detail-box {
+    background-color: var(--surface-raised);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2xs) var(--space-xs);
+    margin-block-end: var(--space-2xs);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
+  }
+
+  .feed-card__detail-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2xs);
+  }
+
+  .feed-card__detail-icon {
+    flex-shrink: 0;
+    inline-size: 16px;
+    text-align: center;
+  }
+
+  /* Engagement counts row */
+  .feed-card__engagement {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-3xs) 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .feed-card__engagement:empty {
+    display: none;
+  }
+
+  .feed-card__engagement-item {
+    cursor: default;
+  }
+
+  /* Action buttons row */
+  .feed-card__actions {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    border-block-start: 1px solid var(--border-subtle);
+    margin-inline: calc(-1 * var(--space-sm));
+    margin-block-end: calc(-1 * var(--space-sm));
+  }
+
+  .feed-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-3xs);
+    padding: var(--space-2xs);
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-action:hover {
+    background-color: var(--surface-raised);
+    color: var(--text-primary);
+  }
+
+  .feed-action--active {
+    color: var(--card-accent, var(--color-events));
+    font-weight: 600;
+  }
+
+  .feed-action--active:hover {
+    color: var(--card-accent, var(--color-events));
+  }
+
+  .feed-action + .feed-action {
+    border-inline-start: 1px solid var(--border-subtle);
+  }
+
+  .feed-action__icon {
+    font-size: 1rem;
+  }
+
+  /* Inline comments section */
+  .feed-card__comments {
+    border-block-start: 1px solid var(--border-subtle);
+    padding: var(--space-xs) var(--space-sm);
+    margin-inline: calc(-1 * var(--space-sm));
+    margin-block-end: calc(-1 * var(--space-sm));
+    background-color: rgba(0, 0, 0, 0.15);
+  }
+
+  .feed-comment {
+    display: flex;
+    gap: var(--space-2xs);
+    margin-block-end: var(--space-2xs);
+  }
+
+  .feed-comment:last-child {
+    margin-block-end: 0;
+  }
+
+  .feed-comment__avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 28px;
+    block-size: 28px;
+    border-radius: var(--radius-sm);
+    background-color: var(--surface-raised);
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .feed-comment__content {
+    flex: 1;
+    min-inline-size: 0;
+  }
+
+  .feed-comment__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2xs);
+    margin-block-end: 2px;
+  }
+
+  .feed-comment__author {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .feed-comment__time {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+  }
+
+  .feed-comment__body {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+  }
+
+  .feed-comment__delete {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 0;
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-comment:hover .feed-comment__delete {
+    opacity: 1;
+  }
+
+  .feed-comment__delete:hover {
+    color: var(--color-events);
+  }
+
+  .feed-comments__view-all {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    margin-block-end: var(--space-2xs);
+  }
+
+  .feed-comments__view-all:hover {
+    color: var(--text-secondary);
+    text-decoration: underline;
+  }
+
+  .feed-comments__form {
+    display: flex;
+    gap: var(--space-2xs);
+    margin-block-start: var(--space-2xs);
+  }
+
+  .feed-comments__input {
+    flex: 1;
+    padding: var(--space-3xs) var(--space-2xs);
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-full);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+  }
+
+  .feed-comments__input:focus {
+    outline: none;
+    border-color: var(--color-communities);
+  }
+
+  .feed-comments__submit {
+    padding: var(--space-3xs) var(--space-xs);
+    background-color: var(--color-communities);
+    border: none;
+    border-radius: var(--radius-full);
+    color: #fff;
+    font-family: var(--font-body);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-comments__submit:hover {
+    opacity: 0.85;
+  }
+
+  /* ── Feed Badges ── */
+  .feed-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .feed-badge--event { background-color: rgba(230, 57, 70, 0.2); color: var(--color-events); }
+  .feed-badge--teaching { background-color: rgba(244, 162, 97, 0.2); color: var(--color-teachings); }
+  .feed-badge--group { background-color: rgba(106, 156, 175, 0.2); color: var(--color-communities); }
+  .feed-badge--business { background-color: rgba(200, 100, 50, 0.2); color: var(--color-businesses); }
+  .feed-badge--contributor { background-color: rgba(131, 56, 236, 0.2); color: var(--color-people); }
+  .feed-badge--language { background-color: rgba(42, 157, 143, 0.2); color: var(--color-language); }
+  .feed-badge--post { background-color: rgba(106, 156, 175, 0.2); color: var(--color-communities); }
+
+  /* ── Feed Filter Chips ── */
+  .feed-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3xs);
+  }
+
+  .feed-chip {
+    padding: var(--space-3xs) var(--space-xs);
+    border-radius: var(--radius-full);
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border-subtle);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    text-decoration: none;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .feed-chip:hover,
+  .feed-chip--active {
+    background-color: rgba(106, 156, 175, 0.15);
+    border-color: var(--color-communities);
+    color: var(--text-primary);
+  }
+
+  /* ── Welcome Card ── */
+  .feed-card--welcome {
+    --card-accent: var(--color-communities);
+    text-align: center;
+    padding: var(--space-md);
+  }
+
+  .feed-card--welcome .feed-card__title {
+    font-size: 1.3rem;
+    margin-block-end: var(--space-2xs);
+  }
+
+  /* ── Communities Pill Cloud ── */
+  .feed-card--communities .feed-card__body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3xs);
+  }
+
+  .community-pill {
+    display: inline-block;
+    padding: var(--space-3xs) var(--space-2xs);
+    border-radius: var(--radius-full);
+    background-color: rgba(106, 156, 175, 0.15);
+    color: var(--color-communities);
+    font-size: 0.8rem;
+    text-decoration: none;
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .community-pill:hover {
+    background-color: rgba(106, 156, 175, 0.3);
+  }
+
+  /* ── Skeleton Loading ── */
+  .feed-card--loading {
+    pointer-events: none;
+  }
+
+  .feed-card__skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    padding: var(--space-sm);
+  }
+
+  .feed-card__skeleton::before,
+  .feed-card__skeleton::after {
+    content: "";
+    display: block;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(
+      90deg,
+      var(--surface-raised) 25%,
+      rgba(255, 255, 255, 0.05) 50%,
+      var(--surface-raised) 75%
+    );
+    background-size: 200% 100%;
+    animation: feed-shimmer 1.5s ease-in-out infinite;
+  }
+
+  .feed-card__skeleton::before {
+    block-size: 40px;
+    inline-size: 60%;
+  }
+
+  .feed-card__skeleton::after {
+    block-size: 80px;
+    inline-size: 100%;
+  }
+
+  @keyframes feed-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  /* ── Feed End Message ── */
+  .feed-end {
+    text-align: center;
+    padding: var(--space-md);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+
+  /* ── Feed Container ── */
+  .feed-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
 }


### PR DESCRIPTION
Adds social feed CSS foundation: three-column grid layout with responsive collapse, community-attributed cards with domain-colored top bars, sidebar navigation and widgets, create-post box, engagement UI (actions, comments), badges, filter chips, skeleton loading. 713 lines added to minoo.css. All 534 PHPUnit tests pass.