### PR TITLE
feat(#455): email Twig templates for auth flows

### DIFF
--- a/templates/email/email-verification.html.twig
+++ b/templates/email/email-verification.html.twig
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your email for Minoo</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f0; padding: 32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+          <tr>
+            <td style="background-color: #2d5016; padding: 24px 32px;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 20px; font-weight: 600;">Minoo</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Boozhoo {{ user_name }},
+              </p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Miigwech for signing up. Please verify your email address so we know it's really you.
+              </p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
+                <tr>
+                  <td style="border-radius: 6px; background-color: #2d5016;">
+                    <a href="{{ verify_url }}" style="display: inline-block; padding: 12px 24px; color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none;">Verify your email</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: #666666;">
+                If you didn't create a Minoo account, no action is needed — this email will expire on its own.
+              </p>
+              <p style="margin: 0; font-size: 14px; line-height: 1.5; color: #666666;">
+                If the button doesn't work, copy and paste this link into your browser:
+              </p>
+              <p style="margin: 8px 0 0; font-size: 13px; line-height: 1.5; color: #2d5016; word-break: break-all;">
+                {{ verify_url }}
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 32px; background-color: #f5f5f0; border-top: 1px solid #e0e0d8;">
+              <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #999999; text-align: center;">
+                Minoo — built by and for our communities.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/email/email-verification.txt.twig
+++ b/templates/email/email-verification.txt.twig
@@ -1,0 +1,10 @@
+Boozhoo {{ user_name }},
+
+Miigwech for signing up. Please verify your email address by visiting the link below:
+
+{{ verify_url }}
+
+If you didn't create a Minoo account, no action is needed — this email will expire on its own.
+
+--
+Minoo — built by and for our communities.

--- a/templates/email/password-reset.html.twig
+++ b/templates/email/password-reset.html.twig
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset your Minoo password</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f0; padding: 32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+          <tr>
+            <td style="background-color: #2d5016; padding: 24px 32px;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 20px; font-weight: 600;">Minoo</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Boozhoo {{ user_name }},
+              </p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5; color: #333333;">
+                We received a request to reset your password. Click the button below to choose a new one.
+              </p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
+                <tr>
+                  <td style="border-radius: 6px; background-color: #2d5016;">
+                    <a href="{{ reset_url }}" style="display: inline-block; padding: 12px 24px; color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none;">Reset your password</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: #666666;">
+                This link expires in 60 minutes. If you didn't request a password reset, you can safely ignore this email — your account is still secure.
+              </p>
+              <p style="margin: 0; font-size: 14px; line-height: 1.5; color: #666666;">
+                If the button doesn't work, copy and paste this link into your browser:
+              </p>
+              <p style="margin: 8px 0 0; font-size: 13px; line-height: 1.5; color: #2d5016; word-break: break-all;">
+                {{ reset_url }}
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 32px; background-color: #f5f5f0; border-top: 1px solid #e0e0d8;">
+              <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #999999; text-align: center;">
+                Minoo — built by and for our communities.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/email/password-reset.txt.twig
+++ b/templates/email/password-reset.txt.twig
@@ -1,0 +1,10 @@
+Boozhoo {{ user_name }},
+
+We received a request to reset your Minoo password. Visit the link below to choose a new one:
+
+{{ reset_url }}
+
+This link expires in 60 minutes. If you didn't request a password reset, you can safely ignore this email — your account is still secure.
+
+--
+Minoo — built by and for our communities.

--- a/templates/email/welcome.html.twig
+++ b/templates/email/welcome.html.twig
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to Minoo</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f0; padding: 32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+          <tr>
+            <td style="background-color: #2d5016; padding: 24px 32px;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 20px; font-weight: 600;">Minoo</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Boozhoo {{ user_name }},
+              </p>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Welcome to Minoo. We're glad you're here.
+              </p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5; color: #333333;">
+                Minoo is a place to connect with your community — find events, explore Teachings, learn Anishinaabemowin, and support our Elders. Everything here is built by and for our communities.
+              </p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
+                <tr>
+                  <td style="border-radius: 6px; background-color: #2d5016;">
+                    <a href="{{ home_url }}" style="display: inline-block; padding: 12px 24px; color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none;">Explore Minoo</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0; font-size: 14px; line-height: 1.5; color: #666666;">
+                If you have questions or need help, reach out to your community coordinator.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 32px; background-color: #f5f5f0; border-top: 1px solid #e0e0d8;">
+              <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #999999; text-align: center;">
+                Minoo — built by and for our communities.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/email/welcome.txt.twig
+++ b/templates/email/welcome.txt.twig
@@ -1,0 +1,12 @@
+Boozhoo {{ user_name }},
+
+Welcome to Minoo. We're glad you're here.
+
+Minoo is a place to connect with your community — find events, explore Teachings, learn Anishinaabemowin, and support our Elders. Everything here is built by and for our communities.
+
+Start exploring: {{ home_url }}
+
+If you have questions or need help, reach out to your community coordinator.
+
+--
+Minoo — built by and for our communities.


### PR DESCRIPTION
## Summary
- Add 6 email Twig templates (HTML + plain text pairs) for password reset, email verification, and welcome flows
- Templates use community voice per content-tone-guide.md: first-person plural, Anishinaabemowin greetings (Boozhoo, Miigwech), capitalized cultural terms
- Simple inline CSS with system font stack, 600px max-width, `#2d5016` brand color buttons

Closes #455

## Test plan
- [ ] Verify templates render correctly with Twig (covered by AuthMailer integration tests in Unit 3)
- [ ] Confirm HTML emails display properly in common email clients
- [ ] Confirm plain text fallbacks are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)