### PR TITLE
feat: add images field to Post entity

### DIFF
--- a/migrations/20260322_200000_add_images_to_post.php
+++ b/migrations/20260322_200000_add_images_to_post.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Add images column to the post table for image upload support.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        $schema->getConnection()->executeStatement(
+            "ALTER TABLE post ADD COLUMN images TEXT DEFAULT '[]'",
+        );
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // SQLite < 3.35 doesn't support DROP COLUMN
+    }
+};

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -25,6 +25,9 @@ final class Post extends ContentEntityBase
             }
         }
 
+        if (!array_key_exists('images', $values)) {
+            $values['images'] = '[]';
+        }
         if (!array_key_exists('status', $values)) {
             $values['status'] = 1;
         }

--- a/src/Provider/EngagementServiceProvider.php
+++ b/src/Provider/EngagementServiceProvider.php
@@ -116,6 +116,11 @@ final class EngagementServiceProvider extends ServiceProvider
                     'label' => 'Community ID',
                     'weight' => 2,
                 ],
+                'images' => [
+                    'type' => 'text_long',
+                    'label' => 'Images',
+                    'weight' => 3,
+                ],
                 'status' => [
                     'type' => 'boolean',
                     'label' => 'Published',


### PR DESCRIPTION
## Summary
- Add `images` text_long field to post entity type definition in `EngagementServiceProvider`
- Default `images` to `'[]'` (empty JSON array) in `Post` constructor
- Create migration `20260322_200000_add_images_to_post.php` adding the column to SQLite

## Test plan
- [ ] Run `./vendor/bin/phpunit` — all existing Post tests pass with new default field
- [ ] Verify migration applies cleanly: `bin/waaseyaa migrate`
- [ ] Verify schema check passes: `bin/waaseyaa schema:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)