### PR TITLE
feat: add image upload support to post creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.sqlite.*.bak
 .env
 storage/geoip/
+storage/uploads/
 .phpunit.cache/
 storage/phpstan/
 .playwright-mcp/

--- a/migrations/20260322_200000_add_images_to_post.php
+++ b/migrations/20260322_200000_add_images_to_post.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Add images column to the post table for storing JSON array of image paths.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        $connection = $schema->getConnection();
+
+        $connection->executeStatement(<<<'SQL'
+            ALTER TABLE post ADD COLUMN images TEXT DEFAULT NULL
+        SQL);
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // SQLite does not support DROP COLUMN before 3.35.0.
+        // For older versions, this is a no-op.
+        $connection = $schema->getConnection();
+
+        try {
+            $connection->executeStatement(<<<'SQL'
+                ALTER TABLE post DROP COLUMN images
+            SQL);
+        } catch (\PDOException) {
+            // Ignore if SQLite version doesn't support DROP COLUMN
+        }
+    }
+};

--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -3694,6 +3694,83 @@
     margin: 0;
   }
 
+  .feed-create__actions-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+
+  .feed-create__photo-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3xs);
+    padding: var(--space-3xs) var(--space-2xs);
+    background: none;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-family: var(--font-body);
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+
+  .feed-create__photo-btn:hover {
+    background-color: var(--surface-raised);
+    color: var(--text-primary);
+  }
+
+  .feed-create__previews {
+    display: flex;
+    gap: var(--space-2xs);
+    padding-block: var(--space-2xs);
+    overflow-x: auto;
+  }
+
+  .feed-create__preview {
+    position: relative;
+    flex-shrink: 0;
+    inline-size: 80px;
+    block-size: 80px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .feed-create__preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .feed-create__preview-remove {
+    position: absolute;
+    inset-block-start: 2px;
+    inset-inline-end: 2px;
+    inline-size: 22px;
+    block-size: 22px;
+    border-radius: 50%;
+    border: none;
+    background: oklch(0.2 0 0 / 0.7);
+    color: #fff;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .feed-create__preview-remove:hover {
+    background: oklch(0.15 0 0 / 0.9);
+  }
+
+  .feed-create__image-error {
+    color: var(--color-error, oklch(0.6 0.2 25));
+    font-size: 0.8rem;
+    margin: 0;
+    padding-block-start: var(--space-3xs);
+  }
+
   /* ── Feed Cards — Community-Attributed Design ── */
   .feed-card {
     background-color: var(--surface-card);
@@ -3717,6 +3794,27 @@
     font-size: var(--text-sm);
     line-height: var(--leading-normal);
     color: var(--text-secondary);
+  }
+
+  /* Post image grid */
+  .feed-card__images {
+    display: grid;
+    gap: 2px;
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-block-start: var(--space-sm);
+  }
+
+  .feed-card__images--1 { grid-template-columns: 1fr; }
+  .feed-card__images--2 { grid-template-columns: 1fr 1fr; }
+  .feed-card__images--3 { grid-template-columns: 1fr 1fr; }
+  .feed-card__images--4 { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; }
+
+  .feed-card__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    max-height: 300px;
   }
 
   /* Attribution row */

--- a/public/uploads
+++ b/public/uploads
@@ -1,0 +1,1 @@
+../storage/uploads

--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minoo\Controller;
 
 use Minoo\Entity\Reaction;
+use Minoo\Support\UploadService;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
@@ -18,8 +19,11 @@ final class EngagementController
         'oral_history', 'dictionary_entry', 'cultural_collection',
     ];
 
