### PR TITLE
feat: add FeedItem score, FeedContext userId, and feed scoring config

### DIFF
--- a/config/feed_scoring.php
+++ b/config/feed_scoring.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'decay_half_life_hours' => 96,
+    'featured_boost' => 100.0,
+    'affinity_cache_ttl' => 900,
+    'interaction_weights' => [
+        'reaction' => 1.0,
+        'comment' => 3.0,
+        'follow' => 2.0,
+    ],
+    'affinity_signals' => [
+        'same_community' => 3.0,
+        'follows_source' => 4.0,
+        'reaction_points' => 1.0,
+        'reaction_max' => 5.0,
+        'comment_points' => 2.0,
+        'comment_max' => 6.0,
+        'geo_close_km' => 50,
+        'geo_close_points' => 2.0,
+        'geo_mid_km' => 150,
+        'geo_mid_points' => 1.0,
+    ],
+    'base_affinity' => 1.0,
+    'diversity' => [
+        'max_consecutive_type' => 3,
+        'max_consecutive_community' => 5,
+    ],
+    'lookback_days' => 30,
+];

--- a/src/Feed/FeedContext.php
+++ b/src/Feed/FeedContext.php
@@ -18,6 +18,7 @@ final readonly class FeedContext
         public int $limit = 20,
         public bool $isFirstVisit = false,
         public bool $isAuthenticated = false,
+        public ?int $userId = null,
     ) {}
 
     public static function defaults(): self

--- a/src/Feed/FeedItem.php
+++ b/src/Feed/FeedItem.php
@@ -34,6 +34,7 @@ final readonly class FeedItem
         public ?string $communitySlug = null,
         public ?string $communityInitial = null,
         public ?string $authorName = null,
+        public ?float $score = null,
     ) {}
 
     public function isSynthetic(): bool
@@ -94,6 +95,9 @@ final readonly class FeedItem
         }
         if ($this->authorName !== null) {
             $data['authorName'] = $this->authorName;
+        }
+        if ($this->score !== null) {
+            $data['score'] = round($this->score, 4);
         }
 
         return $data;


### PR DESCRIPTION
## Summary
- Added optional `?float $score` property to `FeedItem` (last constructor param, null default) with `toArray()` serialization using `round($score, 4)`
- Added optional `?int $userId` property to `FeedContext` for ranking algorithm user context
- Created `config/feed_scoring.php` with decay, affinity, interaction weights, and diversity parameters

## Test plan
- [x] All 666 MinooUnit tests pass (backwards-compatible null defaults)
- [ ] Future units will add scoring algorithm that consumes these additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)