### PR TITLE
feat(#456): EmailVerificationService — token create/validate/consume

### DIFF
--- a/src/Support/EmailVerificationService.php
+++ b/src/Support/EmailVerificationService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+final class EmailVerificationService
+{
+    private bool $tableEnsured = false;
+
+    public function __construct(private readonly \PDO $pdo) {}
+
+    /**
+     * Create a verification token for a user. Invalidates any existing token for that user.
+     * Returns the 64-char hex token string.
+     */
+    public function createToken(int|string $userId): string
+    {
+        $this->ensureTable();
+        // Delete existing tokens for this user
+        $stmt = $this->pdo->prepare('DELETE FROM email_verification_tokens WHERE user_id = :uid');
+        $stmt->execute(['uid' => $userId]);
+        // Generate new token
+        $token = bin2hex(random_bytes(32)); // 64-char hex
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO email_verification_tokens (token, user_id, expires_at, used_at) VALUES (:token, :uid, :expires, NULL)'
+        );
+        $stmt->execute([
+            'token' => $token,
+            'uid' => $userId,
+            'expires' => time() + 86400, // 24 hours
+        ]);
+
+        return $token;
+    }
+
+    /**
+     * Validate a token. Returns user_id if valid, null otherwise.
+     * Valid = exists, not expired, not used.
+     */
+    public function validateToken(string $token): int|string|null
+    {
+        $this->ensureTable();
+        $stmt = $this->pdo->prepare(
+            'SELECT user_id FROM email_verification_tokens WHERE token = :token AND expires_at > :now AND used_at IS NULL'
+        );
+        $stmt->execute(['token' => $token, 'now' => time()]);
+        $result = $stmt->fetchColumn();
+
+        return $result !== false ? $result : null;
+    }
+
+    /**
+     * Mark a token as used (consumed).
+     */
+    public function consumeToken(string $token): void
+    {
+        $this->ensureTable();
+        $stmt = $this->pdo->prepare('UPDATE email_verification_tokens SET used_at = :now WHERE token = :token');
+        $stmt->execute(['token' => $token, 'now' => time()]);
+    }
+
+    private function ensureTable(): void
+    {
+        if ($this->tableEnsured) {
+            return;
+        }
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS email_verification_tokens ('
+            . 'token TEXT PRIMARY KEY, '
+            . 'user_id TEXT NOT NULL, '
+            . 'expires_at INTEGER NOT NULL, '
+            . 'used_at INTEGER'
+            . ')'
+        );
+        $this->tableEnsured = true;
+    }
+}

--- a/tests/Minoo/Unit/Support/EmailVerificationServiceTest.php
+++ b/tests/Minoo/Unit/Support/EmailVerificationServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Support;
+
+use Minoo\Support\EmailVerificationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EmailVerificationService::class)]
+final class EmailVerificationServiceTest extends TestCase
+{
+    private \PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+    }
+
+    #[Test]
+    public function create_token_returns_64_char_hex(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        $token = $service->createToken(1);
+        self::assertSame(64, strlen($token));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    #[Test]
+    public function validate_token_returns_user_id(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        $token = $service->createToken(42);
+        self::assertEquals(42, $service->validateToken($token));
+    }
+
+    #[Test]
+    public function validate_token_returns_null_for_invalid_token(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        self::assertNull($service->validateToken('nonexistent'));
+    }
+
+    #[Test]
+    public function create_token_invalidates_previous_token_for_same_user(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        $token1 = $service->createToken(1);
+        $token2 = $service->createToken(1);
+        self::assertNull($service->validateToken($token1));
+        self::assertEquals(1, $service->validateToken($token2));
+    }
+
+    #[Test]
+    public function consume_token_marks_it_as_used(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        $token = $service->createToken(1);
+        $service->consumeToken($token);
+        self::assertNull($service->validateToken($token));
+    }
+
+    #[Test]
+    public function expired_token_returns_null(): void
+    {
+        $service = new EmailVerificationService($this->pdo);
+        $service->createToken(1); // ensures table exists
+        $this->pdo->exec('DELETE FROM email_verification_tokens');
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO email_verification_tokens (token, user_id, expires_at, used_at) VALUES (:token, :uid, :expires, NULL)'
+        );
+        $stmt->execute(['token' => 'expired-token', 'uid' => 1, 'expires' => time() - 1]);
+        self::assertNull($service->validateToken('expired-token'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EmailVerificationService` mirroring `PasswordResetService` pattern with 24-hour token expiry
- Table: `email_verification_tokens` (auto-created via `ensureTable()`)
- Methods: `createToken()`, `validateToken()`, `consumeToken()`
- 6 unit tests covering token generation, validation, invalidation, consumption, and expiry

Closes #456

## Test plan
- [x] `create_token_returns_64_char_hex` — verifies 64-char hex output
- [x] `validate_token_returns_user_id` — round-trip create/validate
- [x] `validate_token_returns_null_for_invalid_token` — nonexistent token
- [x] `create_token_invalidates_previous_token_for_same_user` — old token nullified
- [x] `consume_token_marks_it_as_used` — consumed token returns null
- [x] `expired_token_returns_null` — manually expired token via PDO
- [x] Full suite: 628 tests, 1558 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)