### PR TITLE
fix(#412): entity validation + emoji→reaction_type rename

### DIFF
--- a/migrations/20260322_120000_rename_emoji_to_reaction_type.php
+++ b/migrations/20260322_120000_rename_emoji_to_reaction_type.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Rename the emoji column to reaction_type in the reaction table.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        $schema->getConnection()->executeStatement(
+            'ALTER TABLE reaction RENAME COLUMN emoji TO reaction_type',
+        );
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $schema->getConnection()->executeStatement(
+            'ALTER TABLE reaction RENAME COLUMN reaction_type TO emoji',
+        );
+    }
+};

--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Minoo\Controller;
 
+use Minoo\Entity\Reaction;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
@@ -25,30 +26,29 @@ final class EngagementController
     {
         $data = $this->jsonBody($request);
 
-        if (!isset($data['emoji'], $data['target_type'], $data['target_id'])) {
-            return $this->json(['error' => 'Missing required fields: emoji, target_type, target_id'], 422);
+        if (!isset($data['reaction_type'], $data['target_type'], $data['target_id'])) {
+            return $this->json(['error' => 'Missing required fields: reaction_type, target_type, target_id'], 422);
         }
 
         if (!$this->isValidTargetType($data['target_type'])) {
             return $this->json(['error' => 'Invalid target_type'], 422);
         }
 
-        $emoji = trim($data['emoji']);
-        if ($emoji === '' || mb_strlen($emoji) > 10) {
-            return $this->json(['error' => 'Invalid emoji'], 422);
+        $reactionType = trim($data['reaction_type']);
+        if (!in_array($reactionType, Reaction::ALLOWED_REACTION_TYPES, true)) {
+            return $this->json(['error' => 'Invalid reaction_type'], 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('reaction');
         $entity = $storage->create([
-            'emoji' => $emoji,
+            'reaction_type' => $reactionType,
             'user_id' => $account->id(),
             'target_type' => $data['target_type'],
             'target_id' => (int) $data['target_id'],
-            'created_at' => time(),
         ]);
         $storage->save($entity);
 
-        return $this->json(['id' => $entity->id(), 'emoji' => $entity->get('emoji')], 201);
+        return $this->json(['id' => $entity->id(), 'reaction_type' => $entity->get('reaction_type')], 201);
     }
 
     public function deleteReaction(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -93,8 +93,6 @@ final class EngagementController
             'user_id' => $account->id(),
             'target_type' => $data['target_type'],
             'target_id' => (int) $data['target_id'],
-            'status' => 1,
-            'created_at' => time(),
         ]);
         $storage->save($entity);
 
@@ -173,7 +171,6 @@ final class EngagementController
             'user_id' => $account->id(),
             'target_type' => $data['target_type'],
             'target_id' => (int) $data['target_id'],
-            'created_at' => time(),
         ]);
         $storage->save($entity);
 
@@ -203,8 +200,8 @@ final class EngagementController
     {
         $data = $this->jsonBody($request);
 
-        if (!isset($data['body'])) {
-            return $this->json(['error' => 'Missing required field: body'], 422);
+        if (!isset($data['body'], $data['community_id'])) {
+            return $this->json(['error' => 'Missing required fields: body, community_id'], 422);
         }
 
         $body = trim($data['body']);
@@ -216,9 +213,7 @@ final class EngagementController
         $entity = $storage->create([
             'body' => $body,
             'user_id' => $account->id(),
-            'status' => 1,
-            'created_at' => time(),
-            'updated_at' => time(),
+            'community_id' => (int) $data['community_id'],
         ]);
         $storage->save($entity);
 

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -19,11 +19,17 @@ final class Comment extends ContentEntityBase
     /** @param array<string, mixed> $values */
     public function __construct(array $values = [])
     {
+        foreach (['user_id', 'target_type', 'target_id', 'body'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
         if (!array_key_exists('status', $values)) {
             $values['status'] = 1;
         }
         if (!array_key_exists('created_at', $values)) {
-            $values['created_at'] = 0;
+            $values['created_at'] = time();
         }
 
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);

--- a/src/Entity/Follow.php
+++ b/src/Entity/Follow.php
@@ -19,8 +19,14 @@ final class Follow extends ContentEntityBase
     /** @param array<string, mixed> $values */
     public function __construct(array $values = [])
     {
+        foreach (['user_id', 'target_type', 'target_id'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
         if (!array_key_exists('created_at', $values)) {
-            $values['created_at'] = 0;
+            $values['created_at'] = time();
         }
 
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -19,14 +19,20 @@ final class Post extends ContentEntityBase
     /** @param array<string, mixed> $values */
     public function __construct(array $values = [])
     {
+        foreach (['user_id', 'body', 'community_id'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
         if (!array_key_exists('status', $values)) {
             $values['status'] = 1;
         }
         if (!array_key_exists('created_at', $values)) {
-            $values['created_at'] = 0;
+            $values['created_at'] = time();
         }
         if (!array_key_exists('updated_at', $values)) {
-            $values['updated_at'] = 0;
+            $values['updated_at'] = time();
         }
 
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);

--- a/src/Entity/Reaction.php
+++ b/src/Entity/Reaction.php
@@ -13,14 +13,35 @@ final class Reaction extends ContentEntityBase
     protected array $entityKeys = [
         'id' => 'rid',
         'uuid' => 'uuid',
-        'label' => 'emoji',
+        'label' => 'reaction_type',
+    ];
+
+    /** @var list<string> */
+    public const ALLOWED_REACTION_TYPES = [
+        'like',
+        'interested',
+        'recommend',
+        'miigwech',
+        'connect',
     ];
 
     /** @param array<string, mixed> $values */
     public function __construct(array $values = [])
     {
+        foreach (['user_id', 'target_type', 'target_id', 'reaction_type'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
+        if (!in_array($values['reaction_type'], self::ALLOWED_REACTION_TYPES, true)) {
+            throw new \InvalidArgumentException(
+                "Invalid reaction_type '{$values['reaction_type']}'. Allowed: " . implode(', ', self::ALLOWED_REACTION_TYPES),
+            );
+        }
+
         if (!array_key_exists('created_at', $values)) {
-            $values['created_at'] = 0;
+            $values['created_at'] = time();
         }
 
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);

--- a/src/Provider/EngagementServiceProvider.php
+++ b/src/Provider/EngagementServiceProvider.php
@@ -22,12 +22,12 @@ final class EngagementServiceProvider extends ServiceProvider
             id: 'reaction',
             label: 'Reaction',
             class: Reaction::class,
-            keys: ['id' => 'rid', 'uuid' => 'uuid', 'label' => 'emoji'],
+            keys: ['id' => 'rid', 'uuid' => 'uuid', 'label' => 'reaction_type'],
             group: 'engagement',
             fieldDefinitions: [
-                'emoji' => [
+                'reaction_type' => [
                     'type' => 'string',
-                    'label' => 'Emoji',
+                    'label' => 'Reaction Type',
                     'weight' => 0,
                 ],
                 'user_id' => [
@@ -110,6 +110,11 @@ final class EngagementServiceProvider extends ServiceProvider
                     'type' => 'integer',
                     'label' => 'User ID',
                     'weight' => 1,
+                ],
+                'community_id' => [
+                    'type' => 'integer',
+                    'label' => 'Community ID',
+                    'weight' => 2,
                 ],
                 'status' => [
                     'type' => 'boolean',

--- a/tests/Minoo/Unit/Controller/EngagementControllerTest.php
+++ b/tests/Minoo/Unit/Controller/EngagementControllerTest.php
@@ -43,7 +43,7 @@ final class EngagementControllerTest extends TestCase
     {
         $controller = $this->makeController();
         $request = $this->jsonRequest('POST', [
-            'emoji' => "\u{2764}\u{FE0F}",
+            'reaction_type' => 'like',
             'target_type' => 'malicious_type',
             'target_id' => 1,
         ]);
@@ -102,14 +102,14 @@ final class EngagementControllerTest extends TestCase
         $this->assertStringContainsString('Invalid target_type', $response->content);
     }
 
-    // --- Emoji validation ---
+    // --- Reaction type validation ---
 
     #[Test]
-    public function react_rejects_empty_emoji(): void
+    public function react_rejects_invalid_reaction_type(): void
     {
         $controller = $this->makeController();
         $request = $this->jsonRequest('POST', [
-            'emoji' => '   ',
+            'reaction_type' => 'invalid_type',
             'target_type' => 'event',
             'target_id' => 1,
         ]);
@@ -117,23 +117,7 @@ final class EngagementControllerTest extends TestCase
         $response = $controller->react([], [], $this->authedAccount(), $request);
 
         $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid emoji', $response->content);
-    }
-
-    #[Test]
-    public function react_rejects_oversized_emoji(): void
-    {
-        $controller = $this->makeController();
-        $request = $this->jsonRequest('POST', [
-            'emoji' => str_repeat("\u{1F600}", 11),
-            'target_type' => 'event',
-            'target_id' => 1,
-        ]);
-
-        $response = $controller->react([], [], $this->authedAccount(), $request);
-
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid emoji', $response->content);
+        $this->assertStringContainsString('Invalid reaction_type', $response->content);
     }
 
     // --- Missing fields ---
@@ -142,7 +126,7 @@ final class EngagementControllerTest extends TestCase
     public function react_rejects_missing_fields(): void
     {
         $controller = $this->makeController();
-        $request = $this->jsonRequest('POST', ['emoji' => "\u{2764}\u{FE0F}"]);
+        $request = $this->jsonRequest('POST', ['reaction_type' => 'like']);
 
         $response = $controller->react([], [], $this->authedAccount(), $request);
 
@@ -166,7 +150,7 @@ final class EngagementControllerTest extends TestCase
     public function createPost_rejects_empty_body(): void
     {
         $controller = $this->makeController();
-        $request = $this->jsonRequest('POST', ['body' => '   ']);
+        $request = $this->jsonRequest('POST', ['body' => '   ', 'community_id' => 1]);
 
         $response = $controller->createPost([], [], $this->authedAccount(), $request);
 
@@ -178,7 +162,7 @@ final class EngagementControllerTest extends TestCase
     public function createPost_rejects_oversized_body(): void
     {
         $controller = $this->makeController();
-        $request = $this->jsonRequest('POST', ['body' => str_repeat('a', 5001)]);
+        $request = $this->jsonRequest('POST', ['body' => str_repeat('a', 5001), 'community_id' => 1]);
 
         $response = $controller->createPost([], [], $this->authedAccount(), $request);
 

--- a/tests/Minoo/Unit/Entity/CommentTest.php
+++ b/tests/Minoo/Unit/Entity/CommentTest.php
@@ -15,19 +15,22 @@ final class CommentTest extends TestCase
     #[Test]
     public function it_creates_with_defaults(): void
     {
+        $before = time();
         $comment = new Comment([
             'body' => 'Great event!',
             'user_id' => 1,
             'target_type' => 'event',
             'target_id' => 42,
         ]);
+        $after = time();
 
         $this->assertSame('Great event!', $comment->get('body'));
         $this->assertSame(1, $comment->get('user_id'));
         $this->assertSame('event', $comment->get('target_type'));
         $this->assertSame(42, $comment->get('target_id'));
         $this->assertSame(1, $comment->get('status'));
-        $this->assertSame(0, $comment->get('created_at'));
+        $this->assertGreaterThanOrEqual($before, $comment->get('created_at'));
+        $this->assertLessThanOrEqual($after, $comment->get('created_at'));
     }
 
     #[Test]
@@ -50,5 +53,39 @@ final class CommentTest extends TestCase
         ]);
 
         $this->assertSame(0, $comment->get('status'));
+    }
+
+    #[Test]
+    public function constructor_requires_required_fields(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Comment([]);
+    }
+
+    #[Test]
+    public function constructor_requires_body(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Comment([
+            'user_id' => 1,
+            'target_type' => 'event',
+            'target_id' => 42,
+        ]);
+    }
+
+    #[Test]
+    public function created_at_defaults_to_current_time(): void
+    {
+        $before = time();
+        $comment = new Comment([
+            'body' => 'Test',
+            'user_id' => 1,
+            'target_type' => 'event',
+            'target_id' => 42,
+        ]);
+        $after = time();
+
+        $this->assertGreaterThanOrEqual($before, $comment->get('created_at'));
+        $this->assertLessThanOrEqual($after, $comment->get('created_at'));
     }
 }

--- a/tests/Minoo/Unit/Entity/FollowTest.php
+++ b/tests/Minoo/Unit/Entity/FollowTest.php
@@ -15,16 +15,19 @@ final class FollowTest extends TestCase
     #[Test]
     public function it_creates_with_defaults(): void
     {
+        $before = time();
         $follow = new Follow([
             'user_id' => 1,
             'target_type' => 'group',
             'target_id' => 10,
         ]);
+        $after = time();
 
         $this->assertSame(1, $follow->get('user_id'));
         $this->assertSame('group', $follow->get('target_type'));
         $this->assertSame(10, $follow->get('target_id'));
-        $this->assertSame(0, $follow->get('created_at'));
+        $this->assertGreaterThanOrEqual($before, $follow->get('created_at'));
+        $this->assertLessThanOrEqual($after, $follow->get('created_at'));
     }
 
     #[Test]
@@ -46,5 +49,37 @@ final class FollowTest extends TestCase
         ]);
 
         $this->assertSame(1711000000, $follow->get('created_at'));
+    }
+
+    #[Test]
+    public function constructor_requires_required_fields(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Follow([]);
+    }
+
+    #[Test]
+    public function constructor_requires_target_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Follow([
+            'user_id' => 1,
+            'target_id' => 10,
+        ]);
+    }
+
+    #[Test]
+    public function created_at_defaults_to_current_time(): void
+    {
+        $before = time();
+        $follow = new Follow([
+            'user_id' => 1,
+            'target_type' => 'group',
+            'target_id' => 10,
+        ]);
+        $after = time();
+
+        $this->assertGreaterThanOrEqual($before, $follow->get('created_at'));
+        $this->assertLessThanOrEqual($after, $follow->get('created_at'));
     }
 }

--- a/tests/Minoo/Unit/Entity/PostTest.php
+++ b/tests/Minoo/Unit/Entity/PostTest.php
@@ -15,22 +15,28 @@ final class PostTest extends TestCase
     #[Test]
     public function it_creates_with_defaults(): void
     {
+        $before = time();
         $post = new Post([
             'body' => 'Community gathering this weekend!',
             'user_id' => 1,
+            'community_id' => 5,
         ]);
+        $after = time();
 
         $this->assertSame('Community gathering this weekend!', $post->get('body'));
         $this->assertSame(1, $post->get('user_id'));
+        $this->assertSame(5, $post->get('community_id'));
         $this->assertSame(1, $post->get('status'));
-        $this->assertSame(0, $post->get('created_at'));
-        $this->assertSame(0, $post->get('updated_at'));
+        $this->assertGreaterThanOrEqual($before, $post->get('created_at'));
+        $this->assertLessThanOrEqual($after, $post->get('created_at'));
+        $this->assertGreaterThanOrEqual($before, $post->get('updated_at'));
+        $this->assertLessThanOrEqual($after, $post->get('updated_at'));
     }
 
     #[Test]
     public function it_exposes_entity_type_id(): void
     {
-        $post = new Post(['body' => 'Test', 'user_id' => 1]);
+        $post = new Post(['body' => 'Test', 'user_id' => 1, 'community_id' => 1]);
 
         $this->assertSame('post', $post->getEntityTypeId());
     }
@@ -41,6 +47,7 @@ final class PostTest extends TestCase
         $post = new Post([
             'body' => 'Draft post',
             'user_id' => 1,
+            'community_id' => 1,
             'status' => 0,
         ]);
 
@@ -53,11 +60,39 @@ final class PostTest extends TestCase
         $post = new Post([
             'body' => 'Test',
             'user_id' => 1,
+            'community_id' => 1,
             'created_at' => 1711000000,
             'updated_at' => 1711000100,
         ]);
 
         $this->assertSame(1711000000, $post->get('created_at'));
         $this->assertSame(1711000100, $post->get('updated_at'));
+    }
+
+    #[Test]
+    public function constructor_requires_required_fields(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([]);
+    }
+
+    #[Test]
+    public function constructor_requires_community_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([
+            'body' => 'Test',
+            'user_id' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function constructor_requires_body(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([
+            'user_id' => 1,
+            'community_id' => 1,
+        ]);
     }
 }

--- a/tests/Minoo/Unit/Entity/ReactionTest.php
+++ b/tests/Minoo/Unit/Entity/ReactionTest.php
@@ -15,24 +15,27 @@ final class ReactionTest extends TestCase
     #[Test]
     public function it_creates_with_defaults(): void
     {
+        $before = time();
         $reaction = new Reaction([
-            'emoji' => "\u{2764}\u{FE0F}",
+            'reaction_type' => 'like',
             'user_id' => 1,
             'target_type' => 'event',
             'target_id' => 42,
         ]);
+        $after = time();
 
-        $this->assertSame("\u{2764}\u{FE0F}", $reaction->get('emoji'));
+        $this->assertSame('like', $reaction->get('reaction_type'));
         $this->assertSame(1, $reaction->get('user_id'));
         $this->assertSame('event', $reaction->get('target_type'));
         $this->assertSame(42, $reaction->get('target_id'));
-        $this->assertSame(0, $reaction->get('created_at'));
+        $this->assertGreaterThanOrEqual($before, $reaction->get('created_at'));
+        $this->assertLessThanOrEqual($after, $reaction->get('created_at'));
     }
 
     #[Test]
     public function it_exposes_entity_type_id(): void
     {
-        $reaction = new Reaction(['emoji' => "\u{1F44D}", 'user_id' => 1, 'target_type' => 'post', 'target_id' => 1]);
+        $reaction = new Reaction(['reaction_type' => 'miigwech', 'user_id' => 1, 'target_type' => 'post', 'target_id' => 1]);
 
         $this->assertSame('reaction', $reaction->getEntityTypeId());
     }
@@ -41,7 +44,7 @@ final class ReactionTest extends TestCase
     public function it_accepts_created_at(): void
     {
         $reaction = new Reaction([
-            'emoji' => "\u{1F44D}",
+            'reaction_type' => 'interested',
             'user_id' => 1,
             'target_type' => 'post',
             'target_id' => 1,
@@ -49,5 +52,49 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame(1711000000, $reaction->get('created_at'));
+    }
+
+    #[Test]
+    public function constructor_requires_user_id_and_target(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Reaction([]);
+    }
+
+    #[Test]
+    public function constructor_requires_reaction_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Reaction([
+            'user_id' => 1,
+            'target_type' => 'event',
+            'target_id' => 42,
+        ]);
+    }
+
+    #[Test]
+    public function rejects_invalid_reaction_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Reaction([
+            'user_id' => 1,
+            'target_type' => 'event',
+            'target_id' => 42,
+            'reaction_type' => 'invalid_type',
+        ]);
+    }
+
+    #[Test]
+    public function accepts_all_valid_reaction_types(): void
+    {
+        foreach (Reaction::ALLOWED_REACTION_TYPES as $type) {
+            $reaction = new Reaction([
+                'reaction_type' => $type,
+                'user_id' => 1,
+                'target_type' => 'event',
+                'target_id' => 1,
+            ]);
+            $this->assertSame($type, $reaction->get('reaction_type'));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add constructor validation with `InvalidArgumentException` for missing required fields on all 4 engagement entities (Reaction, Comment, Post, Follow)
- Default `created_at`/`updated_at` to `time()` instead of `0`
- Rename `emoji` to `reaction_type` across entity, provider, controller, and migration
- Add reaction type whitelist: `like`, `interested`, `recommend`, `miigwech`, `connect`
- Add `community_id` as required field for Post entity

## Test plan
- [x] All 581 PHPUnit tests pass (3 skipped, pre-existing)
- [x] New tests cover constructor validation, time defaults, reaction type whitelist
- [x] Controller tests updated for reaction_type rename and community_id requirement
- [x] Migration file created for emoji→reaction_type column rename

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)