### PR TITLE
feat(#421,#422): component light mode variants

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -684,7 +684,7 @@
 
     .lang-switcher__toggle {
       color: var(--text-on-dark);
-      border-color: oklch(0.6 0 0);
+      border-color: var(--border-subtle);
     }
 
     .lang-switcher__menu {
@@ -704,7 +704,7 @@
     }
 
     .lang-switcher__item--active {
-      color: white;
+      color: var(--text-primary);
     }
 
     .site-header__inner {
@@ -724,7 +724,7 @@
     background-color: var(--surface-card);
     border-radius: var(--radius-md);
     padding: var(--space-sm);
-    border: 1px solid oklch(0.2 0 0);
+    border: 1px solid var(--border-subtle);
     border-inline-start: 3px solid var(--card-accent, var(--border-subtle));
     max-inline-size: var(--width-card);
     box-shadow: 0 1px 3px oklch(0 0 0 / 0.08);
@@ -735,7 +735,7 @@
 
   .card:hover {
     box-shadow: var(--shadow-md);
-    border-color: var(--card-accent, oklch(0.4 0 0));
+    border-color: var(--card-accent, var(--text-muted));
     transform: translateY(-1px);
   }
 
@@ -819,7 +819,7 @@
 
   a.card:hover {
     box-shadow: var(--shadow-md);
-    border-color: var(--card-accent, oklch(0.4 0 0));
+    border-color: var(--card-accent, var(--text-muted));
     transform: translateY(-1px);
   }
 
@@ -1686,7 +1686,7 @@
     padding: var(--space-sm);
     background-color: var(--surface-card);
     border-radius: var(--radius-md);
-    border: 1px solid oklch(0.2 0 0);
+    border: 1px solid var(--border-subtle);
     box-shadow: 0 1px 3px oklch(0 0 0 / 0.08);
     align-self: start;
   }
@@ -1700,7 +1700,7 @@
     padding: var(--space-sm);
     background-color: var(--surface-card);
     border-radius: var(--radius-md);
-    border: 1px solid oklch(0.2 0 0);
+    border: 1px solid var(--border-subtle);
     border-inline-start: 3px solid var(--color-people);
     box-shadow: 0 1px 3px oklch(0 0 0 / 0.08);
   }
@@ -1805,7 +1805,7 @@
   .card--dashboard {
     container-type: inline-size;
     background: var(--surface-raised);
-    border: 1px solid oklch(0.2 0 0);
+    border: 1px solid var(--border-subtle);
     border-radius: var(--radius-md);
     padding: var(--space-sm);
     box-shadow: 0 1px 3px oklch(0 0 0 / 0.08);
@@ -1815,7 +1815,7 @@
 
     &:hover {
       box-shadow: 0 2px 8px oklch(0 0 0 / 0.12);
-      border-color: oklch(0.4 0 0);
+      border-color: var(--text-muted);
     }
   }
 
@@ -2361,7 +2361,7 @@
 
   /* Tags inside content well */
   .content-well .tag {
-    background-color: #e8e3dc;
+    background-color: var(--border-light);
     color: #666;
   }
 
@@ -2399,7 +2399,7 @@
       &:not(:last-child)::after {
         content: "\203A";
         margin-inline-start: var(--space-3xs);
-        color: oklch(0.6 0 0);
+        color: var(--text-muted);
       }
     }
 
@@ -4083,4 +4083,32 @@
     flex-direction: column;
     gap: var(--space-xs);
   }
+}
+
+/* ── Light mode component overrides ── */
+[data-theme="light"] .feed-pill {
+  background: rgba(106, 156, 175, 0.08);
+}
+
+[data-theme="light"] .community-pill {
+  background: rgba(106, 156, 175, 0.1);
+}
+
+[data-theme="light"] .flash-message--success { background: rgba(42, 157, 143, 0.08); }
+[data-theme="light"] .flash-message--error { background: rgba(255, 77, 90, 0.08); }
+[data-theme="light"] .flash-message--info { background: rgba(106, 156, 175, 0.08); }
+[data-theme="light"] .flash-message--warning { background: rgba(244, 162, 97, 0.08); }
+
+/* ── prefers-color-scheme auto-detection equivalents ── */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) .feed-pill {
+    background: rgba(106, 156, 175, 0.08);
+  }
+  :root:not([data-theme="dark"]) .community-pill {
+    background: rgba(106, 156, 175, 0.1);
+  }
+  :root:not([data-theme="dark"]) .flash-message--success { background: rgba(42, 157, 143, 0.08); }
+  :root:not([data-theme="dark"]) .flash-message--error { background: rgba(255, 77, 90, 0.08); }
+  :root:not([data-theme="dark"]) .flash-message--info { background: rgba(106, 156, 175, 0.08); }
+  :root:not([data-theme="dark"]) .flash-message--warning { background: rgba(244, 162, 97, 0.08); }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded oklch/hex colors in card, lang-switcher, dashboard card, business sidebar, owner card, breadcrumb separator, and content-well tag rules with CSS custom property token references (`--border-subtle`, `--text-muted`, `--text-primary`, `--border-light`)
- Add `[data-theme="light"]` overrides for feed-pill, community-pill, and flash-message variants
- Add `@media (prefers-color-scheme: light)` equivalents for OS-level auto-detection

## Test plan
- [ ] Toggle `data-theme="light"` on `:root` and verify cards, pills, flash messages, lang switcher render correctly
- [ ] Verify dark mode is unchanged (no regressions)
- [ ] PHPUnit: 569 tests pass (3 skipped, pre-existing)

Closes #421, closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)