### PR TITLE
fix(#407,#408,#409): engagement API security + JS fixes

### DIFF
--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -11,6 +11,12 @@ use Waaseyaa\SSR\SsrResponse;
 
 final class EngagementController
 {
+    /** @var list<string> Entity types that can be reaction/comment/follow targets */
+    private const ALLOWED_TARGET_TYPES = [
+        'event', 'group', 'teaching', 'community', 'post',
+        'oral_history', 'dictionary_entry', 'cultural_collection',
+    ];
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
@@ -23,9 +29,18 @@ final class EngagementController
             return $this->json(['error' => 'Missing required fields: emoji, target_type, target_id'], 422);
         }
 
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
+        $emoji = trim($data['emoji']);
+        if ($emoji === '' || mb_strlen($emoji) > 10) {
+            return $this->json(['error' => 'Invalid emoji'], 422);
+        }
+
         $storage = $this->entityTypeManager->getStorage('reaction');
         $entity = $storage->create([
-            'emoji' => $data['emoji'],
+            'emoji' => $emoji,
             'user_id' => $account->id(),
             'target_type' => $data['target_type'],
             'target_id' => (int) $data['target_id'],
@@ -61,6 +76,10 @@ final class EngagementController
 
         if (!isset($data['body'], $data['target_type'], $data['target_id'])) {
             return $this->json(['error' => 'Missing required fields: body, target_type, target_id'], 422);
+        }
+
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
         }
 
         $body = trim($data['body']);
@@ -108,6 +127,10 @@ final class EngagementController
     public function getComments(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
         $targetType = $params['target_type'] ?? '';
+        if (!$this->isValidTargetType($targetType)) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
         $targetId = (int) ($params['target_id'] ?? 0);
         $limit = min((int) ($query['limit'] ?? 20), 50);
         $offset = max((int) ($query['offset'] ?? 0), 0);
@@ -139,6 +162,10 @@ final class EngagementController
 
         if (!isset($data['target_type'], $data['target_id'])) {
             return $this->json(['error' => 'Missing required fields: target_type, target_id'], 422);
+        }
+
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('follow');
@@ -235,6 +262,11 @@ final class EngagementController
         } catch (\JsonException) {
             return [];
         }
+    }
+
+    private function isValidTargetType(string $type): bool
+    {
+        return in_array($type, self::ALLOWED_TARGET_TYPES, true);
     }
 
     /** @param array<string, mixed> $data */

--- a/src/Provider/EngagementServiceProvider.php
+++ b/src/Provider/EngagementServiceProvider.php
@@ -167,7 +167,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.react',
             RouteBuilder::create('/api/engagement/react')
                 ->controller('Minoo\\Controller\\EngagementController::react')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('POST')
                 ->build(),
         );
@@ -176,7 +176,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.deleteReaction',
             RouteBuilder::create('/api/engagement/react/{id}')
                 ->controller('Minoo\\Controller\\EngagementController::deleteReaction')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('DELETE')
                 ->requirement('id', '\\d+')
                 ->build(),
@@ -186,7 +186,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.comment',
             RouteBuilder::create('/api/engagement/comment')
                 ->controller('Minoo\\Controller\\EngagementController::comment')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('POST')
                 ->build(),
         );
@@ -195,7 +195,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.deleteComment',
             RouteBuilder::create('/api/engagement/comment/{id}')
                 ->controller('Minoo\\Controller\\EngagementController::deleteComment')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('DELETE')
                 ->requirement('id', '\\d+')
                 ->build(),
@@ -215,7 +215,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.follow',
             RouteBuilder::create('/api/engagement/follow')
                 ->controller('Minoo\\Controller\\EngagementController::follow')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('POST')
                 ->build(),
         );
@@ -224,7 +224,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.deleteFollow',
             RouteBuilder::create('/api/engagement/follow/{id}')
                 ->controller('Minoo\\Controller\\EngagementController::deleteFollow')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('DELETE')
                 ->requirement('id', '\\d+')
                 ->build(),
