### PR TITLE
fix(#459): remove stale volunteer role from test helper

### DIFF
--- a/tests/Minoo/Unit/Controller/AuthControllerTest.php
+++ b/tests/Minoo/Unit/Controller/AuthControllerTest.php
@@ -321,7 +321,7 @@ final class AuthControllerTest extends TestCase
             'uid' => 1,
             'name' => 'Mary',
             'mail' => 'mary@example.com',
-            'roles' => ['volunteer'],
+            'roles' => [],
             'status' => 1,
         ]);
         $user->setRawPassword('password123');


### PR DESCRIPTION
## Summary

- Registration already creates users with empty roles array (no volunteer auto-creation)
- Aligns test helper `createSuccessfulUser()` to match production behavior

Closes #459

## Test plan

- [x] 11/11 AuthController tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)