### PR TITLE
feat: add UploadService for image upload support

### DIFF
--- a/src/Support/UploadService.php
+++ b/src/Support/UploadService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+final class UploadService
+{
+    private const int MAX_SIZE = 5_242_880; // 5MB
+
+    private const array ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+    public function __construct(private readonly string $basePath) {}
+
+    /** @return string[] validation errors */
+    public function validateImage(array $file): array
+    {
+        $errors = [];
+
+        if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            $errors[] = 'Upload failed.';
+
+            return $errors;
+        }
+
+        if (($file['size'] ?? 0) > self::MAX_SIZE) {
+            $errors[] = 'Image must be under 5MB.';
+        }
+
+        if (! in_array($file['type'] ?? '', self::ALLOWED_TYPES, true)) {
+            $errors[] = 'Only JPEG, PNG, GIF, and WebP images are allowed.';
+        }
+
+        return $errors;
+    }
+
+    public function generateSafeFilename(string $original): string
+    {
+        $ext = strtolower(pathinfo($original, PATHINFO_EXTENSION));
+        $name = pathinfo($original, PATHINFO_FILENAME);
+        $safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', $name);
+        $safe = trim($safe, '_');
+
+        if ($safe === '') {
+            $safe = 'upload';
+        }
+
+        return $safe . '_' . bin2hex(random_bytes(4)) . '.' . ($ext ?: 'jpg');
+    }
+
+    /** @return string relative path from basePath */
+    public function moveUpload(array $file, string $subdir): string
+    {
+        $targetDir = $this->basePath . '/' . $subdir;
+
+        if (! is_dir($targetDir)) {
+            mkdir($targetDir, 0755, true);
+        }
+
+        $filename = $this->generateSafeFilename($file['name'] ?? 'upload.jpg');
+        $targetPath = $targetDir . '/' . $filename;
+        move_uploaded_file($file['tmp_name'], $targetPath);
+
+        return $subdir . '/' . $filename;
+    }
+
+    public function deleteDirectory(string $subdir): void
+    {
+        $dir = $this->basePath . '/' . $subdir;
+
+        if (! is_dir($dir)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Minoo/Unit/Support/UploadServiceTest.php
+++ b/tests/Minoo/Unit/Support/UploadServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Support;
+
+use Minoo\Support\UploadService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(UploadService::class)]
+final class UploadServiceTest extends TestCase
+{
+    private UploadService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new UploadService(sys_get_temp_dir() . '/upload_test_' . bin2hex(random_bytes(4)));
+    }
+
+    #[Test]
+    public function validate_rejects_oversized_file(): void
+    {
+        $file = [
+            'error' => UPLOAD_ERR_OK,
+            'size' => 6_000_000,
+            'type' => 'image/jpeg',
+        ];
+
+        $errors = $this->service->validateImage($file);
+
+        self::assertContains('Image must be under 5MB.', $errors);
+    }
+
+    #[Test]
+    public function validate_rejects_non_image(): void
+    {
+        $file = [
+            'error' => UPLOAD_ERR_OK,
+            'size' => 1024,
+            'type' => 'application/pdf',
+        ];
+
+        $errors = $this->service->validateImage($file);
+
+        self::assertContains('Only JPEG, PNG, GIF, and WebP images are allowed.', $errors);
+    }
+
+    #[Test]
+    public function validate_accepts_valid_image(): void
+    {
+        $file = [
+            'error' => UPLOAD_ERR_OK,
+            'size' => 1024,
+            'type' => 'image/jpeg',
+        ];
+
+        $errors = $this->service->validateImage($file);
+
+        self::assertSame([], $errors);
+    }
+
+    #[Test]
+    public function generate_safe_filename_strips_unsafe_chars(): void
+    {
+        $filename = $this->service->generateSafeFilename('../my photo (1).png');
+
+        self::assertMatchesRegularExpression('/^my_photo__1_[a-f0-9]{8}\.png$/', $filename);
+        self::assertStringNotContainsString('..', $filename);
+        self::assertStringNotContainsString(' ', $filename);
+        self::assertStringEndsWith('.png', $filename);
+    }
+
+    #[Test]
+    public function validate_rejects_upload_error(): void
+    {
+        $file = [
+            'error' => UPLOAD_ERR_PARTIAL,
+            'size' => 1024,
+            'type' => 'image/jpeg',
+        ];
+
+        $errors = $this->service->validateImage($file);
+
+        self::assertContains('Upload failed.', $errors);
+        self::assertCount(1, $errors);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UploadService` in `src/Support/` with image validation (type, size, error), safe filename generation, file move, and directory cleanup
- Add 5 unit tests covering all validation paths and filename sanitization
- All 645 tests pass (3 pre-existing skips)

## Test plan
- [x] `validate_rejects_oversized_file` — file over 5MB returns error
- [x] `validate_rejects_non_image` — non-image MIME type returns error
- [x] `validate_accepts_valid_image` — valid JPEG returns no errors
- [x] `generate_safe_filename_strips_unsafe_chars` — path traversal and special chars stripped
- [x] `validate_rejects_upload_error` — PHP upload error code returns early

🤖 Generated with [Claude Code](https://claude.com/claude-code)