### PR TITLE
feat: add engagement data and post support to feed backend

### DIFF
--- a/src/Feed/EngagementCounter.php
+++ b/src/Feed/EngagementCounter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed;
+
+/**
+ * Counts reactions and comments for feed items.
+ * Implementation will be provided by another worker.
+ */
+interface EngagementCounter
+{
+    /**
+     * Get engagement counts for a batch of feed item IDs.
+     *
+     * @param list<string> $feedItemIds Feed item IDs (e.g. "event:42", "post:7")
+     * @return array<string, array{reactions: int, comments: int}> Keyed by feed item ID
+     */
+    public function getCounts(array $feedItemIds): array;
+}

--- a/src/Feed/EntityLoaderService.php
+++ b/src/Feed/EntityLoaderService.php
@@ -122,6 +122,24 @@ class EntityLoaderService
         return $items;
     }
 
+    public function loadPosts(int $limit): array
+    {
+        try {
+            $storage = $this->entityTypeManager->getStorage('post');
+        } catch (\Throwable) {
+            // Post entity type may not exist yet
+            return [];
+        }
+
+        $ids = $storage->getQuery()
+            ->condition('status', 1)
+            ->sort('created_at', 'DESC')
+            ->range(0, $limit)
+            ->execute();
+
+        return $ids !== [] ? array_values($storage->loadMultiple($ids)) : [];
+    }
+
     public function loadAllCommunities(): array
     {
         $storage = $this->entityTypeManager->getStorage('community');

--- a/src/Feed/FeedAssembler.php
+++ b/src/Feed/FeedAssembler.php
@@ -11,6 +11,7 @@ final class FeedAssembler implements FeedAssemblerInterface
     public function __construct(
         private readonly EntityLoaderService $loader,
         private readonly FeedItemFactory $factory,
+        private readonly ?EngagementCounter $engagementCounter = null,
     ) {}
 
     public function assemble(FeedContext $ctx): FeedResponse
@@ -20,11 +21,15 @@ final class FeedAssembler implements FeedAssemblerInterface
         $groups = $this->loader->loadGroups($ctx->limit * 2);
         $businesses = $this->loader->loadBusinesses($ctx->limit * 2);
         $people = $this->loader->loadPublicPeople($ctx->limit * 2);
+        $posts = $this->loader->loadPosts($ctx->limit * 2);
         $featuredRaw = $this->loader->loadFeaturedItems();
         $communities = $this->loader->loadAllCommunities();
 
         // Build community coordinate map for distance calculation
         $communityCoords = $this->buildCommunityCoords($communities);
+
+        // Build community name/slug map for factory lookups
+        $this->factory->setCommunityMap($this->buildCommunityMap($communities));
 
         // 2. Transform — assign typeSlots cyclically for round-robin
         $items = [];
@@ -43,6 +48,7 @@ final class FeedAssembler implements FeedAssemblerInterface
             ['type' => 'group', 'entities' => $groups, 'communityField' => 'community_id'],
             ['type' => 'business', 'entities' => $businesses, 'communityField' => 'community_id'],
             ['type' => 'person', 'entities' => $people, 'communityField' => 'community'],
+            ['type' => 'post', 'entities' => $posts, 'communityField' => 'community_id'],
         ];
 
         foreach ($sources as $sourceIdx => $source) {
@@ -103,6 +109,11 @@ final class FeedAssembler implements FeedAssemblerInterface
         }
 
         $pageItems = array_slice($items, $startIdx, $ctx->limit);
+
+        // 6b. Attach engagement counts only to the page (not all items)
+        if ($this->engagementCounter !== null) {
+            $pageItems = $this->attachEngagementCounts($pageItems);
+        }
 
         $nextCursor = null;
         if ($pageItems !== [] && ($startIdx + $ctx->limit) < count($items)) {
@@ -168,5 +179,63 @@ final class FeedAssembler implements FeedAssemblerInterface
         });
 
         return $communities;