+    private const MAX_IMAGES = 4;
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
+        private readonly UploadService $uploadService,
     ) {}
 
     public function react(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -213,15 +217,28 @@ final class EngagementController
 
     public function createPost(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        $data = $this->jsonBody($request);
+        $contentType = $request->headers->get('Content-Type', '');
+        if (str_contains($contentType, 'application/json')) {
+            $data = $this->jsonBody($request);
+            $body = trim((string) ($data['body'] ?? ''));
+            $communityId = $data['community_id'] ?? null;
+            $uploadedFiles = [];
+        } else {
+            $body = trim((string) $request->request->get('body', ''));
+            $communityId = $request->request->get('community_id');
+            $uploadedFiles = $request->files->all('images') ?: [];
+        }
 
-        if (!isset($data['body'], $data['community_id'])) {
+        if ($body === '' || $communityId === null || $communityId === '') {
             return $this->json(['error' => 'Missing required fields: body, community_id'], 422);
         }
 
-        $body = trim($data['body']);
-        if ($body === '' || mb_strlen($body) > 5000) {
+        if (mb_strlen($body) > 5000) {
             return $this->json(['error' => 'Body must be 1-5000 characters'], 422);
+        }
+
+        if (count($uploadedFiles) > self::MAX_IMAGES) {
+            return $this->json(['error' => 'Maximum ' . self::MAX_IMAGES . ' images allowed'], 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('post');
@@ -230,16 +247,38 @@ final class EngagementController
             $entity = $storage->create([
                 'body' => $body,
                 'user_id' => $account->id(),
-                'community_id' => (int) $data['community_id'],
+                'community_id' => (int) $communityId,
             ]);
             $storage->save($entity);
         } catch (\InvalidArgumentException) {
             return $this->json(['error' => 'Invalid entity data'], 422);
         }
 
+        // Process uploaded images after entity creation (need entity ID for directory)
+        $imagePaths = [];
+        foreach ($uploadedFiles as $file) {
+            $fileArray = [
+                'name' => $file->getClientOriginalName(),
+                'tmp_name' => $file->getPathname(),
+                'size' => $file->getSize(),
+                'type' => $file->getMimeType(),
+                'error' => $file->getError(),
+            ];
+
+            if ($this->uploadService->validateImage($fileArray) === []) {
+                $imagePaths[] = $this->uploadService->moveUpload($fileArray, 'posts/' . $entity->id());
+            }
+        }
+
+        if ($imagePaths !== []) {
+            $entity->set('images', json_encode($imagePaths, JSON_THROW_ON_ERROR));
+            $storage->save($entity);
+        }
+
         return $this->json([
             'id' => $entity->id(),
             'body' => $entity->get('body'),
+            'images' => $imagePaths,
             'created_at' => $entity->get('created_at'),
         ], 201);
     }
@@ -259,6 +298,7 @@ final class EngagementController
         }
 
         $storage->delete([$entity]);
+        $this->uploadService->deleteDirectory('posts/' . $id);
 
         return $this->json(['deleted' => true]);
     }

--- a/src/Feed/FeedItemFactory.php
+++ b/src/Feed/FeedItemFactory.php
@@ -308,6 +308,22 @@ final class FeedItemFactory
         $id = 'post:' . $entity->id();
         $communityId = $entity->get('community_id');
 
+        $images = [];
+        $imagesJson = $entity->get('images');
+        if ($imagesJson !== null && $imagesJson !== '') {
+            try {
+                $decoded = json_decode((string) $imagesJson, true, 4, JSON_THROW_ON_ERROR);
+                $images = is_array($decoded) ? $decoded : [];
+            } catch (\JsonException) {
+                // Ignore malformed JSON
+            }
+        }
+
+        $payload = [];
+        if ($images !== []) {
+            $payload['images'] = $images;
+        }
+
         return new FeedItem(
             id: $id,
             type: 'post',
@@ -324,6 +340,7 @@ final class FeedItemFactory
             communitySlug: $this->resolveCommunitySlug($communityId),
             communityInitial: $this->resolveCommunityInitial($communityId),
             communityName: $entity->get('community_name'),
+            payload: $payload,
         );
     }
 }

--- a/src/Provider/EngagementServiceProvider.php
+++ b/src/Provider/EngagementServiceProvider.php
@@ -8,6 +8,7 @@ use Minoo\Entity\Comment;
 use Minoo\Entity\Follow;
 use Minoo\Entity\Post;
 use Minoo\Entity\Reaction;