@@ -234,7 +234,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.createPost',
             RouteBuilder::create('/api/engagement/post')
                 ->controller('Minoo\\Controller\\EngagementController::createPost')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('POST')
                 ->build(),
         );
@@ -243,7 +243,7 @@ final class EngagementServiceProvider extends ServiceProvider
             'engagement.deletePost',
             RouteBuilder::create('/api/engagement/post/{id}')
                 ->controller('Minoo\\Controller\\EngagementController::deletePost')
-                ->allowAll()
+                ->requireAuthentication()
                 ->methods('DELETE')
                 ->requirement('id', '\\d+')
                 ->build(),

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -143,6 +143,14 @@
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
     const headers = { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken };
 
+    function showFeedback(btn, message, isError) {
+      const label = btn.querySelector('.feed-action__label') || btn;
+      const original = label.textContent;
+      label.textContent = message;
+      if (isError) btn.classList.add('feed-action--error');
+      setTimeout(() => { label.textContent = original; btn.classList.remove('feed-action--error'); }, 2000);
+    }
+
     // Reaction toggling
     document.addEventListener('click', async function(e) {
       const btn = e.target.closest('[data-action="react"]');
@@ -152,18 +160,27 @@
       const isActive = btn.classList.contains('feed-action--active');
 
       try {
-        if (isActive) {
-          await fetch(`/api/react/${type}/${id}`, { method: 'DELETE', headers });
+        if (isActive && btn.dataset.reactionId) {
+          const res = await fetch(`/api/engagement/react/${btn.dataset.reactionId}`, { method: 'DELETE', headers });
+          if (!res.ok) { showFeedback(btn, 'Error', true); return; }
           btn.classList.remove('feed-action--active');
+          delete btn.dataset.reactionId;
         } else {
-          const reactionType = getReactionType(type);
-          await fetch('/api/react', {
+          const emoji = getReactionEmoji(type);
+          const res = await fetch('/api/engagement/react', {
             method: 'POST', headers,
-            body: JSON.stringify({ target_type: type, target_id: id, reaction_type: reactionType })
+            body: JSON.stringify({ target_type: type, target_id: id, emoji: emoji })
           });
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            showFeedback(btn, err.error || 'Error', true);
+            return;
+          }
+          const data = await res.json();
           btn.classList.add('feed-action--active');
+          btn.dataset.reactionId = data.id;
         }
-      } catch (err) { console.error('Reaction error:', err); }
+      } catch (err) { showFeedback(btn, 'Network error', true); }
     });
 
     // Comment expansion
@@ -177,10 +194,13 @@
         if (!section.dataset.loaded) {
           const type = btn.dataset.type;
           const id = btn.dataset.id;
-          const res = await fetch(`/api/comments/${type}/${id}`);
-          const data = await res.json();
-          section.innerHTML = renderComments(data.comments, type, id);
-          section.dataset.loaded = '1';
+          try {
+            const res = await fetch(`/api/engagement/comments/${type}/${id}`);
+            if (!res.ok) { section.innerHTML = '<p class="feed-comments__error">Could not load comments.</p>'; return; }
+            const data = await res.json();
+            section.innerHTML = renderComments(data.comments || [], type, id);
+            section.dataset.loaded = '1';
+          } catch (err) { section.innerHTML = '<p class="feed-comments__error">Could not load comments.</p>'; }
         }
       } else {
         section.hidden = true;
@@ -196,8 +216,7 @@
         navigator.share({ url, title: btn.dataset.title });
       } else {
         navigator.clipboard.writeText(url).then(() => {
-          btn.querySelector('.feed-action__label').textContent = 'Copied!';
-          setTimeout(() => { btn.querySelector('.feed-action__label').textContent = 'Share'; }, 2000);
+          showFeedback(btn, 'Copied!', false);
         });
       }
     });
