### PR TITLE
feat: restructure feed templates with three-column layout + engagement JS

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -14,6 +14,9 @@
   <meta property="og:type" content="{% block og_type %}website{% endblock %}">
   <meta property="og:site_name" content="Minoo">
   <meta name="twitter:card" content="summary_large_image">
+  {% if csrf_token is defined %}
+    <meta name="csrf-token" content="{{ csrf_token }}">
+  {% endif %}
   <link rel="stylesheet" href="/css/minoo.css?v=9">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}

--- a/templates/components/feed-card.html.twig
+++ b/templates/components/feed-card.html.twig
@@ -1,4 +1,4 @@
-{# Unified feed card component — all types render through this template #}
+{# Unified feed card — community-attributed hybrid design #}
 {% if item.type == 'welcome' %}
   <article class="feed-card feed-card--welcome" data-id="{{ item.id }}">
     <h3 class="feed-card__title">{{ item.title }}</h3>
@@ -7,6 +7,12 @@
   </article>
 {% elseif item.type == 'communities' %}
   <article class="feed-card feed-card--communities" data-id="{{ item.id }}">
+    <div class="feed-card__attribution">
+      <div class="feed-card__avatar feed-card__avatar--communities">🏘</div>
+      <div class="feed-card__attribution-text">
+        <span class="feed-card__source">{{ trans('feed.communities_near_you') }}</span>
+      </div>
+    </div>
     <h3 class="feed-card__title">{{ item.title }}</h3>
     <div class="feed-pills">
       {% for community in item.payload.communities|default([]) %}
@@ -14,21 +20,40 @@
       {% endfor %}
     </div>
   </article>
-{% elseif item.type == 'featured' %}
-  <article class="feed-card feed-card--featured" data-id="{{ item.id }}">
-    <span class="feed-badge feed-badge--featured">{{ item.badge }}</span>
-    <h3 class="feed-card__title"><a href="{{ lang_url(item.url) }}">{{ item.title }}</a></h3>
-    {% if item.subtitle %}<p class="feed-card__subtitle">{{ item.subtitle }}</p>{% endif %}
+{% elseif item.type == 'post' %}
+  <article class="feed-card feed-card--post" data-id="{{ item.id }}" data-entity-type="post">
+    <div class="feed-card__attribution">
+      <div class="feed-card__avatar">{{ item.communityInitial|default('?') }}</div>
+      <div class="feed-card__attribution-text">
+        <a href="{{ lang_url('/communities/' ~ item.communitySlug|default('')) }}" class="feed-card__source">{{ item.communityName|default('') }}</a>
+        <span class="feed-card__attribution-action">&middot; {{ item.relativeTime|default('') }}</span>
+      </div>
+    </div>
+    <p class="feed-card__body">{{ item.meta|default('') }}</p>
+    {% include "components/feed-engagement.html.twig" with { item: item } only %}
   </article>
 {% else %}
-  <article class="feed-card feed-card--{{ item.type }}" data-id="{{ item.id }}">
-    <div class="feed-card__header">
-      <span class="feed-badge feed-badge--{{ item.type }}">{{ item.badge }}</span>
-      {% if item.distance is not null %}<span class="feed-card__distance">{{ item.distance|round(1) }} km</span>{% endif %}
+  <article class="feed-card feed-card--{{ item.type }}" data-id="{{ item.id }}" data-entity-type="{{ item.type }}">
+    <div class="feed-card__attribution">
+      <div class="feed-card__avatar feed-card__avatar--{{ item.type }}">{{ item.communityInitial|default(item.badge|default('')|slice(0,1)) }}</div>
+      <div class="feed-card__attribution-text">
+        {% if item.communityName|default('') %}
+          <a href="{{ lang_url('/communities/' ~ item.communitySlug|default('')) }}" class="feed-card__source">{{ item.communityName }}</a>
+          <span class="feed-card__attribution-action">{{ trans('feed.posted_' ~ item.type) }} &middot; {{ item.relativeTime|default('') }}</span>
+        {% else %}
+          <span class="feed-card__source">Minoo</span>
+          <span class="feed-card__attribution-action">&middot; {{ item.badge|default('') }} &middot; {{ item.relativeTime|default('') }}</span>
+        {% endif %}
+      </div>
     </div>
     <h3 class="feed-card__title"><a href="{{ lang_url(item.url) }}">{{ item.title }}</a></h3>
-    {% if item.subtitle %}<p class="feed-card__subtitle">{{ item.subtitle }}</p>{% endif %}
-    {% if item.communityName %}<p class="feed-card__community">{{ item.communityName }}</p>{% endif %}
-    {% if item.meta %}<p class="feed-card__meta">{{ item.meta }}</p>{% endif %}
+    {% if item.subtitle|default('') %}<p class="feed-card__subtitle">{{ item.subtitle }}</p>{% endif %}
+    {% if item.meta|default('') %}
+      <div class="feed-card__detail-box">
+        {% if item.date|default('') %}<div class="feed-card__detail">📅 {{ item.date }}</div>{% endif %}
+        {% if item.communityName|default('') and item.type == 'event' %}<div class="feed-card__detail">📍 {{ item.meta }}</div>{% endif %}
+      </div>
+    {% endif %}
+    {% include "components/feed-engagement.html.twig" with { item: item } only %}
   </article>
 {% endif %}

--- a/templates/components/feed-create-post.html.twig
+++ b/templates/components/feed-create-post.html.twig
@@ -1,0 +1,24 @@
+<div class="feed-create">
+  {% if account is defined and account.isAuthenticated() and user_communities is defined and user_communities|length > 0 %}
+    <div class="feed-create__prompt" id="create-post-trigger">
+      <div class="feed-create__avatar">{{ account_initial }}</div>
+      <span class="feed-create__placeholder">{{ trans('feed.whats_happening') }}</span>
+    </div>
+    <form class="feed-create__form" id="create-post-form" hidden>
+      <textarea class="feed-create__textarea" name="body" placeholder="{{ trans('feed.whats_happening') }}" maxlength="5000" required></textarea>
+      <div class="feed-create__actions">
+        <select name="community_id" class="feed-create__community" required>
+          {% for community in user_communities|default([]) %}
+            <option value="{{ community.id }}"{% if community.is_default|default(false) %} selected{% endif %}>{{ community.name }}</option>
+          {% endfor %}
+        </select>
+        <button type="submit" class="btn btn--primary">{{ trans('feed.post') }}</button>
+      </div>
+    </form>
+  {% else %}
+    <div class="feed-create__guest">
+      <p>{{ trans('feed.join_conversation') }}</p>
+      <a href="{{ lang_url('/login') }}" class="btn btn--secondary">{{ trans('nav.login') }}</a>
+    </div>
+  {% endif %}
+</div>

--- a/templates/components/feed-sidebar-left.html.twig
+++ b/templates/components/feed-sidebar-left.html.twig
@@ -1,0 +1,34 @@
+<aside class="feed-sidebar feed-sidebar--left">
+  <nav class="sidebar-nav" aria-label="{{ trans('feed.sidebar_nav_label') }}">
+    <a href="{{ lang_url('/events') }}" class="sidebar-nav__item sidebar-nav__item--events">
+      <span class="sidebar-nav__icon">🎪</span> {{ trans('nav.events') }}
+    </a>
+    <a href="{{ lang_url('/communities') }}" class="sidebar-nav__item sidebar-nav__item--communities">
+      <span class="sidebar-nav__icon">🏘</span> {{ trans('nav.communities') }}
+    </a>
+    <a href="{{ lang_url('/teachings') }}" class="sidebar-nav__item sidebar-nav__item--teachings">
+      <span class="sidebar-nav__icon">📖</span> {{ trans('nav.teachings') }}
+    </a>
+    <a href="{{ lang_url('/people') }}" class="sidebar-nav__item sidebar-nav__item--people">
+      <span class="sidebar-nav__icon">👤</span> {{ trans('nav.people') }}
+    </a>
+    <a href="{{ lang_url('/businesses') }}" class="sidebar-nav__item sidebar-nav__item--businesses">
+      <span class="sidebar-nav__icon">🏪</span> {{ trans('nav.businesses') }}
+    </a>
+    <a href="{{ lang_url('/volunteer') }}" class="sidebar-nav__item sidebar-nav__item--volunteer">
+      <span class="sidebar-nav__icon">🤝</span> {{ trans('nav.volunteer') }}
+    </a>
+    <a href="{{ lang_url('/elders') }}" class="sidebar-nav__item sidebar-nav__item--elders">
+      <span class="sidebar-nav__icon">🪶</span> {{ trans('nav.elder_support') }}
+    </a>
+  </nav>
+
+  {% if followed_communities is defined and followed_communities|length > 0 %}
+    <div class="sidebar-widget">
+      <h4 class="sidebar-widget__title">{{ trans('feed.your_communities') }}</h4>
+      {% for community in followed_communities %}
+        <a href="{{ lang_url('/communities/' ~ community.slug) }}" class="sidebar-nav__item">{{ community.name }}</a>
+      {% endfor %}
+    </div>
+  {% endif %}
+</aside>

--- a/templates/components/feed-sidebar-right.html.twig
+++ b/templates/components/feed-sidebar-right.html.twig
@@ -1,0 +1,37 @@
+<aside class="feed-sidebar feed-sidebar--right">
+  {% if trending is defined and trending|length > 0 %}
+    <div class="sidebar-widget">
+      <h4 class="sidebar-widget__title">{{ trans('feed.trending') }}</h4>
+      {% for item in trending %}
+        <a href="{{ lang_url(item.url) }}" class="sidebar-widget__item">
+          <span class="feed-badge feed-badge--{{ item.type }}">{{ item.badge }}</span>
+          {{ item.title }}
+        </a>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if upcoming_events is defined and upcoming_events|length > 0 %}
+    <div class="sidebar-widget">
+      <h4 class="sidebar-widget__title">{{ trans('feed.upcoming_events') }}</h4>
+      {% for event in upcoming_events %}
+        <a href="{{ lang_url(event.url) }}" class="sidebar-widget__item">
+          <strong>{{ event.title }}</strong>
+          <span class="sidebar-widget__meta">{{ event.date }}</span>
+        </a>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if suggested_communities is defined and suggested_communities|length > 0 %}
+    <div class="sidebar-widget">
+      <h4 class="sidebar-widget__title">{{ trans('feed.suggested_communities') }}</h4>
+      {% for community in suggested_communities %}
+        <a href="{{ lang_url('/communities/' ~ community.slug) }}" class="sidebar-widget__item">
+          {{ community.name }}
+          {% if community.distance %}<span class="sidebar-widget__meta">{{ community.distance|round(1) }} km</span>{% endif %}
+        </a>
+      {% endfor %}
+    </div>
+  {% endif %}
+</aside>

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -3,40 +3,40 @@
 {% block title %}{{ trans('page.title') }} — Minoo{% endblock %}
 
 {% block content %}
