### PR TITLE
feat(#480): image upload support for post creation

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -3736,6 +3736,94 @@
     font-family: var(--font-body);
   }
 
+  .feed-create__actions-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+
+  .feed-create__photo-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3xs);
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+    cursor: pointer;
+    padding: var(--space-3xs) var(--space-2xs);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-body);
+
+    &:hover { color: var(--text-primary); background: var(--surface); }
+  }
+
+  .feed-create__previews {
+    display: flex;
+    gap: var(--space-xs);
+    padding-block: var(--space-xs);
+    flex-wrap: wrap;
+  }
+
+  .feed-create__preview {
+    position: relative;
+    inline-size: 5rem;
+    block-size: 4rem;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .feed-create__preview img {
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  .feed-create__preview-remove {
+    position: absolute;
+    inset-block-start: 2px;
+    inset-inline-end: 2px;
+    background: oklch(0 0 0 / 0.6);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    inline-size: 1.25rem;
+    block-size: 1.25rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .feed-create__image-error {
+    color: oklch(0.65 0.15 25);
+    font-size: var(--text-sm);
+    margin: 0;
+    padding-block: var(--space-3xs);
+  }
+
+  /* Post image grid */
+  .feed-card__images {
+    display: grid;
+    gap: 2px;
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-block-start: var(--space-sm);
+  }
+
+  .feed-card__images--1 { grid-template-columns: 1fr; }
+  .feed-card__images--2 { grid-template-columns: 1fr 1fr; }
+  .feed-card__images--3 { grid-template-columns: 1fr 1fr; }
+  .feed-card__images--4 { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; }
+
+  .feed-card__image {
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+    max-block-size: 300px;
+  }
+
   .feed-create__guest {
     display: flex;
     align-items: center;

--- a/public/uploads
+++ b/public/uploads
@@ -1,0 +1,1 @@
+../storage/uploads

--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minoo\Controller;
 
 use Minoo\Entity\Reaction;
+use Minoo\Support\UploadService;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
@@ -20,6 +21,7 @@ final class EngagementController
 
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
+        private readonly UploadService $uploadService,
     ) {}
 
     public function react(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -213,13 +215,21 @@ final class EngagementController
 
     public function createPost(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
+        // Support both JSON and multipart form data
+        // Try JSON first (existing API), fall back to form data (multipart with images)
         $data = $this->jsonBody($request);
+        if (isset($data['body'])) {
+            $body = trim($data['body']);
+            $communityId = (int) ($data['community_id'] ?? 0);
+        } else {
+            $body = trim((string) $request->request->get('body', ''));
+            $communityId = (int) $request->request->get('community_id', 0);
+        }
 
-        if (!isset($data['body'], $data['community_id'])) {
+        if ($communityId === 0) {
             return $this->json(['error' => 'Missing required fields: body, community_id'], 422);
         }
 
-        $body = trim($data['body']);
         if ($body === '' || mb_strlen($body) > 5000) {
             return $this->json(['error' => 'Body must be 1-5000 characters'], 422);
         }
@@ -230,11 +240,36 @@ final class EngagementController
             $entity = $storage->create([
                 'body' => $body,
                 'user_id' => $account->id(),
-                'community_id' => (int) $data['community_id'],
+                'community_id' => $communityId,
             ]);
             $storage->save($entity);
         } catch (\InvalidArgumentException) {
             return $this->json(['error' => 'Invalid entity data'], 422);
+        }
+
+        // Handle image uploads
+        $uploadedFiles = $request->files->all('images');
+        if (is_array($uploadedFiles) && $uploadedFiles !== []) {
+            $imagePaths = [];
+            foreach (array_slice($uploadedFiles, 0, 4) as $file) {
+                if (!$file instanceof \Symfony\Component\HttpFoundation\File\UploadedFile) {
+                    continue;
+                }
+                $fileArray = [
+                    'name' => $file->getClientOriginalName(),
+                    'tmp_name' => $file->getPathname(),
+                    'size' => $file->getSize(),
+                    'type' => $file->getMimeType() ?? '',
+                    'error' => $file->getError(),
+                ];
+                if ($this->uploadService->validateImage($fileArray) === []) {
+                    $imagePaths[] = $this->uploadService->moveUpload($fileArray, 'posts/' . $entity->id());
+                }
+            }
+            if ($imagePaths !== []) {
+                $entity->set('images', json_encode($imagePaths));
+                $storage->save($entity);
+            }
         }
 
         return $this->json([
@@ -259,6 +294,7 @@ final class EngagementController
         }
 
         $storage->delete([$entity]);
+        $this->uploadService->deleteDirectory('posts/' . $id);
 
         return $this->json(['deleted' => true]);
     }

--- a/src/Feed/FeedItemFactory.php
+++ b/src/Feed/FeedItemFactory.php
@@ -308,6 +308,8 @@ final class FeedItemFactory
         $id = 'post:' . $entity->id();
         $communityId = $entity->get('community_id');
 
+        $images = json_decode($entity->get('images') ?? '[]', true);
+
         return new FeedItem(
             id: $id,
             type: 'post',
@@ -320,6 +322,7 @@ final class FeedItemFactory
             entity: $entity,
             distance: $distance,
             meta: $this->truncate($entity->get('body')),
+            payload: is_array($images) && $images !== [] ? ['images' => $images] : [],
             relativeTime: $this->formatRelativeTime($createdAt),
             communitySlug: $this->resolveCommunitySlug($communityId),
             communityInitial: $this->resolveCommunityInitial($communityId),

--- a/src/Provider/EngagementServiceProvider.php
+++ b/src/Provider/EngagementServiceProvider.php
@@ -8,6 +8,7 @@ use Minoo\Entity\Comment;
 use Minoo\Entity\Follow;
 use Minoo\Entity\Post;
 use Minoo\Entity\Reaction;
+use Minoo\Support\UploadService;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -168,6 +169,10 @@ final class EngagementServiceProvider extends ServiceProvider
                     'weight' => 10,
                 ],
             ],
+        ));
+
+        $this->singleton(UploadService::class, fn(): UploadService => new UploadService(
+            dirname(__DIR__, 2) . '/storage/uploads',
         ));
     }
 

--- a/templates/components/feed-card.html.twig
+++ b/templates/components/feed-card.html.twig
@@ -30,6 +30,13 @@
       </div>
     </div>
     <p class="feed-card__body">{{ item.meta|default('') }}</p>
+    {% if item.payload.images is defined and item.payload.images|length > 0 %}
+      <div class="feed-card__images feed-card__images--{{ item.payload.images|length|min(4) }}">
+        {% for img in item.payload.images|slice(0, 4) %}
+          <img src="/uploads/{{ img }}" alt="" class="feed-card__image" loading="lazy">
+        {% endfor %}
+      </div>
+    {% endif %}
     {% include "components/feed-engagement.html.twig" with { item: item } only %}
   </article>
 {% else %}

--- a/templates/components/feed-create-post.html.twig
+++ b/templates/components/feed-create-post.html.twig
@@ -4,15 +4,24 @@
       <div class="feed-create__avatar">{{ account_initial }}</div>
       <span class="feed-create__placeholder">{{ trans('feed.whats_happening') }}</span>
     </div>
-    <form class="feed-create__form" id="create-post-form" action="/api/engagement/post" method="post" hidden>
+    <form class="feed-create__form" id="create-post-form" action="/api/engagement/post" method="post" enctype="multipart/form-data" hidden>
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <textarea class="feed-create__textarea" name="body" placeholder="{{ trans('feed.whats_happening') }}" maxlength="5000" required></textarea>
+      <input type="file" id="post-image-input" accept="image/jpeg,image/png,image/gif,image/webp" multiple hidden>
+      <div class="feed-create__previews" id="post-image-previews" hidden></div>
+      <p class="feed-create__image-error" id="post-image-error" hidden></p>
       <div class="feed-create__actions">
-        <select name="community_id" class="feed-create__community" required>
-          {% for community in user_communities|default([]) %}
-            <option value="{{ community.id }}"{% if community.is_default|default(false) %} selected{% endif %}>{{ community.name }}</option>
-          {% endfor %}
-        </select>
+        <div class="feed-create__actions-left">
+          <button type="button" class="feed-create__photo-btn" id="post-photo-btn" aria-label="{{ trans('feed.photo') }}">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+            <span>{{ trans('feed.photo') }}</span>
+          </button>
+          <select name="community_id" class="feed-create__community" required>
+            {% for community in user_communities|default([]) %}
+              <option value="{{ community.id }}"{% if community.is_default|default(false) %} selected{% endif %}>{{ community.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
         <button type="submit" class="btn btn--primary">{{ trans('feed.post') }}</button>
       </div>
     </form>

--- a/templates/feed.html.twig
+++ b/templates/feed.html.twig
@@ -237,11 +237,59 @@
       }
     });
 
