### PR TITLE
fix(#477): show community CTA for authenticated users without communities

### DIFF
--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -100,6 +100,8 @@ return [
     'feed.suggested_communities' => 'Suggested Communities',
     'feed.see_all' => 'See all',
     'feed.join_conversation' => 'Join the conversation — log in to share with your community',
+    'feed.join_community_to_post' => 'Join a community to start posting',
+    'feed.explore_communities' => 'Explore communities',
     'feed.whats_happening' => "What's happening in your community?",
     'feed.post' => 'Post',
     'feed.communities_near_you' => 'Communities near you',

--- a/templates/components/feed-create-post.html.twig
+++ b/templates/components/feed-create-post.html.twig
@@ -26,7 +26,14 @@
       </div>
     </form>
 </div>
-{% elseif account is not defined or not account.isAuthenticated() %}
+{% elseif account is defined and account.isAuthenticated() %}
+<div class="feed-create">
+    <div class="feed-create__guest">
+      <p>{{ trans('feed.join_community_to_post') }}</p>
+      <a href="/communities" class="btn btn--secondary">{{ trans('feed.explore_communities') }}</a>
+    </div>
+</div>
+{% else %}
 <div class="feed-create">
     <div class="feed-create__guest">
       <p>{{ trans('feed.join_conversation') }}</p>


### PR DESCRIPTION
## Summary
- Authenticated users with no communities saw an empty gap where the feed-create box should be
- Added a third template branch showing a "Join a community to start posting" CTA linking to `/communities`
- Added `feed.join_community_to_post` and `feed.explore_communities` translation strings

## Test plan
- [ ] Log in as a user with no community follows
- [ ] Verify "Join a community to start posting" CTA appears instead of empty space
- [ ] Verify CTA links to `/communities`
- [ ] Log out — verify guest CTA still shows correctly
- [ ] Log in as user with communities — verify create box still works

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)