-  {# === Compact Sticky Header === #}
-  <header class="feed-header">
-    <strong class="feed-header__logo">Minoo</strong>
-    <form class="feed-header__search" action="{{ lang_url('/explore') }}" method="get" role="search" aria-label="{{ trans('page.search_label') }}">
-      <label for="feed-q" class="visually-hidden">{{ trans('page.search_query') }}</label>
-      <input id="feed-q" name="q" type="search" class="feed-header__input" placeholder="{{ trans('page.search_placeholder') }}" />
-      <button type="submit" class="feed-header__submit">{{ trans('page.search_button') }}</button>
-    </form>
-  </header>
+  <div class="feed-layout">
+    {% include "components/feed-sidebar-left.html.twig" %}
 
-  {# === Filter Chips === #}
-  <nav class="feed-chips" aria-label="Filter feed">
-    <button class="feed-chip{{ activeFilter == 'all' ? ' feed-chip--active' : '' }}" data-type="all">{{ trans('page.search_all') }}</button>
-    <button class="feed-chip{{ activeFilter == 'event' ? ' feed-chip--active' : '' }}" data-type="event">{{ trans('page.tab_events') }}</button>
-    <button class="feed-chip{{ activeFilter == 'group' ? ' feed-chip--active' : '' }}" data-type="group">{{ trans('page.tab_groups') }}</button>
-    <button class="feed-chip{{ activeFilter == 'business' ? ' feed-chip--active' : '' }}" data-type="business">{{ trans('page.search_businesses') }}</button>
-    <button class="feed-chip{{ activeFilter == 'person' ? ' feed-chip--active' : '' }}" data-type="person">{{ trans('page.tab_people') }}</button>
-  </nav>
+    <div class="feed-main">
+      {% include "components/feed-create-post.html.twig" %}
 
-  {# === Feed Container === #}
-  <div class="feed-container" id="feed" data-next-cursor="{{ nextCursor }}" data-active-filter="{{ activeFilter }}">
-    {% for item in response.items %}
-      {% include "components/feed-card.html.twig" with { item: item } only %}
-    {% endfor %}
-  </div>
+      {# === Filter Chips === #}
+      <nav class="feed-chips" aria-label="Filter feed">
+        <button class="feed-chip{{ activeFilter == 'all' ? ' feed-chip--active' : '' }}" data-type="all">{{ trans('page.search_all') }}</button>
+        <button class="feed-chip{{ activeFilter == 'event' ? ' feed-chip--active' : '' }}" data-type="event">{{ trans('page.tab_events') }}</button>
+        <button class="feed-chip{{ activeFilter == 'group' ? ' feed-chip--active' : '' }}" data-type="group">{{ trans('page.tab_groups') }}</button>
+        <button class="feed-chip{{ activeFilter == 'business' ? ' feed-chip--active' : '' }}" data-type="business">{{ trans('page.search_businesses') }}</button>
+        <button class="feed-chip{{ activeFilter == 'person' ? ' feed-chip--active' : '' }}" data-type="person">{{ trans('page.tab_people') }}</button>
+      </nav>
 
-  {# === Loading Sentinel === #}
-  {% if nextCursor %}
-    <div class="feed-sentinel" id="feed-sentinel">
-      <div class="feed-card feed-card--loading" aria-hidden="true">
-        <div class="feed-card__skeleton"></div>
+      {# === Feed Container === #}
+      <div class="feed-container" id="feed" data-next-cursor="{{ nextCursor }}" data-active-filter="{{ activeFilter }}">
+        {% for item in response.items %}
+          {% include "components/feed-card.html.twig" with { item: item } only %}
+        {% endfor %}
       </div>
+
+      {# === Loading Sentinel === #}
+      {% if nextCursor %}
+        <div class="feed-sentinel" id="feed-sentinel">
+          <div class="feed-card feed-card--loading" aria-hidden="true">
+            <div class="feed-card__skeleton"></div>
+          </div>
+        </div>
+      {% endif %}
     </div>
-  {% endif %}
+
+    {% include "components/feed-sidebar-right.html.twig" %}
+  </div>
 
   {# === Infinite Scroll (Progressive Enhancement) === #}
   <script>
@@ -132,6 +132,142 @@
           .catch(e => { if (e.name !== 'AbortError') console.error(e); });
       });
     });
+  })();
+  </script>
+{% endblock %}
+
+{% block scripts %}
+  {# === Engagement Interactions === #}
+  <script>
+  (function() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    const headers = { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken };
+
+    // Reaction toggling
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('[data-action="react"]');
+      if (!btn) return;
+      const type = btn.dataset.type;
+      const id = btn.dataset.id;
+      const isActive = btn.classList.contains('feed-action--active');
+
+      try {
+        if (isActive) {
+          await fetch(`/api/react/${type}/${id}`, { method: 'DELETE', headers });
+          btn.classList.remove('feed-action--active');
+        } else {
+          const reactionType = getReactionType(type);
+          await fetch('/api/react', {
+            method: 'POST', headers,
+            body: JSON.stringify({ target_type: type, target_id: id, reaction_type: reactionType })
+          });
+          btn.classList.add('feed-action--active');
+        }
+      } catch (err) { console.error('Reaction error:', err); }
+    });
+
+    // Comment expansion
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('[data-action="comment"]');
+      if (!btn) return;
+      const card = btn.closest('.feed-card');
+      const section = card.querySelector('.feed-card__comments');
+      if (section.hidden) {
+        section.hidden = false;
+        if (!section.dataset.loaded) {
+          const type = btn.dataset.type;
+          const id = btn.dataset.id;
+          const res = await fetch(`/api/comments/${type}/${id}`);
+          const data = await res.json();
+          section.innerHTML = renderComments(data.comments, type, id);
+          section.dataset.loaded = '1';
+        }
+      } else {
+        section.hidden = true;
+      }
+    });
+
+    // Share
+    document.addEventListener('click', function(e) {
+      const btn = e.target.closest('[data-action="share"]');
+      if (!btn) return;
+      const url = window.location.origin + btn.dataset.url;
+      if (navigator.share) {
+        navigator.share({ url, title: btn.dataset.title });
+      } else {
+        navigator.clipboard.writeText(url).then(() => {
+          btn.querySelector('.feed-action__label').textContent = 'Copied!';
+          setTimeout(() => { btn.querySelector('.feed-action__label').textContent = 'Share'; }, 2000);
+        });
+      }
+    });
+
+    // Create post
+    const trigger = document.getElementById('create-post-trigger');
+    const postForm = document.getElementById('create-post-form');
+    if (trigger && postForm) {
+      trigger.addEventListener('click', () => { postForm.hidden = false; trigger.hidden = true; });
+      postForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const body = postForm.querySelector('textarea').value.trim();
+        const communityId = postForm.querySelector('select').value;
+        if (!body) return;
+        try {
+          const res = await fetch('/api/post', {
+            method: 'POST', headers,
+            body: JSON.stringify({ body, community_id: communityId })
+          });
+          if (res.ok) location.reload();
+        } catch (err) { console.error('Post error:', err); }
+      });
+    }
+
+    function getReactionType(entityType) {
+      const map = { event: 'interested', teaching: 'miigwech', business: 'recommend', post: 'miigwech' };
+      return map[entityType] || 'interested';
+    }
+
+    function renderComments(comments, type, id) {
+      let html = '<div class="feed-comments__list">';
+      comments.forEach(c => {
+        html += `<div class="feed-comment"><strong>User</strong> <span class="feed-comment__time">${c.relative_time}</span><p>${escapeHtml(c.body)}</p></div>`;
+      });
+      html += '</div>';
+      html += `<form class="feed-comments__form" data-type="${type}" data-id="${id}">
+        <input type="text" placeholder="Write a comment..." maxlength="2000" required>
+        <button type="submit">Post</button>
+      </form>`;
+      return html;
+    }
+
+    // Comment submission
+    document.addEventListener('submit', async function(e) {
+      const form = e.target.closest('.feed-comments__form');
+      if (!form) return;
+      e.preventDefault();
+      const input = form.querySelector('input');
+      const body = input.value.trim();
+      if (!body) return;
+      try {
+        const res = await fetch('/api/comment', {
+          method: 'POST', headers,
+          body: JSON.stringify({ target_type: form.dataset.type, target_id: form.dataset.id, body })
+        });
+        if (res.ok) {
+          const list = form.previousElementSibling;
+          list.insertAdjacentHTML('beforeend',
+            `<div class="feed-comment"><strong>You</strong> <span class="feed-comment__time">just now</span><p>${escapeHtml(body)}</p></div>`
+          );
+          input.value = '';
+        }
+      } catch (err) { console.error('Comment error:', err); }
+    });
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
   })();
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Restructured `feed.html.twig` with three-column grid layout
- Rewrote `feed-card.html.twig` with community-attributed card design
- Added CSRF meta tag to `base.html.twig`
- Added engagement JavaScript (reactions, comments, share, create post)
- Created sidebar and create-post template components

## Test plan
- [ ] Three-column layout renders at wide viewport
- [ ] Cards show attribution row with community name + relative time
- [ ] Engagement buttons visible on all card types
- [ ] JS interactions work (react, comment, share, create post)

Part of Social Feed v1 milestone.