### PR TITLE
feat(#419,#420): light mode token overrides + theme toggle

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -182,6 +182,38 @@
     /* Extended radii */
     --radius-xl: 1.5rem;
   }
+
+  [data-theme="light"] {
+    --surface:           var(--surface-light);
+    --surface-card:      var(--surface-light-card);
+    --surface-raised:    #eae5df;
+    --text-primary:      var(--text-dark);
+    --text-secondary:    var(--text-dark-secondary);
+    --text-muted:        #888;
+    --border:            var(--border-light);
+    --border-dark:       var(--border-light);
+    --border-subtle:     #d4cfc8;
+    --accent:            var(--color-events);
+    --link:              var(--color-events);
+    color-scheme: light;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) {
+      --surface:           var(--surface-light);
+      --surface-card:      var(--surface-light-card);
+      --surface-raised:    #eae5df;
+      --text-primary:      var(--text-dark);
+      --text-secondary:    var(--text-dark-secondary);
+      --text-muted:        #888;
+      --border:            var(--border-light);
+      --border-dark:       var(--border-light);
+      --border-subtle:     #d4cfc8;
+      --accent:            var(--color-events);
+      --link:              var(--color-events);
+      color-scheme: light;
+    }
+  }
 }
 
 @layer base {
@@ -2835,6 +2867,34 @@
     aspect-ratio: 16 / 9;
     border: none;
     border-radius: 0.375rem;
+  }
+
+  /* ── Theme toggle ── */
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-3xs);
+    background: none;
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.375rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.2s, border-color 0.2s;
+  }
+
+  .theme-toggle:hover {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+  }
+
+  .theme-toggle__icon--light { display: none; }
+  [data-theme="light"] .theme-toggle__icon--dark { display: none; }
+  [data-theme="light"] .theme-toggle__icon--light { display: block; }
+
+  @media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) .theme-toggle__icon--dark { display: none; }
+    :root:not([data-theme="dark"]) .theme-toggle__icon--light { display: block; }
   }
 }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,11 +17,12 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=10">
+  <link rel="stylesheet" href="/css/minoo.css?v=11">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
 </head>
 <body>
+  <script>(function(){var t=localStorage.getItem('minoo-theme');if(t)document.documentElement.setAttribute('data-theme',t);})()</script>
   <a href="#main-content" class="skip-link">{{ trans('base.skip_link') }}</a>
   <div class="site">
     <header class="site-header">
@@ -58,6 +59,9 @@
             {% else %}
               <li class="site-nav__utility"><a href="{{ lang_url('/login') }}"{% if path is defined and path == '/login' %} aria-current="page"{% endif %}>{{ trans('nav.login') }}</a></li>
             {% endif %}
+            <li class="site-nav__utility site-nav__theme">
+              {% include "components/theme-toggle.html.twig" %}
+            </li>
             <li class="site-nav__utility site-nav__lang">
               <div class="lang-switcher">
                 <button class="lang-switcher__toggle" aria-expanded="false" aria-haspopup="true" aria-label="{{ trans('language_switcher.label') }}">
@@ -147,6 +151,22 @@
       document.addEventListener('click', function() {
         menu.classList.remove('is-open');
         toggle.setAttribute('aria-expanded', 'false');
+      });
+    })();
+    // Theme toggle
+    (function() {
+      var btn = document.querySelector('.theme-toggle');
+      if (!btn) return;
+      function current() {
+        return document.documentElement.getAttribute('data-theme') ||
+          (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+      }
+      function apply(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('minoo-theme', theme);
+      }
+      btn.addEventListener('click', function() {
+        apply(current() === 'dark' ? 'light' : 'dark');
       });
     })();
   </script>

--- a/templates/components/theme-toggle.html.twig
+++ b/templates/components/theme-toggle.html.twig
@@ -1,0 +1,9 @@
+<button class="theme-toggle" aria-label="Toggle light/dark theme" title="Toggle theme" type="button">
+  <svg class="theme-toggle__icon theme-toggle__icon--dark" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+  <svg class="theme-toggle__icon theme-toggle__icon--light" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  </svg>
+</button>


### PR DESCRIPTION
## Summary
- Added `[data-theme="light"]` token overrides and `@media (prefers-color-scheme: light)` auto-detection block in `@layer tokens`
- Created theme-toggle component (moon/sun SVG icons) with localStorage persistence and FOUC prevention inline script
- Added `.theme-toggle` CSS in `@layer components` with icon swap logic for both manual and auto theme modes
- Bumped CSS version from v10 to v11

Closes #419, closes #420

## Test plan
- [ ] Load site in dark mode (default) — verify no visual change from baseline
- [ ] Click theme toggle button — verify backgrounds switch to light, text remains readable
- [ ] Reload page — verify light mode persists via localStorage
- [ ] Clear localStorage, set OS to light mode — verify auto-detection applies light tokens
- [ ] Set `data-theme="dark"` manually with OS in light mode — verify dark overrides auto

🤖 Generated with [Claude Code](https://claude.com/claude-code)