### PR TITLE
feat(#340): controller + template for map entity type filters

### DIFF
--- a/src/Controller/CommunityController.php
+++ b/src/Controller/CommunityController.php
@@ -73,6 +73,32 @@ final class CommunityController
             ];
         }
 
+        $businessStorage = $this->entityTypeManager->getStorage('group');
+        $businessIds = $businessStorage->getQuery()
+            ->condition('type', 'business')
+            ->condition('status', 1)
+            ->execute();
+        $businesses = $businessIds !== [] ? array_values($businessStorage->loadMultiple($businessIds)) : [];
+
+        $businessesJson = [];
+        foreach ($businesses as $business) {
+            $lat = $business->get('latitude');
+            $lng = $business->get('longitude');
+            $source = $business->get('coordinate_source');
+            if ($lat === null || $lng === null || $source !== 'address') {
+                continue;
+            }
+            $businessesJson[] = [
+                'id' => $business->id(),
+                'name' => $business->get('name'),
+                'slug' => $business->get('slug'),
+                'lat' => (float) $lat,
+                'lng' => (float) $lng,
+                'community_name' => $business->get('community_name') ?? '',
+                'type' => 'business',
+            ];
+        }
+
         // LocationService::fromRequest() already checks session → cookie → IP GeoIP2
         $locationJson = $location->hasLocation()
             ? ['lat' => $location->latitude, 'lng' => $location->longitude, 'name' => $location->communityName]
@@ -82,6 +108,7 @@ final class CommunityController
             'path' => '/communities',
             'communities_json' => json_encode($communitiesJson, JSON_HEX_TAG | JSON_HEX_AMP | JSON_THROW_ON_ERROR),
             'location_json' => json_encode($locationJson, JSON_HEX_TAG | JSON_HEX_AMP | JSON_THROW_ON_ERROR),
+            'businesses_json' => json_encode($businessesJson, JSON_HEX_TAG | JSON_HEX_AMP | JSON_THROW_ON_ERROR),
         ]);
 
         return new SsrResponse(content: $html);

--- a/templates/communities/list.html.twig
+++ b/templates/communities/list.html.twig
@@ -18,6 +18,25 @@
     <div class="community-header__meta" x-text="headerMeta"></div>
   </div>
 
+  {# --- Entity type filters --- #}
+  <div class="atlas-filters" role="group" aria-label="Map entity type filters">
+    <button class="atlas-filter atlas-filter--communities"
+            :class="{ 'is-active': filters.communities }"
+            :aria-pressed="String(filters.communities)"
+            @click="toggleFilter('communities')"
+            type="button">
+      Communities
+    </button>
+    <button class="atlas-filter atlas-filter--businesses"
+            :class="{ 'is-active': filters.businesses }"
+            :aria-pressed="String(filters.businesses)"
+            @click="toggleFilter('businesses')"
+            x-show="businessCount > 0"
+            type="button">
+      Businesses
+    </button>
+  </div>
+
   {# --- Map --- #}
   <div id="atlas-map" class="community-map"></div>
 
@@ -168,6 +187,7 @@
 <script>
   window.__atlas_communities = {{ communities_json|raw }};
   window.__atlas_location = {{ location_json|raw }};
+  window.__atlas_businesses = {{ businesses_json|raw }};
 </script>
 <script src="/js/leaflet.js"></script>
 <script src="/js/leaflet.markercluster.js"></script>


### PR DESCRIPTION
## Summary
- Load businesses with address-level coordinates in `CommunityController::list()` and pass `businesses_json` to the template
- Add Alpine.js entity type filter toggle bar (Communities / Businesses) above the atlas map in `communities/list.html.twig`
- Add `window.__atlas_businesses` script data for client-side JS consumption

Closes #340

## Simplify review
- Fixed field name from `group_type` to `type` to match existing codebase pattern (BusinessController, PeopleController, etc.)
- Removed unnecessary WHAT comment

## Test plan
- [x] PHPUnit: 569 tests pass (run from main repo)
- [ ] Visual: verify filter bar renders above map at `/communities`
- [ ] Functional: verify business markers appear when JS integration lands (Unit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)