@@ -209,28 +228,45 @@
       trigger.addEventListener('click', () => { postForm.hidden = false; trigger.hidden = true; });
       postForm.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const body = postForm.querySelector('textarea').value.trim();
-        const communityId = postForm.querySelector('select').value;
+        const submitBtn = postForm.querySelector('button[type="submit"]');
+        const textarea = postForm.querySelector('textarea');
+        const communitySelect = postForm.querySelector('select[name="community_id"]');
+        const body = textarea.value.trim();
         if (!body) return;
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Posting...';
         try {
-          const res = await fetch('/api/post', {
+          const payload = { body };
+          if (communitySelect) payload.community_id = communitySelect.value;
+          const res = await fetch('/api/engagement/post', {
             method: 'POST', headers,
-            body: JSON.stringify({ body, community_id: communityId })
+            body: JSON.stringify(payload)
           });
-          if (res.ok) location.reload();
-        } catch (err) { console.error('Post error:', err); }
+          if (res.ok) {
+            location.reload();
+          } else {
+            const err = await res.json().catch(() => ({}));
+            submitBtn.textContent = err.error || 'Error — try again';
+            submitBtn.disabled = false;
+            setTimeout(() => { submitBtn.textContent = 'Post'; }, 2000);
+          }
+        } catch (err) {
+          submitBtn.textContent = 'Network error';
+          submitBtn.disabled = false;
+          setTimeout(() => { submitBtn.textContent = 'Post'; }, 2000);
+        }
       });
     }
 