+    }
+
+    /** @return array<int, array{slug: string, name: string}> */
+    private function buildCommunityMap(array $communities): array
+    {
+        $map = [];
+        foreach ($communities as $c) {
+            $id = (int) $c->id();
+            $map[$id] = [
+                'slug' => (string) ($c->get('slug') ?? ''),
+                'name' => (string) ($c->get('name') ?? ''),
+            ];
+        }
+        return $map;
+    }
+
+    /**
+     * Attach reaction and comment counts to feed items via EngagementCounter.
+     * Since FeedItem is readonly, we reconstruct items with engagement data.
+     *
+     * @param list<FeedItem> $items
+     * @return list<FeedItem>
+     */
+    private function attachEngagementCounts(array $items): array
+    {
+        $ids = array_map(fn(FeedItem $item) => $item->id, $items);
+        $counts = $this->engagementCounter->getCounts($ids);
+
+        return array_map(function (FeedItem $item) use ($counts) {
+            $itemCounts = $counts[$item->id] ?? null;
+            if ($itemCounts === null) {
+                return $item;
+            }
+
+            return new FeedItem(
+                id: $item->id,
+                type: $item->type,
+                title: $item->title,
+                url: $item->url,
+                badge: $item->badge,
+                weight: $item->weight,
+                createdAt: $item->createdAt,
+                sortKey: $item->sortKey,
+                entity: $item->entity,
+                subtitle: $item->subtitle,
+                date: $item->date,
+                distance: $item->distance,
+                communityName: $item->communityName,
+                meta: $item->meta,
+                payload: $item->payload,
+                reactionCount: $itemCounts['reactions'] ?? 0,
+                commentCount: $itemCounts['comments'] ?? 0,
+                userReaction: $item->userReaction,
+                relativeTime: $item->relativeTime,
+                communitySlug: $item->communitySlug,
+                communityInitial: $item->communityInitial,
+            );
+        }, $items);
     }
 }

--- a/src/Feed/FeedItem.php
+++ b/src/Feed/FeedItem.php
@@ -27,6 +27,12 @@ final readonly class FeedItem
         public ?string $communityName = null,
         public ?string $meta = null,
         public array $payload = [],
+        public int $reactionCount = 0,
+        public int $commentCount = 0,
+        public ?string $userReaction = null,
+        public ?string $relativeTime = null,
+        public ?string $communitySlug = null,
+        public ?string $communityInitial = null,
     ) {}
 
     public function isSynthetic(): bool
@@ -66,6 +72,24 @@ final readonly class FeedItem
         }
         if ($this->payload !== []) {
             $data['payload'] = $this->payload;
+        }
+        if ($this->reactionCount > 0) {
+            $data['reactionCount'] = $this->reactionCount;
+        }
+        if ($this->commentCount > 0) {
+            $data['commentCount'] = $this->commentCount;
+        }
+        if ($this->userReaction !== null) {
+            $data['userReaction'] = $this->userReaction;
+        }
+        if ($this->relativeTime !== null) {
+            $data['relativeTime'] = $this->relativeTime;
+        }
+        if ($this->communitySlug !== null) {
+            $data['communitySlug'] = $this->communitySlug;
+        }
+        if ($this->communityInitial !== null) {
+            $data['communityInitial'] = $this->communityInitial;
         }
 
         return $data;

--- a/src/Feed/FeedItemFactory.php
+++ b/src/Feed/FeedItemFactory.php
@@ -11,6 +11,19 @@ final class FeedItemFactory
 {
     private const int MAX_META_LENGTH = 60;
 
+    /** @var array<int|string, array{slug: string, name: string}> */
+    private array $communityCache = [];
+
+    /**
+     * Inject community lookup data for slug/initial resolution.
+     *
+     * @param array<int|string, array{slug: string, name: string}> $communities keyed by community ID
+     */
+    public function setCommunityMap(array $communities): void
+    {
+        $this->communityCache = $communities;
+    }
+
     public function fromEntity(
         string $type,
         ContentEntityBase $entity,
@@ -32,6 +45,7 @@ final class FeedItemFactory
             'business' => $this->buildBusiness($entity, $typeSlot, $distance, $createdAt),
             'person' => $this->buildPerson($entity, $typeSlot, $distance, $createdAt),
             'featured' => $this->buildFeatured($entity, $typeSlot, $distance, $createdAt),
+            'post' => $this->buildPost($entity, $typeSlot, $distance, $createdAt),
             default => throw new \InvalidArgumentException("Unknown feed item type: {$type}"),
         };
     }
