### PR TITLE
feat: FeedController sidebar data and CSRF token

### DIFF
--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -6,22 +6,34 @@ namespace Minoo\Controller;
 
 use Minoo\Feed\FeedAssemblerInterface;
 use Minoo\Feed\FeedContext;
+use Minoo\Feed\FeedResponse;
+use Minoo\Support\GeoDistance;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\SsrResponse;
+use Waaseyaa\User\User;
 
 final class FeedController
 {
     public function __construct(
         private readonly FeedAssemblerInterface $assembler,
         private readonly Environment $twig,
+        private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
     public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $ctx = $this->buildContext($request, $query);
+        $ctx = $this->buildContext($request, $query, $account);
         $response = $this->assembler->assemble($ctx);
+
+        $trending = $this->buildTrending($response);
+        $upcomingEvents = $this->buildUpcomingEvents();
+        $suggestedCommunities = $this->buildSuggestedCommunities($ctx->latitude, $ctx->longitude);
+        $followedCommunities = $this->buildFollowedCommunities($account);
+        $userCommunities = $this->buildUserCommunities($followedCommunities, $suggestedCommunities);
+        $accountInitial = $this->buildAccountInitial($account);
 
         $html = $this->twig->render('feed.html.twig', [
             'path' => '/',
@@ -29,6 +41,13 @@ final class FeedController
             'response' => $response,
             'nextCursor' => $response->nextCursor,
             'activeFilter' => $response->activeFilter,
+            'csrf_token' => $this->generateCsrfToken($request),
+            'trending' => $trending,
+            'upcoming_events' => $upcomingEvents,
+            'suggested_communities' => $suggestedCommunities,
+            'followed_communities' => $followedCommunities,
+            'user_communities' => $userCommunities,
+            'account_initial' => $accountInitial,
         ]);
 
         $headers = ['Content-Type' => 'text/html; charset=UTF-8'];
@@ -43,7 +62,7 @@ final class FeedController
 
     public function api(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $ctx = $this->buildContext($request, $query);
+        $ctx = $this->buildContext($request, $query, $account);
         $response = $this->assembler->assemble($ctx);
 
         $items = array_map(function ($item) {
@@ -86,7 +105,295 @@ final class FeedController
         return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $target]);
     }
 
-    private function buildContext(HttpRequest $request, array $query): FeedContext
+    /**
+     * HMAC-SHA256 derived from session ID for stability across page reloads.
+     * Falls back to a random token for anonymous/cookieless visitors.
+     */
+    private function generateCsrfToken(HttpRequest $request): string
+    {
+        $sessionId = $request->cookies->get('PHPSESSID', '');
+
+        if ($sessionId === '') {
+            return bin2hex(random_bytes(32));
+        }
+
+        $secret = getenv('APP_SECRET') ?: 'minoo-csrf-fallback-key';
+
+        return hash_hmac('sha256', $sessionId, $secret);
+    }
+
+    /**
+     * Top 5 trending items by reaction count (last 7 days).
+     *
+     * Falls back to the 5 newest feed items when no reactions exist.
+     *
+     * @return list<array{type: string, badge: string, title: string, url: string}>
+     */
+    private function buildTrending(FeedResponse $response): array
+    {
+        $trending = [];
+
+        if ($this->entityTypeManager->hasDefinition('reaction')) {
+            try {
+                $storage = $this->entityTypeManager->getStorage('reaction');
+                $sevenDaysAgo = (new \DateTimeImmutable('-7 days'))->format('Y-m-d H:i:s');
+                $ids = $storage->getQuery()
+                    ->condition('created_at', $sevenDaysAgo, '>=')
+                    ->execute();
+
+                if ($ids !== []) {
+                    $reactions = array_values($storage->loadMultiple($ids));
+                    $counts = [];
+                    foreach ($reactions as $reaction) {
+                        $key = $reaction->get('target_type') . ':' . $reaction->get('target_id');
+                        $counts[$key] = ($counts[$key] ?? 0) + 1;
+                    }
+                    arsort($counts);
+
+                    $top = array_slice(array_keys($counts), 0, 5);
+                    foreach ($top as $compositeKey) {
+                        [$type, $id] = explode(':', $compositeKey, 2);
+                        if ($this->entityTypeManager->hasDefinition($type)) {
+                            try {
+                                $entity = $this->entityTypeManager->getStorage($type)->load($id);
+                                if ($entity !== null) {
+                                    $trending[] = [
+                                        'type' => $type,
+                                        'badge' => ucfirst($type),
+                                        'title' => $entity->label(),
+                                        'url' => '/' . $type . 's/' . ($entity->get('slug') ?? $entity->id()),
+                                    ];
+                                }
+                            } catch (\Throwable) {
+                                // Entity missing — skip
+                            }
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                // Reaction storage unavailable — fall through to fallback
+            }
+        }
+
+        if ($trending === []) {
+            foreach (array_slice($response->items, 0, 5) as $item) {
+                $trending[] = [
+                    'type' => $item->type,
+                    'badge' => $item->badge,
+                    'title' => $item->title,
+                    'url' => $item->url,
+                ];
+            }
+        }
+
+        return $trending;
+    }
+
+    /**
+     * Next 3 upcoming events (starts_at > now).
+     *
+     * @return list<array{title: string, date: string, url: string}>
+     */
+    private function buildUpcomingEvents(): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('event')) {
+            return [];
+        }
+
+        try {
+            $storage = $this->entityTypeManager->getStorage('event');
+            $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+            $ids = $storage->getQuery()
+                ->condition('status', 1)
+                ->condition('starts_at', $now, '>')
+                ->sort('starts_at', 'ASC')
+                ->range(0, 3)
+                ->execute();
+
+            if ($ids === []) {
+                return [];
+            }
+
+            $events = array_values($storage->loadMultiple($ids));
+            $result = [];
+
+            foreach ($events as $event) {
+                $result[] = [
+                    'title' => $event->label(),
+                    'date' => (string) ($event->get('starts_at') ?? ''),
+                    'url' => '/events/' . ($event->get('slug') ?? $event->id()),
+                ];
+            }
+
+            return $result;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Up to 6 communities near the user's location.
+     *
+     * @return list<array{name: string, slug: string, distance: float}>
+     */
+    private function buildSuggestedCommunities(?float $lat, ?float $lon): array
+    {
+        if ($lat === null || $lon === null) {
+            return [];
+        }
+
+        if (!$this->entityTypeManager->hasDefinition('community')) {
+            return [];
+        }
+
+        try {
+            $storage = $this->entityTypeManager->getStorage('community');
+            $ids = $storage->getQuery()
+                ->condition('status', 1)
+                ->execute();
+
+            if ($ids === []) {
+                return [];
+            }
+
+            $communities = array_values($storage->loadMultiple($ids));
+            $withDistance = [];
+
+            foreach ($communities as $community) {
+                $cLat = $community->get('latitude');
+                $cLon = $community->get('longitude');
+
+                if ($cLat === null || $cLon === null) {
+                    continue;
+                }
+
+                $distance = GeoDistance::haversine($lat, $lon, (float) $cLat, (float) $cLon);
+                $withDistance[] = [
+                    'name' => $community->get('name') ?? $community->label(),
+                    'slug' => (string) ($community->get('slug') ?? ''),
+                    'distance' => round($distance, 1),
+                ];
+            }
+
+            usort($withDistance, fn(array $a, array $b): int => $a['distance'] <=> $b['distance']);
+
+            return array_slice($withDistance, 0, 6);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Communities the authenticated user follows.
+     *
+     * @return list<array{name: string, slug: string}>
+     */
+    private function buildFollowedCommunities(AccountInterface $account): array
+    {
+        if (!$account->isAuthenticated()) {
+            return [];
+        }
+
+        if (!$this->entityTypeManager->hasDefinition('follow')) {
+            return [];
+        }
+
+        try {
+            $followStorage = $this->entityTypeManager->getStorage('follow');
+            $ids = $followStorage->getQuery()
+                ->condition('user_id', $account->id())
+                ->condition('target_type', 'community')
+                ->execute();
+
+            if ($ids === []) {
+                return [];
+            }
+
+            $follows = array_values($followStorage->loadMultiple($ids));
+            $communityIds = array_map(fn($f) => $f->get('target_id'), $follows);
+            $communityIds = array_filter($communityIds);
+
+            if ($communityIds === []) {
+                return [];
+            }
+
+            $communityStorage = $this->entityTypeManager->getStorage('community');
+            $communities = $communityStorage->loadMultiple($communityIds);
+            $result = [];
+
+            foreach ($communities as $community) {
+                $result[] = [
+                    'name' => $community->get('name') ?? $community->label(),
+                    'slug' => (string) ($community->get('slug') ?? ''),
+                ];
+            }
+
+            return $result;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Communities for the create-post selector.
+     *
+     * Uses followed communities if available, otherwise falls back to nearby communities.
+     *
+     * @param list<array{name: string, slug: string}> $followed
+     * @param list<array{name: string, slug: string, distance: float}> $suggested
+     * @return list<array{id: string, name: string, is_default: bool}>
+     */
+    private function buildUserCommunities(array $followed, array $suggested): array
+    {
+        $source = $followed !== [] ? $followed : $suggested;
+
+        if ($source === []) {
+            return [];
+        }
+
+        $result = [];
+        $first = true;
+
+        foreach ($source as $community) {
+            $result[] = [
+                'id' => $community['slug'],
+                'name' => $community['name'],
+                'is_default' => $first,
+            ];
+            $first = false;
+        }
+
+        return $result;
+    }
+
+    /**
+     * First letter of the authenticated user's display name, uppercased.
+     */
+    private function buildAccountInitial(AccountInterface $account): string
+    {
+        if (!$account->isAuthenticated()) {
+            return '';
+        }
+
+        // User entity has getName(); generic AccountInterface does not.
+        if ($account instanceof User) {
+            $name = $account->getName();
+            if ($name !== '') {
+                return mb_strtoupper(mb_substr($name, 0, 1));
+            }
+        }
+
+        if (method_exists($account, 'label')) {
+            $label = (string) $account->label();
+            if ($label !== '') {
+                return mb_strtoupper(mb_substr($label, 0, 1));
+            }
+        }
+
+        return '?';
+    }
+
+    private function buildContext(HttpRequest $request, array $query, ?AccountInterface $account = null): FeedContext
     {
         $locationCookie = $request->cookies->get('minoo_loc');
         $lat = null;
@@ -111,7 +418,7 @@ final class FeedController
             cursor: $query['cursor'] ?? null,
             limit: min((int) ($query['limit'] ?? 20), 50),
             isFirstVisit: $isFirstVisit,
-            isAuthenticated: false,
+            isAuthenticated: $account?->isAuthenticated() ?? false,
         );
     }
 }

--- a/tests/Minoo/Unit/Controller/FeedControllerTest.php
+++ b/tests/Minoo/Unit/Controller/FeedControllerTest.php
@@ -14,15 +14,25 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
 
 #[CoversClass(FeedController::class)]
 final class FeedControllerTest extends TestCase
 {
+    private function createEntityTypeManager(): EntityTypeManager
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(false);
+
+        return $etm;
+    }
+
     #[Test]
     public function index_renders_feed_template(): void
     {
         $twig = $this->createMock(Environment::class);
         $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $etm = $this->createEntityTypeManager();
 
         $assembler->method('assemble')->willReturn(
             new FeedResponse([], null, 'all')
@@ -32,7 +42,7 @@ final class FeedControllerTest extends TestCase
             ->with('feed.html.twig', $this->anything())
             ->willReturn('<html>feed</html>');
 
-        $controller = new FeedController($assembler, $twig);
+        $controller = new FeedController($assembler, $twig, $etm);
         $account = $this->createMock(AccountInterface::class);
         $request = HttpRequest::create('/');
 
@@ -42,10 +52,67 @@ final class FeedControllerTest extends TestCase
     }
 
     #[Test]
+    public function index_passes_sidebar_data_to_template(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $etm = $this->createEntityTypeManager();
+
+        $item = new FeedItem(
+            id: 'event:1', type: 'event', title: 'Pow Wow',
+            url: '/events/pow-wow', badge: 'Event', weight: 0,
+            createdAt: new \DateTimeImmutable(), sortKey: 'key',
+        );
+
+        $assembler->method('assemble')->willReturn(
+            new FeedResponse([$item], null, 'all')
+        );
+
+        $capturedContext = null;
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('feed.html.twig', $this->callback(function (array $ctx) use (&$capturedContext): bool {
+                $capturedContext = $ctx;
+
+                return true;
+            }))
+            ->willReturn('<html>feed</html>');
+
+        $controller = new FeedController($assembler, $twig, $etm);
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(false);
+        $request = HttpRequest::create('/');
+
+        $controller->index([], [], $account, $request);
+
+        $this->assertArrayHasKey('csrf_token', $capturedContext);
+        $this->assertNotEmpty($capturedContext['csrf_token']);
+        $this->assertArrayHasKey('trending', $capturedContext);
+        $this->assertArrayHasKey('upcoming_events', $capturedContext);
+        $this->assertArrayHasKey('suggested_communities', $capturedContext);
+        $this->assertArrayHasKey('followed_communities', $capturedContext);
+        $this->assertArrayHasKey('user_communities', $capturedContext);
+        $this->assertArrayHasKey('account_initial', $capturedContext);
+
+        // Trending falls back to feed items when no reaction entity type exists
+        $this->assertCount(1, $capturedContext['trending']);
+        $this->assertSame('Pow Wow', $capturedContext['trending'][0]['title']);
+
+        // No location cookie — suggested communities empty
+        $this->assertSame([], $capturedContext['suggested_communities']);
+
+        // Anonymous user — followed/user communities empty, initial empty
+        $this->assertSame([], $capturedContext['followed_communities']);
+        $this->assertSame([], $capturedContext['user_communities']);
+        $this->assertSame('', $capturedContext['account_initial']);
+    }
+
+    #[Test]
     public function api_returns_json(): void
     {
         $twig = $this->createMock(Environment::class);
         $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $etm = $this->createEntityTypeManager();
 
         $item = new FeedItem(
             id: 'event:1', type: 'event', title: 'Test',
@@ -60,7 +127,7 @@ final class FeedControllerTest extends TestCase
         // API needs Twig to render card HTML fragments
         $twig->method('render')->willReturn('<article>card</article>');
 
-        $controller = new FeedController($assembler, $twig);
+        $controller = new FeedController($assembler, $twig, $etm);
         $account = $this->createMock(AccountInterface::class);
         $request = HttpRequest::create('/api/feed?filter=all');
 
@@ -79,8 +146,9 @@ final class FeedControllerTest extends TestCase
     {
         $twig = $this->createMock(Environment::class);
         $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $etm = $this->createEntityTypeManager();
 
-        $controller = new FeedController($assembler, $twig);
+        $controller = new FeedController($assembler, $twig, $etm);
         $account = $this->createMock(AccountInterface::class);
         $request = HttpRequest::create('/explore?type=events&q=pow+wow');
 


### PR DESCRIPTION
## Summary
- Add `EntityTypeManager` dependency to `FeedController` for sidebar data queries
- Pass 7 new template variables: `csrf_token`, `trending`, `upcoming_events`, `suggested_communities`, `followed_communities`, `user_communities`, `account_initial`
- Trending uses reaction-based ranking with fallback to newest feed items when reaction entity type doesn't exist yet
- All entity queries guarded with `hasDefinition()` + `try/catch` for graceful degradation

## Test plan
- [x] All 534 existing tests pass (3 skipped, unchanged)
- [x] New test `index_passes_sidebar_data_to_template` validates all sidebar variables are present in template context
- [x] PHP syntax validation passes
- [ ] Verify template renders correctly with new variables (requires template updates from another worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)