### PR TITLE
feat(#478,#479): minimal header + sidebar-first navigation

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -295,7 +295,11 @@
     min-width: 0;
   }
 
+  /* === Minimal Header === */
   .site-header {
+    position: sticky;
+    inset-block-start: 0;
+    z-index: 100;
     background-color: var(--surface-dark);
     border-block-end: 1px solid var(--border-dark);
     padding-block: var(--space-xs);
@@ -307,18 +311,19 @@
     margin-inline: auto;
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: var(--space-md);
   }
 
-  .site-name {
-    font-family: var(--font-heading);
-    font-size: var(--text-xl);
-    color: var(--text-primary);
-    text-decoration: none;
-    letter-spacing: var(--tracking-tight);
+  .site-header__left {
     display: flex;
     align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .site-header__logo {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
   }
 
   .site-name__wordmark {
@@ -327,229 +332,279 @@
     filter: brightness(0) invert(1);
   }
 
-  .site-nav {
+  .sidebar-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: var(--space-3xs);
+  }
+
+  .site-header__center {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+  }
+
+  .header-search {
     display: flex;
     align-items: center;
-    gap: var(--space-xs);
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    gap: var(--space-2xs);
+    background: var(--surface);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--radius);
+    padding: var(--space-3xs) var(--space-sm);
+    max-inline-size: 24rem;
+    inline-size: 100%;
   }
 
-  .site-nav > li {
-    display: flex;
-    align-items: stretch;
-    margin: 0;
+  .header-search__icon {
+    flex-shrink: 0;
+    color: var(--text-muted);
   }
 
-  .site-nav a,
-  .site-nav button {
+  .header-search__input {
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+    inline-size: 100%;
+    outline: none;
+
+    &::placeholder { color: var(--text-muted); }
+  }
+
+  .site-header__right {
     display: flex;
     align-items: center;
   }
 
-  .site-nav a {
-    color: var(--text-secondary);
-    font-family: var(--font-body);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    text-decoration: none;
-    transition: color var(--duration-fast) var(--ease-out);
-    padding: var(--space-2xs) var(--space-3xs);
-    position: relative;
+  /* === User Menu === */
+  .user-menu { position: relative; }
 
-    &::after {
-      content: '';
-      position: absolute;
-      inset-inline: 0;
-      inset-block-end: -2px;
-      block-size: 2px;
-      background: var(--link);
-      transform: scaleX(0);
-      transition: transform var(--duration-fast) var(--ease-out);
-      transform-origin: center;
-    }
-
-    &:hover {
-      color: var(--text-primary);
-      background-color: transparent;
-    }
-
-    &:hover::after,
-    &[aria-current="page"]::after {
-      transform: scaleX(1);
-    }
-
-    &[aria-current="page"] {
-      color: var(--accent);
-      background-color: transparent;
-    }
-  }
-
-  /* Domain-colored nav links */
-  .site-nav a[href*="/communities"] { color: var(--color-communities); }
-  .site-nav a[href*="/people"] { color: var(--color-people); }
-  .site-nav a[href*="/teachings"] { color: var(--color-teachings); }
-  .site-nav a[href*="/events"] { color: var(--color-events); }
-  .site-nav a[href*="/elders"],
-  .site-nav a[href*="/volunteer"] { color: var(--color-programs); }
-  .site-nav a[href*="/language"] { color: var(--color-language); }
-
-  /* Nav dropdown */
-  .site-nav__dropdown {
-    position: relative;
-  }
-
-  .site-nav__dropdown-toggle {
-    padding: var(--space-2xs) var(--space-3xs);
-    border-radius: var(--radius-sm);
-    text-decoration: none;
-    font-size: var(--text-sm);
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    color: var(--text-secondary);
+  .user-menu__trigger {
     background: none;
     border: none;
     cursor: pointer;
-    font-family: var(--font-body);
-    transition: color var(--duration-fast) var(--ease-out);
-
-    &:hover {
-      color: var(--text-primary);
-      background-color: transparent;
-    }
-
-    &[aria-current="true"] {
-      color: var(--accent);
-      background-color: transparent;
-    }
-
-    &::after {
-      content: " \25BE";
-      font-size: 0.75em;
-    }
+    padding: 0;
   }
 
-  .site-nav__dropdown-menu {
-    display: none;
-    position: absolute;
-    inset-block-start: 100%;
-    inset-inline-start: 0;
-    min-inline-size: 10rem;
-    background-color: var(--surface-dark);
-    border: 1px solid var(--border-dark);
-    border-radius: var(--radius-sm);
-    box-shadow: var(--shadow-md);
-    padding: var(--space-3xs) 0;
-    list-style: none;
-    z-index: 10;
-    opacity: 0;
-    transform: translateY(-4px);
-    transition: opacity var(--duration-fast) var(--ease-out),
-                transform var(--duration-fast) var(--ease-out);
-
-    &.is-open {
-      display: block;
-      opacity: 1;
-      transform: translateY(0);
-    }
-
-    a {
-      display: block;
-      padding: var(--space-3xs) var(--space-sm);
-      white-space: nowrap;
-      color: var(--text-secondary);
-
-      &:hover {
-        color: var(--text-primary);
-        background-color: transparent;
-      }
-    }
-  }
-
-  /* Utility nav items (Search, Login) */
-  .site-nav__utility {
-    margin-inline-start: auto;
-  }
-
-  .site-nav__utility + .site-nav__utility {
-    margin-inline-start: 0;
-  }
-
-  /* Language switcher */
-  .lang-switcher {
-    position: relative;
-  }
-
-  .lang-switcher__toggle {
-    padding: var(--space-3xs) var(--space-2xs);
-    border-radius: var(--radius-sm);
+  .user-menu__avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2.25rem;
+    block-size: 2.25rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--color-communities), var(--accent));
+    color: white;
+    font-weight: 600;
     font-size: var(--text-sm);
-    color: var(--text-secondary);
-    background: none;
-    border: 1px solid var(--border-dark);
-    cursor: pointer;
-    transition: color 0.15s ease, border-color 0.15s ease;
-
-    &::after {
-      content: " \25BE";
-      font-size: 0.75em;
-    }
-
-    &:hover {
-      color: var(--text-primary);
-      border-color: var(--text-secondary);
-    }
   }
 
-  .lang-switcher__menu {
-    display: none;
+  .user-menu__avatar--lg {
+    inline-size: 2.5rem;
+    block-size: 2.5rem;
+  }
+
+  .user-menu__dropdown {
     position: absolute;
-    inset-block-start: 100%;
+    inset-block-start: calc(100% + var(--space-xs));
     inset-inline-end: 0;
-    min-inline-size: 10rem;
+    min-inline-size: 14rem;
     background-color: var(--surface-dark);
     border: 1px solid var(--border-dark);
-    border-radius: var(--radius-sm);
-    box-shadow: var(--shadow-md);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    z-index: 200;
+    overflow: hidden;
+  }
+
+  .user-menu__identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+    border-block-end: 1px solid var(--border-dark);
+  }
+
+  .user-menu__name {
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: var(--text-sm);
+  }
+
+  .user-menu__email {
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+  }
+
+  .user-menu__section {
     padding: var(--space-3xs) 0;
-    list-style: none;
-    z-index: 10;
-    margin-block-start: var(--space-3xs);
+    border-block-end: 1px solid var(--border-dark);
 
-    &.is-open {
-      display: block;
-    }
+    &:last-child { border-block-end: none; }
   }
 
-  .lang-switcher__item {
-    display: block;
-    padding: var(--space-3xs) var(--space-sm);
-    white-space: nowrap;
-    text-decoration: none;
+  .user-menu__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-2xs) var(--space-sm);
     color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    background: none;
+    border: none;
+    inline-size: 100%;
+    cursor: pointer;
+    text-align: start;
+    font-family: var(--font-body);
 
-    &:hover {
-      color: var(--text-primary);
-      background-color: transparent;
-    }
+    &:hover { background-color: var(--surface); color: var(--text-primary); }
   }
 
-  .lang-switcher__item--active {
-    font-weight: 700;
-    color: var(--accent);
+  .user-menu__item--danger {
+    color: oklch(0.65 0.15 25);
+
+    &:hover { color: oklch(0.75 0.18 25); }
   }
 
-  .site-main {
-    padding-block: var(--space-lg);
+  .user-menu__value {
+    margin-inline-start: auto;
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+  }
+
+  /* === App Layout (sidebar + main) === */
+  .app-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-block-size: calc(100dvh - 3.5rem);
+  }
+
+  .app-layout--no-sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  .app-sidebar {
+    position: sticky;
+    inset-block-start: 3.5rem;
+    block-size: calc(100dvh - 3.5rem);
+    overflow-y: auto;
+    background-color: var(--surface-dark);
+    border-inline-end: 1px solid var(--border-dark);
+    padding: var(--space-sm) 0;
+    z-index: 50;
+  }
+
+  .app-sidebar__overlay {
+    display: none;
+  }
+
+  .app-main {
+    padding-block: var(--space-md);
     padding-inline: var(--gutter);
     min-block-size: 60vh;
   }
 
-  .site-main__inner {
-    max-inline-size: var(--width-content);
-    margin-inline: auto;
+  /* === Sidebar Navigation === */
+  .sidebar-nav__group {
+    margin-block-end: var(--space-md);
+    padding-inline: var(--space-2xs);
+  }
+
+  .sidebar-nav__label {
+    padding: var(--space-3xs) var(--space-sm);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+  }
+
+  .sidebar-nav__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-2xs) var(--space-sm);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    border-radius: var(--radius-sm);
+    transition: background-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
+
+    &:hover {
+      background-color: var(--surface);
+      color: var(--text-primary);
+    }
+
+    svg { flex-shrink: 0; }
+  }
+
+  .sidebar-nav__item--active {
+    background-color: var(--surface);
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .sidebar-nav__community-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1.25rem;
+    block-size: 1.25rem;
+    border-radius: 50%;
+    background-color: var(--surface);
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+    flex-shrink: 0;
+  }
+
+  /* === Responsive: Tablet === */
+  @media (max-width: 1024px) {
+    .app-layout { grid-template-columns: 60px 1fr; }
+    .sidebar-nav__text { display: none; }
+    .sidebar-nav__label { display: none; }
+    .sidebar-nav__item { justify-content: center; padding: var(--space-xs); }
+    .sidebar-nav__community-avatar { margin: 0; }
+    .sidebar-toggle { display: none; }
+  }
+
+  /* === Responsive: Mobile === */
+  @media (max-width: 640px) {
+    .sidebar-toggle { display: flex; }
+    .header-search { max-inline-size: none; }
+    .app-layout { grid-template-columns: 1fr; }
+
+    .app-sidebar {
+      position: fixed;
+      inset-block-start: 3.5rem;
+      inset-inline-start: 0;
+      inline-size: 260px;
+      block-size: calc(100dvh - 3.5rem);
+      transform: translateX(-100%);
+      transition: transform var(--duration-normal) var(--ease-out);
+    }
+
+    .app-sidebar--open {
+      transform: translateX(0);
+    }
+
+    .app-sidebar__overlay {
+      display: none;
+      position: fixed;
+      inset: 3.5rem 0 0 0;
+      background: oklch(0 0 0 / 0.5);
+      z-index: 40;
+    }
+
+    .app-sidebar__overlay--visible {
+      display: block;
+    }
+
+    .sidebar-nav__text { display: inline; }
+    .sidebar-nav__label { display: block; }
   }
 
   .site-footer {

--- a/templates/auth/check-email.html.twig
+++ b/templates/auth/check-email.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ trans('auth.check_email_title') }} — Minoo{% endblock %}
 

