### PR TITLE
feat: add AffinityCache and AffinityCalculator for feed ranking

### DIFF
--- a/src/Feed/Scoring/AffinityCache.php
+++ b/src/Feed/Scoring/AffinityCache.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+use Waaseyaa\Cache\CacheBackendInterface;
+
+final class AffinityCache
+{
+    private const int TTL = 900; // 15 minutes
+
+    public function __construct(private readonly CacheBackendInterface $cache) {}
+
+    /**
+     * @return array<string, float>|null
+     */
+    public function get(int $userId): ?array
+    {
+        $item = $this->cache->get($this->cid($userId));
+
+        return $item === false ? null : $item->data;
+    }
+
+    /**
+     * @param array<string, float> $scores
+     */
+    public function set(int $userId, array $scores): void
+    {
+        $this->cache->set($this->cid($userId), $scores, time() + self::TTL);
+    }
+
+    public function invalidate(int $userId): void
+    {
+        $this->cache->delete($this->cid($userId));
+    }
+
+    private function cid(int $userId): string
+    {
+        return 'feed_affinity:' . $userId;
+    }
+}

--- a/src/Feed/Scoring/AffinityCalculator.php
+++ b/src/Feed/Scoring/AffinityCalculator.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+use Minoo\Support\GeoDistance;
+use Waaseyaa\Database\DatabaseInterface;
+
+final class AffinityCalculator
+{
+    public function __construct(
+        private readonly DatabaseInterface $database,
+        private readonly AffinityCache $cache,
+        private readonly float $baseAffinity = 1.0,
+        private readonly float $followPoints = 4.0,
+        private readonly float $sameCommunityPoints = 3.0,
+        private readonly float $reactionPoints = 1.0,
+        private readonly float $reactionMax = 5.0,
+        private readonly float $commentPoints = 2.0,
+        private readonly float $commentMax = 6.0,
+        private readonly float $geoCloseKm = 50.0,
+        private readonly float $geoClosePoints = 2.0,
+        private readonly float $geoMidKm = 150.0,
+        private readonly float $geoMidPoints = 1.0,
+        private readonly int $lookbackDays = 30,
+    ) {}
+
+    /**
+     * Compute affinity scores for a user against a set of source keys.
+     *
+     * @param int|null $userId Null for anonymous users
+     * @param string[] $sourceKeys Source identifiers to score
+     * @param int|null $userCommunityId User's community for same-community bonus
+     * @param array{lat: float, lon: float}|null $userLocation User's location
+     * @param array<string, array{lat: float, lon: float, community_id?: int}>|null $sourceLocations Source locations keyed by source key
+     * @return array<string, float>|null Null for anonymous users, otherwise sourceKey => score
+     */
+    public function computeBatch(
+        ?int $userId,
+        array $sourceKeys,
+        ?int $userCommunityId,
+        ?array $userLocation,
+        ?array $sourceLocations = null,
+    ): ?array {
+        if ($userId === null) {
+            return null;
+        }
+
+        if ($sourceKeys === []) {
+            return [];
+        }
+
+        // Check cache — return cached scores if all requested keys are present.
+        $cached = $this->cache->get($userId);
+        if ($cached !== null && $this->allKeysPresent($cached, $sourceKeys)) {
+            return array_intersect_key($cached, array_flip($sourceKeys));
+        }
+
+        $follows = $this->queryFollows($userId);
+        $reactionCounts = $this->queryGroupedCounts('reaction', $userId);
+        $commentCounts = $this->queryGroupedCounts('comment', $userId);
+
+        $scores = [];
+        foreach ($sourceKeys as $key) {
+            $score = $this->baseAffinity;
+
+            if (isset($follows[$key])) {
+                $score += $this->followPoints;
+            }
+
+            if (isset($reactionCounts[$key])) {
+                $score += min($reactionCounts[$key] * $this->reactionPoints, $this->reactionMax);
+            }
+
+            if (isset($commentCounts[$key])) {
+                $score += min($commentCounts[$key] * $this->commentPoints, $this->commentMax);
+            }
+
+            $sourceMeta = $sourceLocations[$key] ?? null;
+
+            if ($sourceMeta !== null && $userCommunityId !== null
+                && isset($sourceMeta['community_id']) && $sourceMeta['community_id'] === $userCommunityId) {
+                $score += $this->sameCommunityPoints;
+            }
+
+            if ($sourceMeta !== null && $userLocation !== null
+                && isset($sourceMeta['lat'], $sourceMeta['lon'])) {
+                $distance = GeoDistance::haversine(
+                    $userLocation['lat'],
+                    $userLocation['lon'],
+                    $sourceMeta['lat'],
+                    $sourceMeta['lon'],
+                );
+
+                if ($distance <= $this->geoCloseKm) {
+                    $score += $this->geoClosePoints;
+                } elseif ($distance <= $this->geoMidKm) {
+                    $score += $this->geoMidPoints;
+                }
+            }
+
+            $scores[$key] = $score;
+        }
+
+        // Merge with any existing cached scores and store.
+        $toCache = $cached !== null ? array_merge($cached, $scores) : $scores;
+        $this->cache->set($userId, $toCache);
+
+        return $scores;
+    }
+
+    /**
+     * @param array<string, float> $cached
+     * @param string[] $sourceKeys
+     */
+    private function allKeysPresent(array $cached, array $sourceKeys): bool
+    {
+        foreach ($sourceKeys as $key) {
+            if (!isset($cached[$key])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Query follow relationships for the user (all time).
+     *
+     * @return array<string, true> Followed source keys as keys
+     */
+    private function queryFollows(int $userId): array
+    {
+        $rows = $this->database->select('follow', 'f')
+            ->fields('f', ['target_key'])
+            ->condition('user_id', $userId)
+            ->execute();
+
+        $follows = [];
+        foreach ($rows as $row) {
+            $follows[$row['target_key']] = true;
+        }
+
+        return $follows;
+    }
+
+    /**
+     * Query grouped counts per source key within the lookback window.
+     *
+     * @return array<string, int> sourceKey => count
+     */
+    private function queryGroupedCounts(string $table, int $userId): array
+    {
+        $cutoff = date('Y-m-d H:i:s', time() - ($this->lookbackDays * 86400));
+
+        $rows = $this->database->query(
+            "SELECT source_key, COUNT(*) AS cnt FROM {$table} WHERE user_id = ? AND created_at >= ? GROUP BY source_key",
+            [$userId, $cutoff],
+        );
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row['source_key']] = (int) $row['cnt'];
+        }
+
+        return $counts;
+    }
+}

--- a/tests/Minoo/Unit/Feed/Scoring/AffinityCacheTest.php
+++ b/tests/Minoo/Unit/Feed/Scoring/AffinityCacheTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Feed\Scoring;
+
+use Minoo\Feed\Scoring\AffinityCache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Cache\Backend\MemoryBackend;
+
+#[CoversClass(AffinityCache::class)]
+final class AffinityCacheTest extends TestCase
+{
+    #[Test]
+    public function cache_miss_returns_null(): void
+    {
+        $cache = new AffinityCache(new MemoryBackend());
+
+        $this->assertNull($cache->get(42));
+    }
+
+    #[Test]
+    public function set_and_get_round_trips(): void
+    {
+        $cache = new AffinityCache(new MemoryBackend());
+        $scores = ['source_a' => 3.5, 'source_b' => 1.0];
+
+        $cache->set(1, $scores);
+
+        $this->assertSame($scores, $cache->get(1));
+    }
+
+    #[Test]
+    public function invalidate_removes_cached_scores(): void
+    {
+        $cache = new AffinityCache(new MemoryBackend());
+        $cache->set(1, ['source_a' => 2.0]);
+
+        $cache->invalidate(1);
+
+        $this->assertNull($cache->get(1));
+    }
+
+    #[Test]
+    public function independent_users_do_not_interfere(): void
+    {
+        $cache = new AffinityCache(new MemoryBackend());
+        $cache->set(1, ['source_a' => 1.0]);
+        $cache->set(2, ['source_b' => 5.0]);
+
+        $this->assertSame(['source_a' => 1.0], $cache->get(1));
+        $this->assertSame(['source_b' => 5.0], $cache->get(2));
+
+        $cache->invalidate(1);
+
+        $this->assertNull($cache->get(1));
+        $this->assertSame(['source_b' => 5.0], $cache->get(2));
+    }
+}

--- a/tests/Minoo/Unit/Feed/Scoring/AffinityCalculatorTest.php
+++ b/tests/Minoo/Unit/Feed/Scoring/AffinityCalculatorTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Feed\Scoring;
+
+use Minoo\Feed\Scoring\AffinityCache;
+use Minoo\Feed\Scoring\AffinityCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Cache\Backend\MemoryBackend;
+use Waaseyaa\Database\DBALDatabase;
+
+#[CoversClass(AffinityCalculator::class)]
+final class AffinityCalculatorTest extends TestCase
+{
+    private DBALDatabase $db;
+    private AffinityCache $affinityCache;
+
+    protected function setUp(): void
+    {
+        $this->db = DBALDatabase::createSqlite();
+        $this->affinityCache = new AffinityCache(new MemoryBackend());
+
+        $this->createTables();
+    }
+
+    private function createTables(): void
+    {
+        $schema = $this->db->schema();
+
+        $schema->createTable('follow', [
+            'fields' => [
+                'id' => ['type' => 'serial', 'not null' => true],
+                'user_id' => ['type' => 'int', 'not null' => true],
+                'target_key' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            ],
+            'primary key' => ['id'],
+        ]);
+
+        $schema->createTable('reaction', [
+            'fields' => [
+                'id' => ['type' => 'serial', 'not null' => true],
+                'user_id' => ['type' => 'int', 'not null' => true],
+                'source_key' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+                'created_at' => ['type' => 'varchar', 'length' => 32, 'not null' => true],
+            ],
+            'primary key' => ['id'],
+        ]);
+
+        $schema->createTable('comment', [
+            'fields' => [
+                'id' => ['type' => 'serial', 'not null' => true],
+                'user_id' => ['type' => 'int', 'not null' => true],
+                'source_key' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+                'created_at' => ['type' => 'varchar', 'length' => 32, 'not null' => true],
+            ],
+            'primary key' => ['id'],
+        ]);
+    }
+
+    private function makeCalculator(): AffinityCalculator
+    {
+        return new AffinityCalculator($this->db, $this->affinityCache);
+    }
+
+    #[Test]
+    public function anonymous_user_returns_null(): void
+    {
+        $calc = $this->makeCalculator();
+
+        $result = $calc->computeBatch(null, ['source_a'], null, null);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function unknown_source_gets_base_affinity(): void
+    {
+        $calc = $this->makeCalculator();
+
+        $result = $calc->computeBatch(1, ['source_a'], null, null);
+
+        $this->assertNotNull($result);
+        $this->assertSame(1.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function follow_adds_points(): void
+    {
+        $this->db->insert('follow')
+            ->fields(['user_id', 'target_key'])
+            ->values([1, 'source_a'])
+            ->execute();
+
+        $calc = $this->makeCalculator();
+        $result = $calc->computeBatch(1, ['source_a', 'source_b'], null, null);
+
+        $this->assertNotNull($result);
+        // source_a: base(1) + follow(4) = 5
+        $this->assertSame(5.0, $result['source_a']);
+        // source_b: base(1) only
+        $this->assertSame(1.0, $result['source_b']);
+    }
+
+    #[Test]
+    public function reactions_add_capped_points(): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        // Add 7 reactions — should be capped at reactionMax (5.0)
+        for ($i = 0; $i < 7; $i++) {
+            $this->db->insert('reaction')
+                ->fields(['user_id', 'source_key', 'created_at'])
+                ->values([1, 'source_a', $now])
+                ->execute();
+        }
+
+        $calc = $this->makeCalculator();
+        $result = $calc->computeBatch(1, ['source_a'], null, null);
+
+        $this->assertNotNull($result);
+        // base(1) + min(7*1, 5) = 6.0
+        $this->assertSame(6.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function comments_add_capped_points(): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        // Add 5 comments — should be capped at commentMax (6.0)
+        for ($i = 0; $i < 5; $i++) {
+            $this->db->insert('comment')
+                ->fields(['user_id', 'source_key', 'created_at'])
+                ->values([1, 'source_a', $now])
+                ->execute();
+        }
+
+        $calc = $this->makeCalculator();
+        $result = $calc->computeBatch(1, ['source_a'], null, null);
+
+        $this->assertNotNull($result);
+        // base(1) + min(5*2, 6) = 7.0
+        $this->assertSame(7.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function same_community_adds_points(): void
+    {
+        $calc = $this->makeCalculator();
+
+        $sourceLocations = [
+            'source_a' => ['lat' => 46.0, 'lon' => -81.0, 'community_id' => 10],
+            'source_b' => ['lat' => 46.0, 'lon' => -81.0, 'community_id' => 20],
+        ];
+
+        $result = $calc->computeBatch(1, ['source_a', 'source_b'], 10, null, $sourceLocations);
+
+        $this->assertNotNull($result);
+        // source_a: base(1) + sameCommunity(3) = 4
+        $this->assertSame(4.0, $result['source_a']);
+        // source_b: base(1) only (different community)
+        $this->assertSame(1.0, $result['source_b']);
+    }
+
+    #[Test]
+    public function geo_proximity_close_adds_points(): void
+    {
+        $calc = $this->makeCalculator();
+
+        // Two points ~11 km apart (within 50 km)
+        $userLocation = ['lat' => 46.0, 'lon' => -81.0];
+        $sourceLocations = [
+            'source_a' => ['lat' => 46.1, 'lon' => -81.0],
+        ];
+
+        $result = $calc->computeBatch(1, ['source_a'], null, $userLocation, $sourceLocations);
+
+        $this->assertNotNull($result);
+        // base(1) + geoClose(2) = 3
+        $this->assertSame(3.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function geo_proximity_mid_adds_points(): void
+    {
+        $calc = $this->makeCalculator();
+
+        // Two points ~111 km apart (between 50 and 150 km)
+        $userLocation = ['lat' => 46.0, 'lon' => -81.0];
+        $sourceLocations = [
+            'source_a' => ['lat' => 47.0, 'lon' => -81.0],
+        ];
+
+        $result = $calc->computeBatch(1, ['source_a'], null, $userLocation, $sourceLocations);
+
+        $this->assertNotNull($result);
+        // base(1) + geoMid(1) = 2
+        $this->assertSame(2.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function geo_beyond_mid_range_gets_no_bonus(): void
+    {
+        $calc = $this->makeCalculator();
+
+        // Two points ~555 km apart (beyond 150 km)
+        $userLocation = ['lat' => 46.0, 'lon' => -81.0];
+        $sourceLocations = [
+            'source_a' => ['lat' => 51.0, 'lon' => -81.0],
+        ];
+
+        $result = $calc->computeBatch(1, ['source_a'], null, $userLocation, $sourceLocations);
+
+        $this->assertNotNull($result);
+        // base(1) only
+        $this->assertSame(1.0, $result['source_a']);
+    }
+
+    #[Test]
+    public function cache_is_used_on_second_call(): void
+    {
+        $this->db->insert('follow')
+            ->fields(['user_id', 'target_key'])
+            ->values([1, 'source_a'])
+            ->execute();
+
+        $calc = $this->makeCalculator();
+
+        // First call populates cache.
+        $result1 = $calc->computeBatch(1, ['source_a'], null, null);
+        $this->assertSame(5.0, $result1['source_a']);
+
+        // Remove the follow row — second call should still return cached value.
+        $this->db->delete('follow')
+            ->condition('user_id', 1)
+            ->execute();
+
+        $result2 = $calc->computeBatch(1, ['source_a'], null, null);
+        $this->assertSame(5.0, $result2['source_a']);
+    }
+
+    #[Test]
+    public function empty_source_keys_returns_empty_array(): void
+    {
+        $calc = $this->makeCalculator();
+
+        $result = $calc->computeBatch(1, [], null, null);
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AffinityCache` — thin wrapper around `CacheBackendInterface` for per-user affinity score caching with 15-minute TTL
- Add `AffinityCalculator` — computes user-source affinity from interaction history (follows, reactions, comments, community membership, geo proximity) with configurable point values and caps
- 15 tests (29 assertions) covering cache round-trips, all scoring signals, capping, geo tiers, anonymous users, and cache hit behavior

## Test plan
- [x] `./vendor/bin/phpunit tests/Minoo/Unit/Feed/Scoring/` — 15 tests, 29 assertions pass
- [x] `./vendor/bin/phpunit --testsuite MinooUnit` — 681 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)