@@ -89,6 +103,7 @@ final class FeedItemFactory
     {
         $id = 'event:' . $entity->id();
         $startsAt = $entity->get('starts_at');
+        $communityId = $entity->get('community_id');
 
         return new FeedItem(
             id: $id,
@@ -104,12 +119,16 @@ final class FeedItemFactory
             date: $startsAt,
             distance: $distance,
             meta: $entity->get('location'),
+            relativeTime: $this->formatRelativeTime($createdAt),
+            communitySlug: $this->resolveCommunitySlug($communityId),
+            communityInitial: $this->resolveCommunityInitial($communityId),
         );
     }
 
     private function buildGroup(ContentEntityBase $entity, int $typeSlot, ?float $distance, \DateTimeImmutable $createdAt): FeedItem
     {
         $id = 'group:' . $entity->id();
+        $communityId = $entity->get('community_id');
 
         return new FeedItem(
             id: $id,
@@ -123,12 +142,16 @@ final class FeedItemFactory
             entity: $entity,
             distance: $distance,
             meta: $this->truncate($entity->get('description')),
+            relativeTime: $this->formatRelativeTime($createdAt),
+            communitySlug: $this->resolveCommunitySlug($communityId),
+            communityInitial: $this->resolveCommunityInitial($communityId),
         );
     }
 
     private function buildBusiness(ContentEntityBase $entity, int $typeSlot, ?float $distance, \DateTimeImmutable $createdAt): FeedItem
     {
         $id = 'business:' . $entity->id();
+        $communityId = $entity->get('community_id');
 
         return new FeedItem(
             id: $id,
@@ -142,12 +165,16 @@ final class FeedItemFactory
             entity: $entity,
             distance: $distance,
             meta: $this->truncate($entity->get('description')),
+            relativeTime: $this->formatRelativeTime($createdAt),
+            communitySlug: $this->resolveCommunitySlug($communityId),
+            communityInitial: $this->resolveCommunityInitial($communityId),
         );
     }
 
     private function buildPerson(ContentEntityBase $entity, int $typeSlot, ?float $distance, \DateTimeImmutable $createdAt): FeedItem
     {
         $id = 'person:' . $entity->id();
+        $communityId = $entity->get('community_id');
 
         return new FeedItem(
             id: $id,
@@ -162,6 +189,9 @@ final class FeedItemFactory
             distance: $distance,
             communityName: $entity->get('community'),
             meta: $entity->get('role'),
+            relativeTime: $this->formatRelativeTime($createdAt),
+            communitySlug: $this->resolveCommunitySlug($communityId),
+            communityInitial: $this->resolveCommunityInitial($communityId),
         );
     }
 
@@ -181,6 +211,7 @@ final class FeedItemFactory
             entity: $entity,
             subtitle: $entity->get('subheadline'),
             distance: $distance,
+            relativeTime: $this->formatRelativeTime($createdAt),
         );
     }
 
@@ -205,5 +236,79 @@ final class FeedItemFactory
         }
 
         return mb_substr($text, 0, self::MAX_META_LENGTH) . '…';
