### PR TITLE
test(#423): Playwright visual regression tests for light/dark mode

### DIFF
--- a/tests/playwright/light-mode.spec.ts
+++ b/tests/playwright/light-mode.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+const pages = [
+  { name: 'homepage', path: '/' },
+  { name: 'events', path: '/events' },
+  { name: 'teachings', path: '/teachings' },
+  { name: 'communities', path: '/communities' },
+  { name: 'language', path: '/language' },
+  { name: 'search', path: '/search' },
+];
+
+test.describe('Light mode visual regression', () => {
+  for (const { name, path } of pages) {
+    test(`${name} — dark mode`, async ({ page }) => {
+      await page.goto(path);
+      await page.evaluate(() => {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      });
+      await page.waitForTimeout(300);
+      await expect(page).toHaveScreenshot(`${name}-dark.png`, { fullPage: true });
+    });
+
+    test(`${name} — light mode`, async ({ page }) => {
+      await page.goto(path);
+      await page.evaluate(() => {
+        document.documentElement.setAttribute('data-theme', 'light');
+      });
+      await page.waitForTimeout(300);
+      await expect(page).toHaveScreenshot(`${name}-light.png`, { fullPage: true });
+    });
+  }
+});
+
+test.describe('Theme toggle behavior', () => {
+  test('theme toggle persists across navigation', async ({ page }) => {
+    await page.goto('/');
+    await page.click('.theme-toggle');
+    const theme = await page.evaluate(() =>
+      document.documentElement.getAttribute('data-theme'),
+    );
+    expect(theme).toBe('light');
+
+    await page.goto('/events');
+    const persisted = await page.evaluate(() =>
+      document.documentElement.getAttribute('data-theme'),
+    );
+    expect(persisted).toBe('light');
+  });
+
+  test('theme toggle switches icons', async ({ page }) => {
+    await page.goto('/');
+    // Dark mode default — moon icon visible
+    await expect(page.locator('.theme-toggle__icon--dark')).toBeVisible();
+    await expect(page.locator('.theme-toggle__icon--light')).toBeHidden();
+
+    await page.click('.theme-toggle');
+    // Light mode — sun icon visible
+    await expect(page.locator('.theme-toggle__icon--light')).toBeVisible();
+    await expect(page.locator('.theme-toggle__icon--dark')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Playwright visual regression tests covering 6 pages (homepage, events, teachings, communities, language, search) in both dark and light themes
- Tests theme toggle persistence across navigation (localStorage)
- Tests theme toggle icon switching (sun/moon)

## Test plan
- [ ] Run `npx playwright test tests/playwright/light-mode.spec.ts --update-snapshots` to generate baseline screenshots
- [ ] Run again without `--update-snapshots` to verify pass
- [ ] Verify toggle persistence test passes with theme-toggle JS in place
- [ ] Verify icon switching test passes with `.theme-toggle__icon--dark` / `--light` selectors

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)