-    function getReactionType(entityType) {
-      const map = { event: 'interested', teaching: 'miigwech', business: 'recommend', post: 'miigwech' };
+    function getReactionEmoji(entityType) {
+      const map = { event: 'interested', teaching: 'miigwech', group: 'recommend', post: 'miigwech' };
       return map[entityType] || 'interested';
     }
 
     function renderComments(comments, type, id) {
       let html = '<div class="feed-comments__list">';
       comments.forEach(c => {
-        html += `<div class="feed-comment"><strong>User</strong> <span class="feed-comment__time">${c.relative_time}</span><p>${escapeHtml(c.body)}</p></div>`;
+        html += `<div class="feed-comment"><strong>User</strong> <span class="feed-comment__time">${c.relative_time || ''}</span><p>${escapeHtml(c.body)}</p></div>`;
       });
       html += '</div>';
       html += `<form class="feed-comments__form" data-type="${type}" data-id="${id}">
@@ -248,8 +284,10 @@
       const input = form.querySelector('input');
       const body = input.value.trim();
       if (!body) return;
+      const submitBtn = form.querySelector('button');
+      submitBtn.disabled = true;
       try {
-        const res = await fetch('/api/comment', {
+        const res = await fetch('/api/engagement/comment', {
           method: 'POST', headers,
           body: JSON.stringify({ target_type: form.dataset.type, target_id: form.dataset.id, body })
         });
@@ -259,8 +297,17 @@
             `<div class="feed-comment"><strong>You</strong> <span class="feed-comment__time">just now</span><p>${escapeHtml(body)}</p></div>`
           );
           input.value = '';
+        } else {
+          const err = await res.json().catch(() => ({}));
+          input.value = '';
+          input.placeholder = err.error || 'Error — try again';
+          setTimeout(() => { input.placeholder = 'Write a comment...'; }, 2000);
         }
-      } catch (err) { console.error('Comment error:', err); }
+      } catch (err) {
+        input.placeholder = 'Network error';
+        setTimeout(() => { input.placeholder = 'Write a comment...'; }, 2000);
+      }
+      submitBtn.disabled = false;
     });
 
     function escapeHtml(str) {

--- a/tests/Minoo/Unit/Controller/EngagementControllerTest.php
+++ b/tests/Minoo/Unit/Controller/EngagementControllerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\EngagementController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+#[CoversClass(EngagementController::class)]
+final class EngagementControllerTest extends TestCase
+{
+    private function makeController(): EngagementController
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+
+        return new EngagementController($etm);
+    }
+
+    private function authedAccount(int $id = 1): AccountInterface
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('id')->willReturn($id);
+        $account->method('isAuthenticated')->willReturn(true);
+
+        return $account;
+    }
+
+    private function jsonRequest(string $method, array $body): HttpRequest
+    {
+        return HttpRequest::create('/', $method, [], [], [], [], json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    // --- Target type whitelist ---
+
+    #[Test]
+    public function react_rejects_invalid_target_type(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'emoji' => "\u{2764}\u{FE0F}",
+            'target_type' => 'malicious_type',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->react([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid target_type', $response->content);
+    }
+
+    #[Test]
+    public function comment_rejects_invalid_target_type(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'body' => 'Hello',
+            'target_type' => 'sql_injection',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->comment([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid target_type', $response->content);
+    }
+
+    #[Test]
+    public function follow_rejects_invalid_target_type(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'target_type' => 'nonexistent',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->follow([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid target_type', $response->content);
+    }
+
+    #[Test]
+    public function getComments_rejects_invalid_target_type(): void
+    {
+        $controller = $this->makeController();
+        $request = HttpRequest::create('/');
+
+        $response = $controller->getComments(
+            ['target_type' => 'xss_attempt', 'target_id' => '1'],
+            [],
+            $this->authedAccount(),
+            $request,
+        );
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid target_type', $response->content);
+    }
+
+    // --- Emoji validation ---
+
+    #[Test]
+    public function react_rejects_empty_emoji(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'emoji' => '   ',
+            'target_type' => 'event',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->react([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid emoji', $response->content);
+    }
+
+    #[Test]
+    public function react_rejects_oversized_emoji(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'emoji' => str_repeat("\u{1F600}", 11),
+            'target_type' => 'event',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->react([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Invalid emoji', $response->content);
+    }
+
+    // --- Missing fields ---
+
+    #[Test]
+    public function react_rejects_missing_fields(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', ['emoji' => "\u{2764}\u{FE0F}"]);
+
+        $response = $controller->react([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Missing required fields', $response->content);
+    }
+
+    #[Test]
+    public function comment_rejects_missing_fields(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', ['body' => 'Hello']);
+
+        $response = $controller->comment([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Missing required fields', $response->content);
+    }
+
+    #[Test]
+    public function createPost_rejects_empty_body(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', ['body' => '   ']);
+
+        $response = $controller->createPost([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Body must be', $response->content);
+    }
+
+    #[Test]
+    public function createPost_rejects_oversized_body(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', ['body' => str_repeat('a', 5001)]);
+
+        $response = $controller->createPost([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Body must be', $response->content);
+    }
+
+    #[Test]
+    public function comment_rejects_oversized_body(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->jsonRequest('POST', [
+            'body' => str_repeat('a', 2001),
+            'target_type' => 'event',
+            'target_id' => 1,
+        ]);
+
+        $response = $controller->comment([], [], $this->authedAccount(), $request);
+
+        $this->assertSame(422, $response->statusCode);
+        $this->assertStringContainsString('Body must be', $response->content);
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce `requireAuthentication()` on all 8 engagement mutation routes (was `allowAll()`)
- Add `ALLOWED_TARGET_TYPES` whitelist validation on all endpoints accepting `target_type`
- Fix all JS API URLs (`/api/engagement/*`), add `res.ok` checks, user-facing error feedback
- Restore `community_id` in post creation payload
- 11 new EngagementController unit tests for validation paths

## Issues
Closes #407, #408, #409, #397, #411

## Test plan
- [x] 569 tests passing (1443 assertions), 11 new
- [ ] Manual: verify unauthenticated POST to `/api/engagement/react` returns 401
- [ ] Manual: verify invalid `target_type` returns 422
- [ ] Manual: verify reaction/comment/post JS interactions work on feed page

🤖 Generated with [Claude Code](https://claude.com/claude-code)