+use Minoo\Support\UploadService;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -18,6 +19,11 @@ final class EngagementServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->singleton(UploadService::class, function (): UploadService {
+            $projectRoot = $this->config['app_root'] ?? dirname(__DIR__, 2);
+            return new UploadService($projectRoot . '/storage/uploads');
+        });
+
         $this->entityType(new EntityType(
             id: 'reaction',
             label: 'Reaction',
@@ -126,6 +132,11 @@ final class EngagementServiceProvider extends ServiceProvider
                     'type' => 'timestamp',
                     'label' => 'Created',
                     'weight' => 10,
+                ],
+                'images' => [
+                    'type' => 'text_long',
+                    'label' => 'Images',
+                    'weight' => 6,
                 ],
                 'updated_at' => [
                     'type' => 'timestamp',

--- a/src/Support/UploadService.php
+++ b/src/Support/UploadService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+final class UploadService
+{
+    private const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
+    private const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+    public function __construct(
+        private readonly string $uploadRoot,
+    ) {}
+
+    /**
+     * Validate an uploaded image file.
+     *
+     * @param array{name: string, tmp_name: string, size: int, type: string, error: int} $file
+     * @return list<string> Validation errors (empty = valid)
+     */
+    public function validateImage(array $file): array
+    {
+        $errors = [];
+
+        if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            $errors[] = 'Upload failed';
+            return $errors;
+        }
+
+        if (($file['size'] ?? 0) > self::MAX_IMAGE_SIZE) {
+            $errors[] = 'Image must be under 5 MB';
+        }
+
+        $mime = $file['type'] ?? '';
+        if (!in_array($mime, self::ALLOWED_MIME_TYPES, true)) {
+            $errors[] = 'Only JPEG, PNG, GIF, and WebP images are allowed';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Move an uploaded file to the uploads directory.
+     *
+     * @param array{name: string, tmp_name: string, size: int, type: string, error: int} $file
+     * @param string $subdirectory e.g. "posts/42"
+     * @return string Relative path from uploads root (e.g. "posts/42/abc123.jpg")
+     */
+    public function moveUpload(array $file, string $subdirectory): string
+    {
+        $dir = rtrim($this->uploadRoot, '/') . '/' . trim($subdirectory, '/');
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+
+        $ext = $this->extensionFromMime($file['type'] ?? '');
+        $filename = bin2hex(random_bytes(8)) . $ext;
+        $destination = $dir . '/' . $filename;
+
+        $tmpName = $file['tmp_name'] ?? '';
+
+        if (is_uploaded_file($tmpName)) {
+            move_uploaded_file($tmpName, $destination);
+        } else {
+            // Fallback for testing or non-standard environments
+            copy($tmpName, $destination);
+        }
+
+        return trim($subdirectory, '/') . '/' . $filename;
+    }
+
+    /**
+     * Delete all files in a subdirectory (e.g. when deleting a post).
+     */
+    public function deleteDirectory(string $subdirectory): void
+    {
+        $dir = rtrim($this->uploadRoot, '/') . '/' . trim($subdirectory, '/');
+
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = glob($dir . '/*');
+        if ($files !== false) {
+            foreach ($files as $file) {
+                if (is_file($file)) {
+                    unlink($file);
+                }
+            }
+        }
+
+        @rmdir($dir);
+    }
+
+    private function extensionFromMime(string $mime): string
+    {
+        return match ($mime) {
+            'image/jpeg' => '.jpg',
+            'image/png' => '.png',
+            'image/gif' => '.gif',
+            'image/webp' => '.webp',
+            default => '.bin',
+        };
+    }
+}

--- a/templates/components/feed-card.html.twig
+++ b/templates/components/feed-card.html.twig
@@ -30,6 +30,14 @@
       </div>
     </div>
     <p class="feed-card__body">{{ item.meta|default('') }}</p>
+    {% set post_images = item.payload.images|default([]) %}
+    {% if post_images|length > 0 %}
+      <div class="feed-card__images feed-card__images--{{ min(post_images|length, 4) }}">
+        {% for img in post_images|slice(0, 4) %}
+          <img src="/uploads/{{ img }}" alt="" class="feed-card__image" loading="lazy">
+        {% endfor %}
+      </div>
+    {% endif %}
     {% include "components/feed-engagement.html.twig" with { item: item } only %}
   </article>
 {% else %}

--- a/templates/components/feed-create-post.html.twig
+++ b/templates/components/feed-create-post.html.twig
@@ -4,15 +4,24 @@
       <div class="feed-create__avatar">{{ account_initial }}</div>
       <span class="feed-create__placeholder">{{ trans('feed.whats_happening') }}</span>
     </div>
-    <form class="feed-create__form" id="create-post-form" action="/api/engagement/post" method="post" hidden>
+    <form class="feed-create__form" id="create-post-form" action="/api/engagement/post" method="post" enctype="multipart/form-data" hidden>
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <textarea class="feed-create__textarea" name="body" placeholder="{{ trans('feed.whats_happening') }}" maxlength="5000" required></textarea>
+      <input type="file" id="post-image-input" accept="image/jpeg,image/png,image/gif,image/webp" multiple hidden>
+      <div class="feed-create__previews" id="post-image-previews" hidden></div>
+      <p class="feed-create__image-error" id="post-image-error" hidden></p>
       <div class="feed-create__actions">
-        <select name="community_id" class="feed-create__community" required>
-          {% for community in user_communities|default([]) %}
-            <option value="{{ community.id }}"{% if community.is_default|default(false) %} selected{% endif %}>{{ community.name }}</option>
-          {% endfor %}
-        </select>
+        <div class="feed-create__actions-left">
+          <button type="button" class="feed-create__photo-btn" id="post-photo-btn" aria-label="Add photos">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+            <span>Photo</span>
+          </button>
+          <select name="community_id" class="feed-create__community" required>
+            {% for community in user_communities|default([]) %}
+              <option value="{{ community.id }}"{% if community.is_default|default(false) %} selected{% endif %}>{{ community.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
         <button type="submit" class="btn btn--primary">{{ trans('feed.post') }}</button>
       </div>
     </form>

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -239,11 +239,65 @@
       }
     });
 
-    // Create post
+    // Create post (with image upload support)
     const trigger = document.getElementById('create-post-trigger');
     const postForm = document.getElementById('create-post-form');
     if (trigger && postForm) {
+      const imageInput = document.getElementById('post-image-input');
+      const previewsContainer = document.getElementById('post-image-previews');
+      const photoBtn = document.getElementById('post-photo-btn');
+      const imageError = document.getElementById('post-image-error');
+      const MAX_IMAGES = 4;
+      const MAX_SIZE = 5 * 1024 * 1024;
+      let selectedFiles = [];
+
       trigger.addEventListener('click', () => { postForm.hidden = false; trigger.hidden = true; });
+
+      if (photoBtn && imageInput) {
+        photoBtn.addEventListener('click', () => imageInput.click());
+        imageInput.addEventListener('change', () => {
+          imageError.hidden = true;
+          const newFiles = Array.from(imageInput.files || []);
+          for (const file of newFiles) {
+            if (selectedFiles.length >= MAX_IMAGES) {
+              imageError.textContent = 'Maximum ' + MAX_IMAGES + ' images allowed';
+              imageError.hidden = false;
+              break;
+            }
+            if (file.size > MAX_SIZE) {
+              imageError.textContent = file.name + ' is too large (max 5 MB)';
+              imageError.hidden = false;
+              continue;
+            }
+            selectedFiles.push(file);
+          }
+          imageInput.value = '';
+          renderPreviews();
+        });
+      }
+
+      function renderPreviews() {
+        previewsContainer.querySelectorAll('img').forEach(img => URL.revokeObjectURL(img.src));
+        previewsContainer.innerHTML = '';
+        previewsContainer.hidden = selectedFiles.length === 0;
+        selectedFiles.forEach((file, i) => {
+          const url = URL.createObjectURL(file);
+          const wrapper = document.createElement('div');
+          wrapper.className = 'feed-create__preview';
+          wrapper.innerHTML = '<img src="' + url + '" alt=""><button type="button" class="feed-create__preview-remove" data-index="' + i + '" aria-label="Remove image">&times;</button>';
+          previewsContainer.appendChild(wrapper);
+        });
+      }
+
+      previewsContainer.addEventListener('click', (e) => {
+        const removeBtn = e.target.closest('.feed-create__preview-remove');
+        if (!removeBtn) return;
+        const idx = parseInt(removeBtn.dataset.index, 10);
+        selectedFiles.splice(idx, 1);
+        imageError.hidden = true;
+        renderPreviews();
+      });
+
       postForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         const submitBtn = postForm.querySelector('button[type="submit"]');
@@ -254,11 +308,15 @@
         submitBtn.disabled = true;
         submitBtn.textContent = 'Posting...';
         try {
-          const payload = { body };
-          if (communitySelect) payload.community_id = communitySelect.value;
+          const fd = new FormData();
+          fd.append('body', body);
+          if (communitySelect) fd.append('community_id', communitySelect.value);
+          fd.append('_csrf_token', postForm.querySelector('[name="_csrf_token"]').value);
+          selectedFiles.forEach(f => fd.append('images[]', f));
           const res = await fetch('/api/engagement/post', {
-            method: 'POST', headers,
-            body: JSON.stringify(payload)
+            method: 'POST',
+            headers: { 'X-CSRF-Token': csrfToken },
+            body: fd
           });
           if (res.ok) {
             location.reload();


### PR DESCRIPTION
## Summary
- Add `UploadService` for image validation, storage, and cleanup (5MB max, JPEG/PNG/GIF/WebP)
- Add `images` field to Post entity type + migration for the column
- Update `EngagementController::createPost()` to handle multipart/form-data with file uploads (backward-compatible with JSON)
- Update `EngagementController::deletePost()` to clean up uploaded images
- Add photo button + image preview UI to post creation form (max 4 images)
- Render post images in feed cards via image grid layout (1-4 images)
- Decode images JSON in `FeedItemFactory::buildPost()` and pass via payload
- Add CSS for image grid, photo button, and preview thumbnails
- Create `public/uploads` symlink to `storage/uploads`

## Test plan
- [x] All 640 existing tests pass (3 skipped, pre-existing)
- [ ] Manual: create post with 1-4 images, verify preview and grid rendering
- [ ] Manual: create post without images, verify backward compatibility
- [ ] Manual: delete post with images, verify upload cleanup
- [ ] Manual: attempt >4 images or >5MB file, verify error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)