-    // Create post
+    // Create post with image upload
     const trigger = document.getElementById('create-post-trigger');
     const postForm = document.getElementById('create-post-form');
     if (trigger && postForm) {
+      const photoBtn = document.getElementById('post-photo-btn');
+      const fileInput = document.getElementById('post-image-input');
+      const previewsEl = document.getElementById('post-image-previews');
+      const errorEl = document.getElementById('post-image-error');
+      let selectedFiles = [];
+
       trigger.addEventListener('click', () => { postForm.hidden = false; trigger.hidden = true; });
+
+      // Photo button triggers file input
+      photoBtn?.addEventListener('click', () => fileInput?.click());
+
+      // Handle file selection
+      fileInput?.addEventListener('change', () => {
+        const newFiles = Array.from(fileInput.files);
+        errorEl.hidden = true;
+        for (const file of newFiles) {
+          if (selectedFiles.length >= 4) {
+            errorEl.textContent = '{{ trans("feed.max_images") }}';
+            errorEl.hidden = false;
+            break;
+          }
+          if (file.size > 5 * 1024 * 1024) {
+            errorEl.textContent = '{{ trans("feed.image_too_large") }}';
+            errorEl.hidden = false;
+            continue;
+          }
+          selectedFiles.push(file);
+        }
+        fileInput.value = '';
+        renderPreviews();
+      });
+
+      function renderPreviews() {
+        previewsEl.innerHTML = '';
+        previewsEl.hidden = selectedFiles.length === 0;
+        selectedFiles.forEach((file, i) => {
+          const url = URL.createObjectURL(file);
+          const div = document.createElement('div');
+          div.className = 'feed-create__preview';
+          div.innerHTML = `<img src="${url}" alt=""><button type="button" class="feed-create__preview-remove" data-index="${i}">&times;</button>`;
+          div.querySelector('button').addEventListener('click', () => {
+            URL.revokeObjectURL(url);
+            selectedFiles.splice(i, 1);
+            renderPreviews();
+          });
+          previewsEl.appendChild(div);
+        });
+      }
+
       postForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         const submitBtn = postForm.querySelector('button[type="submit"]');
@@ -252,13 +300,19 @@
         submitBtn.disabled = true;
         submitBtn.textContent = 'Posting...';
         try {
-          const payload = { body };
-          if (communitySelect) payload.community_id = communitySelect.value;
+          const fd = new FormData();
+          fd.append('body', body);
+          fd.append('_csrf_token', csrfToken);
+          if (communitySelect) fd.append('community_id', communitySelect.value);
+          selectedFiles.forEach(f => fd.append('images[]', f));
           const res = await fetch('/api/engagement/post', {
-            method: 'POST', headers,
-            body: JSON.stringify(payload)
+            method: 'POST',
+            headers: { 'X-CSRF-Token': csrfToken },
+            body: fd
           });
           if (res.ok) {
+            selectedFiles.forEach(f => { const u = URL.createObjectURL(f); URL.revokeObjectURL(u); });
+            selectedFiles = [];
             location.reload();
           } else {
             const err = await res.json().catch(() => ({}));

--- a/tests/Minoo/Unit/Controller/EngagementControllerTest.php
+++ b/tests/Minoo/Unit/Controller/EngagementControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minoo\Tests\Unit\Controller;
 
 use Minoo\Controller\EngagementController;
+use Minoo\Support\UploadService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +24,7 @@ final class EngagementControllerTest extends TestCase
     protected function setUp(): void
     {
         $this->etm = $this->createMock(EntityTypeManager::class);
-        $this->controller = new EngagementController($this->etm);
+        $this->controller = new EngagementController($this->etm, new UploadService(sys_get_temp_dir() . '/minoo-test-uploads'));
     }
 
     private function mockAccount(int $id = 1, bool $isAdmin = false): AccountInterface


### PR DESCRIPTION
## Summary

- Posts now support up to 4 image uploads (5MB each, JPEG/PNG/GIF/WebP)
- Photo button + client-side preview with remove in post form
- FormData multipart submission (backward-compatible with JSON API)
- Images stored in `storage/uploads/posts/{id}/`, served via symlink
- Image grid in feed cards (1=full, 2=side-by-side, 3-4=grid)
- Post deletion cleans up uploaded images
- UploadService registered as singleton in EngagementServiceProvider

Closes #480

## Test plan

- [x] 645 tests passing (1602 assertions)
- [ ] Visual: post form shows photo button, select images, see previews
- [ ] Visual: post with images renders grid in feed
- [ ] Visual: remove preview image before posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)