+    }
+
+    /**
+     * Format a timestamp as a human-readable relative time string.
+     * Falls back to simple calculation if RelativeTime class is not yet available.
+     */
+    public function formatRelativeTime(\DateTimeImmutable $createdAt): string
+    {
+        if (class_exists(RelativeTime::class)) {
+            return RelativeTime::format($createdAt);
+        }
+
+        $diff = (new \DateTimeImmutable())->getTimestamp() - $createdAt->getTimestamp();
+
+        return match (true) {
+            $diff < 60 => 'just now',
+            $diff < 3600 => (int) ($diff / 60) . 'm ago',
+            $diff < 86400 => (int) ($diff / 3600) . 'h ago',
+            $diff < 604800 => (int) ($diff / 86400) . 'd ago',
+            default => $createdAt->format('M j'),
+        };
+    }
+
+    /**
+     * Resolve community slug from community ID using the cached map.
+     */
+    public function resolveCommunitySlug(mixed $communityId): ?string
+    {
+        if ($communityId === null) {
+            return null;
+        }
+
+        return $this->communityCache[(int) $communityId]['slug'] ?? null;
+    }
+
+    /**
+     * Resolve first letter of community name, uppercased, for avatar display.
+     */
+    public function resolveCommunityInitial(mixed $communityId): ?string
+    {
+        if ($communityId === null) {
+            return null;
+        }
+
+        $name = $this->communityCache[(int) $communityId]['name'] ?? null;
+        if ($name === null || $name === '') {
+            return null;
+        }
+
+        return mb_strtoupper(mb_substr($name, 0, 1));
+    }
+
+    private function buildPost(ContentEntityBase $entity, int $typeSlot, ?float $distance, \DateTimeImmutable $createdAt): FeedItem
+    {
+        $id = 'post:' . $entity->id();
+        $communityId = $entity->get('community_id');
+
+        return new FeedItem(
+            id: $id,
+            type: 'post',
+            title: (string) ($entity->get('title') ?? ''),
+            url: '/posts/' . $entity->get('slug'),
+            badge: 'Post',
+            weight: 0,
+            createdAt: $createdAt,
+            sortKey: $this->buildSortKey(0, $distance, $typeSlot, $createdAt, $id),
+            entity: $entity,
+            distance: $distance,
+            meta: $this->truncate($entity->get('body')),
+            relativeTime: $this->formatRelativeTime($createdAt),
+            communitySlug: $this->resolveCommunitySlug($communityId),
+            communityInitial: $this->resolveCommunityInitial($communityId),
+            communityName: $entity->get('community_name'),
+        );
     }
 }

--- a/tests/Minoo/Unit/Feed/FeedAssemblerTest.php
+++ b/tests/Minoo/Unit/Feed/FeedAssemblerTest.php
@@ -34,6 +34,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 
@@ -58,6 +59,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([$group]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([$person]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 
@@ -83,6 +85,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([$group]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 
@@ -106,6 +109,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 
@@ -134,6 +138,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 
@@ -165,6 +170,7 @@ final class FeedAssemblerTest extends TestCase
         $this->loader->method('loadGroups')->willReturn([$group]);
         $this->loader->method('loadBusinesses')->willReturn([]);
         $this->loader->method('loadPublicPeople')->willReturn([$person]);
+        $this->loader->method('loadPosts')->willReturn([]);
         $this->loader->method('loadFeaturedItems')->willReturn([]);
         $this->loader->method('loadAllCommunities')->willReturn([]);
 


### PR DESCRIPTION
## Summary
- Add `reactionCount`, `commentCount`, `userReaction`, `relativeTime`, `communitySlug`, `communityInitial` fields to `FeedItem` readonly constructor with defaults
- Wire `post` entity type into `FeedAssembler` sources alongside events, groups, businesses, people
- Add optional `EngagementCounter` interface dependency to `FeedAssembler` — attaches reaction/comment counts to paginated items only
- Add community map resolution helpers (`resolveCommunitySlug`, `resolveCommunityInitial`, `formatRelativeTime`) to `FeedItemFactory`
- Add `loadPosts()` to `EntityLoaderService` with graceful fallback if post entity type doesn't exist yet

## Test plan
- [x] All 534 existing tests pass (3 pre-existing skips)
- [x] New FeedItem fields have defaults — no breaking changes to existing test assertions
- [x] FeedAssemblerTest updated with `loadPosts` mock stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)