--- a/templates/auth/forgot-password.html.twig
+++ b/templates/auth/forgot-password.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ trans('auth.forgot_title') }} — Minoo{% endblock %}
 

--- a/templates/auth/login.html.twig
+++ b/templates/auth/login.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ trans('auth.login_title') }} — Minoo{% endblock %}
 

--- a/templates/auth/register.html.twig
+++ b/templates/auth/register.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ trans('auth.register_title') }} — Minoo{% endblock %}
 

--- a/templates/auth/reset-password.html.twig
+++ b/templates/auth/reset-password.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ trans('auth.reset_title') }} — Minoo{% endblock %}
 

--- a/templates/auth/verify-email.html.twig
+++ b/templates/auth/verify-email.html.twig
@@ -1,4 +1,5 @@
 {% extends "base.html.twig" %}
+{% set hide_sidebar = true %}
 
 {% block title %}{{ verified ? trans('auth.verify_title') : trans('auth.verify_error_title') }} — Minoo{% endblock %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -27,74 +27,41 @@
   <div class="site">
     <header class="site-header">
       <div class="site-header__inner">
-        <a href="{{ lang_url('/') }}" class="site-name" aria-label="{{ trans('base.home_label') }}">
-          <img src="/img/minoo-wordmark.svg" alt="Minoo" class="site-name__wordmark" width="100" height="28" fetchpriority="high">
-        </a>
-        <button class="nav-toggle" aria-expanded="false" aria-controls="main-nav" aria-label="{{ trans('base.menu') }}">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M3 5h14M3 10h14M3 15h14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-        </button>
-        <nav id="main-nav" aria-label="{{ trans('base.nav_main') }}">
-          <ul class="site-nav">
-            <li><a href="{{ lang_url('/communities') }}"{% if path is defined and path starts with '/communities' %} aria-current="page"{% endif %}>{{ trans('nav.communities') }}</a></li>
-            <li><a href="{{ lang_url('/people') }}"{% if path is defined and path starts with '/people' %} aria-current="page"{% endif %}>{{ trans('nav.people') }}</a></li>
-            <li><a href="{{ lang_url('/teachings') }}"{% if path is defined and path starts with '/teachings' %} aria-current="page"{% endif %}>{{ trans('nav.teachings') }}</a></li>
-            <li><a href="{{ lang_url('/events') }}"{% if path is defined and path starts with '/events' %} aria-current="page"{% endif %}>{{ trans('nav.events') }}</a></li>
-            <li><a href="{{ lang_url('/oral-histories') }}"{% if path is defined and path starts with '/oral-histories' %} aria-current="page"{% endif %}>{{ trans('nav.oral_histories') }}</a></li>
-            <li class="site-nav__dropdown">
-              <button class="site-nav__dropdown-toggle" aria-expanded="false"{% if path is defined and (path starts with '/elders' or path starts with '/volunteer') %} aria-current="true"{% endif %}>{{ trans('nav.programs') }}</button>
-              <ul class="site-nav__dropdown-menu">
-                <li><a href="{{ lang_url('/elders') }}"{% if path is defined and path starts with '/elders' %} aria-current="page"{% endif %}>{{ trans('nav.elder_support') }}</a></li>
-                <li><a href="{{ lang_url('/volunteer') }}"{% if path is defined and path starts with '/volunteer' %} aria-current="page"{% endif %}>{{ trans('nav.volunteer') }}</a></li>
-              </ul>
-            </li>
-            <li class="site-nav__utility"><a href="{{ lang_url('/search') }}"{% if path is defined and path starts with '/search' %} aria-current="page"{% endif %}>{{ trans('nav.search') }}</a></li>
-            {% if account is defined and account.isAuthenticated() %}
-              {% if 'elder_coordinator' in account.getRoles() %}
-                <li class="site-nav__utility"><a href="{{ lang_url('/dashboard/coordinator') }}"{% if path is defined and path starts with '/dashboard' %} aria-current="page"{% endif %}>{{ trans('nav.dashboard') }}</a></li>
-              {% elseif 'volunteer' in account.getRoles() %}
-                <li class="site-nav__utility"><a href="{{ lang_url('/dashboard/volunteer') }}"{% if path is defined and path starts with '/dashboard' %} aria-current="page"{% endif %}>{{ trans('nav.my_dashboard') }}</a></li>
-              {% endif %}
-              <li class="site-nav__utility"><a href="{{ lang_url('/account') }}"{% if path is defined and path starts with '/account' %} aria-current="page"{% endif %}>{{ trans('nav.account') }}</a></li>
-              <li class="site-nav__utility"><a href="{{ lang_url('/logout') }}">{{ trans('nav.logout') }}</a></li>
-            {% else %}
-              <li class="site-nav__utility"><a href="{{ lang_url('/login') }}"{% if path is defined and path == '/login' %} aria-current="page"{% endif %}>{{ trans('nav.login') }}</a></li>
-            {% endif %}
-            <li class="site-nav__utility site-nav__theme">
-              {% include "components/theme-toggle.html.twig" %}
-            </li>
-            <li class="site-nav__utility site-nav__lang">
-              <div class="lang-switcher">
-                <button class="lang-switcher__toggle" aria-expanded="false" aria-haspopup="true" aria-label="{{ trans('language_switcher.label') }}">
-                  {{ current_language().label }}
-                </button>
-                <ul class="lang-switcher__menu" role="menu">
-                  {% for lang in available_languages() %}
-                    <li role="menuitem">
-                      {% if lang.is_current %}
-                        <span class="lang-switcher__item lang-switcher__item--active" aria-current="true">{{ lang.label }}</span>
-                      {% else %}
-                        <a class="lang-switcher__item" href="{{ lang_switch_url(lang.id, path is defined ? path : '/') }}">{{ lang.label }}</a>
-                      {% endif %}
-                    </li>
-                  {% endfor %}
-                </ul>
-              </div>
-            </li>
-          </ul>
-        </nav>
+        <div class="site-header__left">
+          <button class="sidebar-toggle" id="sidebar-toggle" aria-label="{{ trans('base.menu') }}" aria-expanded="false">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M3 5h14M3 10h14M3 15h14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+          <a href="{{ lang_url('/') }}" class="site-header__logo" aria-label="{{ trans('base.home_label') }}">
+            <img src="/img/minoo-wordmark.svg" alt="Minoo" class="site-name__wordmark" width="100" height="28" fetchpriority="high">
+          </a>
+        </div>
+        <div class="site-header__center">
+          <form class="header-search" action="{{ lang_url('/search') }}" method="get">
+            <svg class="header-search__icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="7" cy="7" r="5"/><path d="M11 11l4 4"/></svg>
+            <input class="header-search__input" type="search" name="q" placeholder="{{ trans('search.placeholder') }}" autocomplete="off">
+          </form>
+        </div>
+        <div class="site-header__right">
+          {% include "components/user-menu.html.twig" %}
+        </div>
       </div>
     </header>
 
     <div class="ribbon" aria-hidden="true"></div>
 
-    {% include "components/location-bar.html.twig" %}
-
-    <main class="site-main" id="main-content">
-      <div class="site-main__inner">
+    <div class="app-layout{% if hide_sidebar is defined and hide_sidebar %} app-layout--no-sidebar{% endif %}">
+      {% if hide_sidebar is not defined or not hide_sidebar %}
+        <aside class="app-sidebar" id="app-sidebar">
+          {% include "components/sidebar-nav.html.twig" %}
+        </aside>
+        <div class="app-sidebar__overlay" id="sidebar-overlay"></div>
+      {% endif %}
+      <main class="app-main" id="main-content">
+        {% include "components/location-bar.html.twig" %}
         {% include "components/flash-messages.html.twig" %}
         {% block content %}{% endblock %}
-      </div>
-    </main>
+      </main>
+    </div>
 
     <div class="ribbon" aria-hidden="true"></div>
 
@@ -119,55 +86,59 @@
     </footer>
   </div>
   <script>
-    document.querySelector('.nav-toggle')?.addEventListener('click', function() {
-      const nav = document.getElementById('main-nav')?.querySelector('.site-nav');
-      const open = nav?.classList.toggle('is-open');
-      this.setAttribute('aria-expanded', open ? 'true' : 'false');
+    // Sidebar toggle (mobile)
+    document.getElementById('sidebar-toggle')?.addEventListener('click', function() {
+      const sidebar = document.getElementById('app-sidebar');
+      const overlay = document.getElementById('sidebar-overlay');
+      const isOpen = sidebar?.classList.toggle('app-sidebar--open');
+      overlay?.classList.toggle('app-sidebar__overlay--visible', isOpen);
+      this.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     });
-    document.querySelectorAll('.site-nav__dropdown-toggle').forEach(function(btn) {
-      btn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        const menu = this.nextElementSibling;
-        const isOpen = menu.classList.toggle('is-open');
-        this.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-      });
+    document.getElementById('sidebar-overlay')?.addEventListener('click', function() {
+      document.getElementById('app-sidebar')?.classList.remove('app-sidebar--open');
+      this.classList.remove('app-sidebar__overlay--visible');
+      document.getElementById('sidebar-toggle')?.setAttribute('aria-expanded', 'false');
     });
-    document.addEventListener('click', function() {
-      document.querySelectorAll('.site-nav__dropdown-menu.is-open').forEach(function(m) {
-        m.classList.remove('is-open');
-        m.previousElementSibling.setAttribute('aria-expanded', 'false');
-      });
-    });
-    // Language switcher dropdown
+    // User menu dropdown
     (function() {
-      const toggle = document.querySelector('.lang-switcher__toggle');
-      if (!toggle) return;
-      const menu = toggle.nextElementSibling;
-      toggle.addEventListener('click', function(e) {
+      const trigger = document.querySelector('.user-menu__trigger');
+      if (!trigger) return;
+      const dropdown = document.getElementById('user-menu-dropdown');
+      trigger.addEventListener('click', function(e) {
         e.stopPropagation();
-        const isOpen = menu.classList.toggle('is-open');
-        this.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        const isOpen = !dropdown.hidden;
+        dropdown.hidden = isOpen;
+        this.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
       });
       document.addEventListener('click', function() {
-        menu.classList.remove('is-open');
-        toggle.setAttribute('aria-expanded', 'false');
+        dropdown.hidden = true;
+        trigger.setAttribute('aria-expanded', 'false');
       });
     })();
-    // Theme toggle
+    // Theme toggle (header user menu + standalone)
     (function() {
-      var btn = document.querySelector('.theme-toggle');
-      if (!btn) return;
-      function current() {
+      function currentTheme() {
         return document.documentElement.getAttribute('data-theme') ||
           (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
       }
-      function apply(theme) {
+      function applyTheme(theme) {
         document.documentElement.setAttribute('data-theme', theme);
         localStorage.setItem('minoo-theme', theme);
+        var label = document.getElementById('user-menu-theme-value');
+        if (label) label.textContent = theme === 'dark' ? 'Dark' : 'Light';
       }
-      btn.addEventListener('click', function() {
-        apply(current() === 'dark' ? 'light' : 'dark');
+      // User menu theme button
+      document.getElementById('user-menu-theme-toggle')?.addEventListener('click', function() {
+        applyTheme(currentTheme() === 'dark' ? 'light' : 'dark');
       });
+      // Standalone toggle (fallback)
+      var btn = document.querySelector('.theme-toggle');
+      if (btn) btn.addEventListener('click', function() {
+        applyTheme(currentTheme() === 'dark' ? 'light' : 'dark');
+      });
+      // Set initial label
+      var label = document.getElementById('user-menu-theme-value');
+      if (label) label.textContent = currentTheme() === 'dark' ? 'Dark' : 'Light';
     })();
   </script>
   <script>

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -4,8 +4,6 @@
 
 {% block content %}
   <div class="feed-layout">
-    {% include "components/feed-sidebar-left.html.twig" %}
-
     <div class="feed-main">
       {% include "components/feed-create-post.html.twig" %}
 


### PR DESCRIPTION
## Summary

- Replace 11-item top nav with minimal header (Logo + Search + User Menu avatar)
- Move all navigation into left sidebar in base.html.twig (all pages)
- User menu dropdown: profile, dashboard, theme toggle, language, sign out
- Sidebar groups: Navigate, Programs, Your Communities
- Responsive: full on desktop, icons on tablet, overlay on mobile
- Auth pages (login, register, etc.) hide sidebar

Closes #478
Closes #479

## Test plan

- [x] 645 tests passing (1602 assertions)
- [ ] Visual: homepage sidebar + feed layout
- [ ] Visual: communities/events/teachings pages have sidebar
- [ ] Visual: login page has no sidebar
- [ ] Visual: mobile hamburger toggles sidebar overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)