### PR TITLE
feat: add DecayCalculator for feed ranking

### DIFF
--- a/src/Feed/Scoring/DecayCalculator.php
+++ b/src/Feed/Scoring/DecayCalculator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+final class DecayCalculator
+{
+    public function __construct(
+        private readonly float $halfLifeHours = 96.0,
+    ) {}
+
+    public function compute(int $createdAt, ?int $now = null): float
+    {
+        $now ??= time();
+        $ageHours = ($now - $createdAt) / 3600.0;
+
+        return pow(0.5, $ageHours / $this->halfLifeHours);
+    }
+}

--- a/tests/Minoo/Unit/Feed/Scoring/DecayCalculatorTest.php
+++ b/tests/Minoo/Unit/Feed/Scoring/DecayCalculatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Feed\Scoring;
+
+use Minoo\Feed\Scoring\DecayCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DecayCalculator::class)]
+final class DecayCalculatorTest extends TestCase
+{
+    #[Test]
+    public function brandNewContentHasNoDecay(): void
+    {
+        $calculator = new DecayCalculator();
+        $now = 1_000_000;
+
+        $score = $calculator->compute($now, $now);
+
+        $this->assertEqualsWithDelta(1.0, $score, 0.001);
+    }
+
+    #[Test]
+    public function contentAtHalfLifeDecaysToHalf(): void
+    {
+        $calculator = new DecayCalculator(halfLifeHours: 96.0);
+        $now = 1_000_000;
+        $createdAt = $now - (96 * 3600);
+
+        $score = $calculator->compute($createdAt, $now);
+
+        $this->assertEqualsWithDelta(0.5, $score, 0.001);
+    }
+
+    #[Test]
+    public function twoHalfLivesDecaysToQuarter(): void
+    {
+        $calculator = new DecayCalculator(halfLifeHours: 96.0);
+        $now = 1_000_000;
+        $createdAt = $now - (2 * 96 * 3600);
+
+        $score = $calculator->compute($createdAt, $now);
+
+        $this->assertEqualsWithDelta(0.25, $score, 0.001);
+    }
+
+    #[Test]
+    public function customHalfLifeWorks(): void
+    {
+        $calculator = new DecayCalculator(halfLifeHours: 24.0);
+        $now = 1_000_000;
+        $createdAt = $now - (24 * 3600);
+
+        $score = $calculator->compute($createdAt, $now);
+
+        $this->assertEqualsWithDelta(0.5, $score, 0.001);
+    }
+
+    #[Test]
+    public function decayNeverReachesZero(): void
+    {
+        $calculator = new DecayCalculator();
+        $now = 1_000_000;
+        $thirtyDaysAgo = $now - (30 * 24 * 3600);
+
+        $score = $calculator->compute($thirtyDaysAgo, $now);
+
+        $this->assertGreaterThan(0.0, $score);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DecayCalculator` — pure math component computing exponential time decay for feed ranking
- Default half-life of 96 hours (4 days), configurable via constructor
- 5 unit tests covering: no decay at t=0, half-life decay, double half-life, custom half-life, asymptotic non-zero

## Test plan
- [x] 5 new unit tests pass
- [x] Full MinooUnit suite (671 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)