### PR TITLE
feat(#410,#415): controller hardening — silent logging + bookmarkable filters

### DIFF
--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -25,7 +25,8 @@ final class FeedController
 
     public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $ctx = $this->buildContext($request, $query, $account);
+        $resolved = self::resolveFilter($query['filter'] ?? 'all');
+        $ctx = $this->buildContext($request, $query, $account, $resolved['filter']);
         $response = $this->assembler->assemble($ctx);
 
         $trending = $this->buildTrending($response);
@@ -41,6 +42,7 @@ final class FeedController
             'response' => $response,
             'nextCursor' => $response->nextCursor,
             'activeFilter' => $response->activeFilter,
+            'filterParam' => $resolved['filterParam'],
             'csrf_token' => $this->generateCsrfToken($request),
             'trending' => $trending,
             'upcoming_events' => $upcomingEvents,
@@ -164,14 +166,18 @@ final class FeedController
                                         'url' => '/' . $type . 's/' . ($entity->get('slug') ?? $entity->id()),
                                     ];
                                 }
-                            } catch (\Throwable) {
-                                // Entity missing — skip
+                            } catch (\PDOException $e) {
+                                error_log(sprintf('[FeedController::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+                            } catch (\RuntimeException $e) {
+                                error_log(sprintf('[FeedController::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
                             }
                         }
                     }
                 }
-            } catch (\Throwable) {
-                // Reaction storage unavailable — fall through to fallback
+            } catch (\PDOException $e) {
+                error_log(sprintf('[FeedController::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            } catch (\RuntimeException $e) {
+                error_log(sprintf('[FeedController::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             }
         }
 
@@ -226,7 +232,11 @@ final class FeedController
             }
 
             return $result;
-        } catch (\Throwable) {
+        } catch (\PDOException $e) {
+            error_log(sprintf('[FeedController::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            return [];
+        } catch (\RuntimeException $e) {
+            error_log(sprintf('[FeedController::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             return [];
         }
     }
@@ -294,7 +304,11 @@ final class FeedController
             usort($withDistance, fn(array $a, array $b): int => $a['distance'] <=> $b['distance']);
 
             return array_slice($withDistance, 0, 6);
-        } catch (\Throwable) {
+        } catch (\PDOException $e) {
+            error_log(sprintf('[FeedController::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            return [];
+        } catch (\RuntimeException $e) {
+            error_log(sprintf('[FeedController::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             return [];
         }
     }
@@ -345,7 +359,11 @@ final class FeedController
             }
 
             return $result;
-        } catch (\Throwable) {
+        } catch (\PDOException $e) {
+            error_log(sprintf('[FeedController::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            return [];
+        } catch (\RuntimeException $e) {
+            error_log(sprintf('[FeedController::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             return [];
         }
     }
@@ -409,7 +427,38 @@ final class FeedController
         return '?';
     }
 
-    private function buildContext(HttpRequest $request, array $query, ?AccountInterface $account = null): FeedContext
+    /**
+     * URL-friendly filter names mapped to internal entity type identifiers.
+     *
+     * @var array<string, string>
+     */
+    private const FILTER_MAP = [
+        'all' => 'all',
+        'event' => 'event',
+        'group' => 'group',
+        'business' => 'business',
+        'people' => 'resource_person',
+        'person' => 'resource_person',
+    ];
+
+    /**
+     * Resolve and validate the ?filter= query parameter.
+     *
+     * @return array{filterParam: string, filter: string} URL-facing param and internal entity type
+     */
+    public static function resolveFilter(string $filterParam): array
+    {
+        if (!array_key_exists($filterParam, self::FILTER_MAP)) {
+            $filterParam = 'all';
+        }
+
+        return [
+            'filterParam' => $filterParam,
+            'filter' => self::FILTER_MAP[$filterParam],
+        ];
+    }
+
+    private function buildContext(HttpRequest $request, array $query, ?AccountInterface $account = null, ?string $resolvedFilter = null): FeedContext
     {
         $locationCookie = $request->cookies->get('minoo_loc');
         $lat = null;
@@ -427,10 +476,12 @@ final class FeedController
 
         $isFirstVisit = $request->cookies->get('minoo_fv') === null;
 
+        $activeFilter = $resolvedFilter ?? self::resolveFilter($query['filter'] ?? 'all')['filter'];
+
         return new FeedContext(
             latitude: $lat,
             longitude: $lon,
-            activeFilter: $query['filter'] ?? 'all',
+            activeFilter: $activeFilter,
             cursor: $query['cursor'] ?? null,
             limit: min((int) ($query['limit'] ?? 20), 50),
             isFirstVisit: $isFirstVisit,

--- a/src/Feed/EntityLoaderService.php
+++ b/src/Feed/EntityLoaderService.php
@@ -80,7 +80,11 @@ class EntityLoaderService
     {
         try {
             $storage = $this->entityTypeManager->getStorage('featured_item');
-        } catch (\Throwable) {
+        } catch (\PDOException $e) {
+            error_log(sprintf('[EntityLoaderService::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            return [];
+        } catch (\RuntimeException $e) {
+            error_log(sprintf('[EntityLoaderService::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             return [];
         }
 
@@ -108,7 +112,11 @@ class EntityLoaderService
             try {
                 $refStorage = $this->entityTypeManager->getStorage($entityType);
                 $entity = $refStorage->load((int) $entityId);
-            } catch (\Throwable) {
+            } catch (\PDOException $e) {
+                error_log(sprintf('[EntityLoaderService::%s] Database error loading %s:%s: %s', __FUNCTION__, $entityType, $entityId, $e->getMessage()));
+                continue;
+            } catch (\RuntimeException $e) {
+                error_log(sprintf('[EntityLoaderService::%s] Runtime error loading %s:%s: %s', __FUNCTION__, $entityType, $entityId, $e->getMessage()));
                 continue;
             }
 
@@ -126,8 +134,12 @@ class EntityLoaderService
     {
         try {
             $storage = $this->entityTypeManager->getStorage('post');
-        } catch (\Throwable) {
+        } catch (\PDOException $e) {
+            error_log(sprintf('[EntityLoaderService::%s] Database error: %s', __FUNCTION__, $e->getMessage()));
+            return [];
+        } catch (\RuntimeException $e) {
             // Post entity type may not exist yet
+            error_log(sprintf('[EntityLoaderService::%s] Runtime error: %s', __FUNCTION__, $e->getMessage()));
             return [];
         }
 

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -91,46 +91,63 @@
     }, { rootMargin: '200px' });
     observer.observe(sentinel);
 
-    // Filter chips
-    document.querySelectorAll('.feed-chip').forEach(chip => {
-      chip.addEventListener('click', function() {
-        const type = this.dataset.type;
-        if (type === activeFilter) return;
+    function applyFilter(type) {
+      if (type === activeFilter) return;
 
-        activeFilter = type;
-        nextCursor = null;
-        feed.dataset.activeFilter = type;
-        feed.innerHTML = '';
-        seenIds.clear();
+      activeFilter = type;
+      nextCursor = null;
+      feed.dataset.activeFilter = type;
+      feed.innerHTML = '';
+      seenIds.clear();
+
+      // Reset sentinel
+      sentinel.innerHTML = '<div class="feed-card feed-card--loading" aria-hidden="true"><div class="feed-card__skeleton"></div></div>';
+
+      // Fetch first page with new filter
+      fetchToken++;
+      if (controller) controller.abort();
+      controller = new AbortController();
+      loading = false;
+
+      fetch('/api/feed?filter=' + encodeURIComponent(activeFilter), { signal: controller.signal })
+        .then(r => r.json())
+        .then(data => {
+          for (const item of data.items) {
+            if (seenIds.has(item.id)) continue;
+            seenIds.add(item.id);
+            feed.insertAdjacentHTML('beforeend', item.html);
+          }
+          nextCursor = data.nextCursor;
+          feed.dataset.nextCursor = nextCursor || '';
+          if (!nextCursor) {
+            sentinel.innerHTML = '<p class="feed-end">You\'re all caught up</p>';
+          }
+        })
+        .catch(e => { if (e.name !== 'AbortError') console.error(e); });
+    }
+
+    // Filter chips — pushState for bookmarkable URLs
+    document.querySelectorAll('.feed-chip').forEach(chip => {
+      chip.addEventListener('click', function(e) {
+        e.preventDefault();
+        const type = this.dataset.type;
+
+        history.pushState({ filter: type }, '', '?filter=' + encodeURIComponent(type));
 
         document.querySelectorAll('.feed-chip').forEach(c => c.classList.remove('feed-chip--active'));
         this.classList.add('feed-chip--active');
 
-        // Reset sentinel
-        sentinel.innerHTML = '<div class="feed-card feed-card--loading" aria-hidden="true"><div class="feed-card__skeleton"></div></div>';
-
-        // Fetch first page with new filter
-        fetchToken++;
-        if (controller) controller.abort();
-        controller = new AbortController();
-        loading = false;
-
-        fetch('/api/feed?filter=' + encodeURIComponent(activeFilter), { signal: controller.signal })
-          .then(r => r.json())
-          .then(data => {
-            for (const item of data.items) {
-              if (seenIds.has(item.id)) continue;
-              seenIds.add(item.id);
-              feed.insertAdjacentHTML('beforeend', item.html);
-            }
-            nextCursor = data.nextCursor;
-            feed.dataset.nextCursor = nextCursor || '';
-            if (!nextCursor) {
-              sentinel.innerHTML = '<p class="feed-end">You\'re all caught up</p>';
-            }
-          })
-          .catch(e => { if (e.name !== 'AbortError') console.error(e); });
+        applyFilter(type);
       });
+    });
+
+    // Back/forward navigation restores filter state
+    window.addEventListener('popstate', function(e) {
+      const filter = e.state?.filter || 'all';
+      document.querySelectorAll('.feed-chip').forEach(c => {
+        c.classList.toggle('feed-chip--active', c.dataset.type === filter);
+      });
+      applyFilter(filter);
     });
   })();
   </script>

--- a/tests/Minoo/Unit/Controller/FeedControllerFilterTest.php
+++ b/tests/Minoo/Unit/Controller/FeedControllerFilterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\FeedController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FeedController::class)]
+final class FeedControllerFilterTest extends TestCase
+{
+    #[Test]
+    public function filterQueryParamPassesToFeedContext(): void
+    {
+        $resolved = FeedController::resolveFilter('event');
+
+        $this->assertSame('event', $resolved['filterParam']);
+        $this->assertSame('event', $resolved['filter']);
+    }
+
+    #[Test]
+    public function invalidFilterDefaultsToAll(): void
+    {
+        $resolved = FeedController::resolveFilter('invalid');
+
+        $this->assertSame('all', $resolved['filterParam']);
+        $this->assertSame('all', $resolved['filter']);
+    }
+
+    #[Test]
+    public function peopleFilterMapsToResourcePerson(): void
+    {
+        $resolved = FeedController::resolveFilter('people');
+
+        $this->assertSame('people', $resolved['filterParam']);
+        $this->assertSame('resource_person', $resolved['filter']);
+    }
+
+    #[Test]
+    public function personFilterAlsoMapsToResourcePerson(): void
+    {
+        $resolved = FeedController::resolveFilter('person');
+
+        $this->assertSame('person', $resolved['filterParam']);
+        $this->assertSame('resource_person', $resolved['filter']);
+    }
+
+    #[Test]
+    public function businessFilterMapsCorrectly(): void
+    {
+        $resolved = FeedController::resolveFilter('business');
+
+        $this->assertSame('business', $resolved['filterParam']);
+        $this->assertSame('business', $resolved['filter']);
+    }
+
+    #[Test]
+    public function groupFilterMapsCorrectly(): void
+    {
+        $resolved = FeedController::resolveFilter('group');
+
+        $this->assertSame('group', $resolved['filterParam']);
+        $this->assertSame('group', $resolved['filter']);
+    }
+
+    #[Test]
+    public function allFilterMapsCorrectly(): void
+    {
+        $resolved = FeedController::resolveFilter('all');
+
+        $this->assertSame('all', $resolved['filterParam']);
+        $this->assertSame('all', $resolved['filter']);
+    }
+}

--- a/tests/Minoo/Unit/Controller/FeedControllerLoggingTest.php
+++ b/tests/Minoo/Unit/Controller/FeedControllerLoggingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\FeedController;
+use Minoo\Feed\FeedAssemblerInterface;
+use Minoo\Feed\FeedContext;
+use Minoo\Feed\FeedResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+#[CoversClass(FeedController::class)]
+final class FeedControllerLoggingTest extends TestCase
+{
+    #[Test]
+    public function buildTrendingLogsAndReturnsEmptyOnPdoException(): void
+    {
+        $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $etm = $this->createMock(EntityTypeManager::class);
+
+        $etm->method('hasDefinition')->with('reaction')->willReturn(true);
+        $etm->method('getStorage')->with('reaction')->willThrowException(
+            new \PDOException('Connection refused')
+        );
+
+        $controller = new FeedController($assembler, $twig, $etm);
+
+        $method = new \ReflectionMethod($controller, 'buildTrending');
+
+        $response = new FeedResponse(items: [], nextCursor: null, activeFilter: 'all');
+
+        $result = $method->invoke($controller, $response);
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function buildUpcomingEventsLogsAndReturnsEmptyOnRuntimeException(): void
+    {
+        $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $etm = $this->createMock(EntityTypeManager::class);
+
+        $etm->method('hasDefinition')->with('event')->willReturn(true);
+        $etm->method('getStorage')->with('event')->willThrowException(
+            new \RuntimeException('Storage unavailable')
+        );
+
+        $controller = new FeedController($assembler, $twig, $etm);
+
+        $method = new \ReflectionMethod($controller, 'buildUpcomingEvents');
+
+        $result = $method->invoke($controller);
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function buildSuggestedCommunitiesLogsAndReturnsEmptyOnPdoException(): void
+    {
+        $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $etm = $this->createMock(EntityTypeManager::class);
+
+        $etm->method('hasDefinition')->with('community')->willReturn(true);
+        $etm->method('getStorage')->with('community')->willThrowException(
+            new \PDOException('Disk full')
+        );
+
+        $controller = new FeedController($assembler, $twig, $etm);
+
+        $method = new \ReflectionMethod($controller, 'buildSuggestedCommunities');
+
+        $result = $method->invoke($controller, 46.0, -81.0);
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function buildFollowedCommunitiesLogsAndReturnsEmptyOnRuntimeException(): void
+    {
+        $assembler = $this->createMock(FeedAssemblerInterface::class);
+        $twig = $this->createMock(Environment::class);
+        $etm = $this->createMock(EntityTypeManager::class);
+
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(true);
+        $account->method('id')->willReturn(1);
+
+        $etm->method('hasDefinition')->with('follow')->willReturn(true);
+        $etm->method('getStorage')->with('follow')->willThrowException(
+            new \RuntimeException('Follow storage broken')
+        );
+
+        $controller = new FeedController($assembler, $twig, $etm);
+
+        $method = new \ReflectionMethod($controller, 'buildFollowedCommunities');
+
+        $result = $method->invoke($controller, $account);
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- **Silent failure logging (#410):** Narrowed 8 `catch(\Throwable)` blocks to `catch(\PDOException|\RuntimeException)` with `error_log()` in `FeedController` (5 sites) and `EntityLoaderService` (3 sites). Errors are now logged with class/method context instead of silently swallowed.
- **Bookmarkable filter URLs (#415):** Added `FILTER_MAP` constant and `resolveFilter()` static method for validating `?filter=` query params. Invalid filters default to `all`. URL param `people` maps to internal `resource_person`. Added `pushState`/`popstate` JS for browser history integration.
- **Tests:** 11 new unit tests — 4 logging tests (verify graceful degradation on PDO/Runtime exceptions) and 7 filter mapping tests.

## Test plan
- [x] `./vendor/bin/phpunit` — 549 tests, 1361 assertions, all passing
- [x] `http://localhost:8081/?filter=event` — returns 200
- [x] `http://localhost:8081/?filter=people` — returns 200
- [x] `http://localhost:8081/?filter=invalid` — returns 200 (defaults to all)

Closes #410, closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)