### PR TITLE
test(#340): Playwright tests for map entity filter toggles

### DIFF
--- a/tests/playwright/map-entity-filter.spec.ts
+++ b/tests/playwright/map-entity-filter.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Map entity type filters', () => {
+  test('filter buttons are visible on communities page', async ({ page }) => {
+    await page.goto('/communities');
+    const btn = page.locator('.atlas-filter--communities');
+    const hasFilter = await btn.count();
+    test.skip(hasFilter === 0, 'Entity filter buttons not rendered — requires seeded data');
+    await expect(btn).toBeVisible();
+  });
+
+  test('community filter toggles markers', async ({ page }) => {
+    await page.goto('/communities');
+    const btn = page.locator('.atlas-filter--communities');
+    const hasFilter = await btn.count();
+    test.skip(hasFilter === 0, 'Entity filter buttons not rendered — requires seeded data');
+
+    // Active by default
+    await expect(btn).toHaveClass(/is-active/);
+
+    // Toggle off
+    await btn.click();
+    await expect(btn).not.toHaveClass(/is-active/);
+
+    // Toggle back on
+    await btn.click();
+    await expect(btn).toHaveClass(/is-active/);
+  });
+
+  test('filter buttons have correct aria-pressed', async ({ page }) => {
+    await page.goto('/communities');
+    const btn = page.locator('.atlas-filter--communities');
+    const hasFilter = await btn.count();
+    test.skip(hasFilter === 0, 'Entity filter buttons not rendered — requires seeded data');
+
+    await expect(btn).toHaveAttribute('aria-pressed', 'true');
+
+    await btn.click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Playwright test file `tests/playwright/map-entity-filter.spec.ts` for the map entity type filter feature
- Tests filter button visibility, toggle active/inactive state, and `aria-pressed` accessibility attributes
- Uses `test.skip` guards matching existing project conventions for data-dependent assertions

Closes #340

## Test plan
- [ ] Run `npx playwright test map-entity-filter` with dev server and seeded data
- [ ] Verify tests skip gracefully when filter buttons are not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)