### PR TITLE
feat: add feed ranking algorithm with scoring pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
                 "Minoo\\Provider\\OralHistoryServiceProvider",
                 "Minoo\\Provider\\ContributorServiceProvider",
                 "Minoo\\Provider\\EngagementServiceProvider",
+                "Minoo\\Provider\\FeedScoringServiceProvider",
                 "Minoo\\Provider\\FeedServiceProvider"
             ]
         }

--- a/config/feed_scoring.php
+++ b/config/feed_scoring.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Time-decay half-life in hours (content loses half its score after this many hours)
+    'decay_half_life_hours' => 24.0,
+
+    // Engagement weight multipliers
+    'reaction_weight' => 1.0,
+    'comment_weight' => 2.0,
+
+    // Affinity signal weights
+    'affinity_reaction_weight' => 1.0,
+    'affinity_comment_weight' => 2.0,
+    'affinity_follow_weight' => 5.0,
+
+    // Featured item score boost
+    'featured_boost' => 100.0,
+
+    // Diversity reranker window size
+    'diversity_window_size' => 3,
+];

--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -465,6 +465,12 @@ final class FeedController
 
         $activeFilter = $resolvedFilter ?? self::resolveFilter($query['filter'] ?? 'all')['filter'];
 
+        $userId = null;
+        if ($account !== null && $account->isAuthenticated()) {
+            $id = $account->id();
+            $userId = $id !== null ? (int) $id : null;
+        }
+
         return new FeedContext(
             latitude: $lat,
             longitude: $lon,
@@ -473,6 +479,7 @@ final class FeedController
             limit: min((int) ($query['limit'] ?? 20), 50),
             isFirstVisit: $isFirstVisit,
             isAuthenticated: $account?->isAuthenticated() ?? false,
+            userId: $userId,
         );
     }
 }

--- a/src/Feed/FeedAssembler.php
+++ b/src/Feed/FeedAssembler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Minoo\Feed;
 
+use Minoo\Feed\Scoring\FeedScorer;
 use Minoo\Support\GeoDistance;
 
 final class FeedAssembler implements FeedAssemblerInterface
@@ -12,6 +13,7 @@ final class FeedAssembler implements FeedAssemblerInterface
         private readonly EntityLoaderService $loader,
         private readonly FeedItemFactory $factory,
         private readonly ?EngagementCounter $engagementCounter = null,
+        private readonly ?FeedScorer $scorer = null,
     ) {}
 
     public function assemble(FeedContext $ctx): FeedResponse
@@ -110,8 +112,12 @@ final class FeedAssembler implements FeedAssemblerInterface
             }));
         }
 
-        // 5. Sort
-        usort($items, fn(FeedItem $a, FeedItem $b) => strcmp($a->sortKey, $b->sortKey));
+        // 5. Score or Sort
+        if ($this->scorer !== null) {
+            $items = $this->scorer->score($items, $ctx->userId);
+        } else {
+            usort($items, fn(FeedItem $a, FeedItem $b) => strcmp($a->sortKey, $b->sortKey));
+        }
 
         // 6. Paginate
         $startIdx = 0;
@@ -131,7 +137,8 @@ final class FeedAssembler implements FeedAssemblerInterface
         $pageItems = array_slice($items, $startIdx, $ctx->limit);
 
         // 6b. Attach engagement counts only to the page (not all items)
-        if ($this->engagementCounter !== null) {
+        // Skip if scorer already attached engagement counts
+        if ($this->scorer === null && $this->engagementCounter !== null) {
             $pageItems = $this->attachEngagementCounts($pageItems);
         }
 

--- a/src/Feed/FeedContext.php
+++ b/src/Feed/FeedContext.php
@@ -18,6 +18,7 @@ final readonly class FeedContext
         public int $limit = 20,
         public bool $isFirstVisit = false,
         public bool $isAuthenticated = false,
+        public ?int $userId = null,
     ) {}
 
     public static function defaults(): self

--- a/src/Feed/FeedItem.php
+++ b/src/Feed/FeedItem.php
@@ -34,6 +34,7 @@ final readonly class FeedItem
         public ?string $communitySlug = null,
         public ?string $communityInitial = null,
         public ?string $authorName = null,
+        public ?float $score = null,
     ) {}
 
     public function isSynthetic(): bool
@@ -94,6 +95,9 @@ final readonly class FeedItem
         }
         if ($this->authorName !== null) {
             $data['authorName'] = $this->authorName;
+        }
+        if ($this->score !== null) {
+            $data['score'] = round($this->score, 4);
         }
 
         return $data;

--- a/src/Feed/Scoring/AffinityCache.php
+++ b/src/Feed/Scoring/AffinityCache.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+/**
+ * Per-request memory cache for user affinity scores.
+ *
+ * Uses a simple in-memory array backend. Acceptable at current scale
+ * (affinity is computed once per request). Can be swapped for Redis/Memcached later.
+ */
+final class AffinityCache
+{
+    /** @var array<string, array<string, float>> userId => [sourceKey => score] */
+    private array $cache = [];
+
+    /**
+     * Get cached affinity scores for a user.
+     *
+     * @return array<string, float>|null null if not cached
+     */
+    public function get(int $userId): ?array
+    {
+        return $this->cache[(string) $userId] ?? null;
+    }
+
+    /**
+     * Store affinity scores for a user.
+     *
+     * @param array<string, float> $scores sourceKey => affinity score
+     */
+    public function set(int $userId, array $scores): void
+    {
+        $this->cache[(string) $userId] = $scores;
+    }
+
+    /**
+     * Invalidate all cached data for a user.
+     */
+    public function invalidate(int $userId): void
+    {
+        unset($this->cache[(string) $userId]);
+    }
+
+    /**
+     * Clear the entire cache.
+     */
+    public function clear(): void
+    {
+        $this->cache = [];
+    }
+}

--- a/src/Feed/Scoring/AffinityCalculator.php
+++ b/src/Feed/Scoring/AffinityCalculator.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Computes user-source affinity scores based on past engagement.
+ *
+ * Affinity = sum of weighted interactions (reactions, comments, follows)
+ * between a user and a content source (user, community, entity).
+ */
+final class AffinityCalculator
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly AffinityCache $cache,
+        private readonly float $reactionAffinity = 1.0,
+        private readonly float $commentAffinity = 2.0,
+        private readonly float $followAffinity = 5.0,
+    ) {}
+
+    /**
+     * Compute affinity scores between a user and multiple source keys.
+     *
+     * @param int $userId
+     * @param list<string> $sourceKeys e.g. ["user:42", "community:7"]
+     * @return array<string, float> sourceKey => affinity score (default 1.0)
+     */
+    public function computeBatch(int $userId, array $sourceKeys): array
+    {
+        $cached = $this->cache->get($userId);
+        if ($cached !== null) {
+            // Return cached values, defaulting missing keys to 1.0
+            $result = [];
+            foreach ($sourceKeys as $key) {
+                $result[$key] = $cached[$key] ?? 1.0;
+            }
+            return $result;
+        }
+
+        $scores = $this->computeFromStorage($userId, $sourceKeys);
+        $this->cache->set($userId, $scores);
+
+        return $scores;
+    }
+
+    /**
+     * @param list<string> $sourceKeys
+     * @return array<string, float>
+     */
+    private function computeFromStorage(int $userId, array $sourceKeys): array
+    {
+        $result = [];
+        foreach ($sourceKeys as $key) {
+            $result[$key] = 1.0; // Base affinity
+        }
+
+        // Count reactions by user toward each source's content
+        if ($this->entityTypeManager->hasDefinition('reaction')) {
+            try {
+                $storage = $this->entityTypeManager->getStorage('reaction');
+                $ids = $storage->getQuery()
+                    ->condition('user_id', $userId)
+                    ->execute();
+
+                if ($ids !== []) {
+                    $reactions = array_values($storage->loadMultiple($ids));
+                    foreach ($reactions as $reaction) {
+                        $targetType = (string) ($reaction->get('target_type') ?? '');
+                        $targetId = (string) ($reaction->get('target_id') ?? '');
+                        $sourceKey = $this->resolveSourceFromTarget($targetType, $targetId);
+                        if ($sourceKey !== null && isset($result[$sourceKey])) {
+                            $result[$sourceKey] += $this->reactionAffinity;
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                // Silently continue — affinity is best-effort
+            }
+        }
+
+        // Count comments by user
+        if ($this->entityTypeManager->hasDefinition('comment')) {
+            try {
+                $storage = $this->entityTypeManager->getStorage('comment');
+                $ids = $storage->getQuery()
+                    ->condition('user_id', $userId)
+                    ->execute();
+
+                if ($ids !== []) {
+                    $comments = array_values($storage->loadMultiple($ids));
+                    foreach ($comments as $comment) {
+                        $targetType = (string) ($comment->get('target_type') ?? '');
+                        $targetId = (string) ($comment->get('target_id') ?? '');
+                        $sourceKey = $this->resolveSourceFromTarget($targetType, $targetId);
+                        if ($sourceKey !== null && isset($result[$sourceKey])) {
+                            $result[$sourceKey] += $this->commentAffinity;
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                // Silently continue
+            }
+        }
+
+        // Count follows by user
+        if ($this->entityTypeManager->hasDefinition('follow')) {
+            try {
+                $storage = $this->entityTypeManager->getStorage('follow');
+                $ids = $storage->getQuery()
+                    ->condition('user_id', $userId)
+                    ->execute();
+
+                if ($ids !== []) {
+                    $follows = array_values($storage->loadMultiple($ids));
+                    foreach ($follows as $follow) {
+                        $targetType = (string) ($follow->get('target_type') ?? '');
+                        $targetId = (string) ($follow->get('target_id') ?? '');
+                        $key = $targetType . ':' . $targetId;
+                        if (isset($result[$key])) {
+                            $result[$key] += $this->followAffinity;
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                // Silently continue
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolve a target (type:id) to its source key for affinity tracking.
+     * Posts map to user:{user_id}, other types map to {type}:{id}.
+     */
+    private function resolveSourceFromTarget(string $targetType, string $targetId): ?string
+    {
+        if ($targetType === '' || $targetId === '') {
+            return null;
+        }
+
+        if ($targetType === 'post') {
+            // Try to resolve post author
+            try {
+                $storage = $this->entityTypeManager->getStorage('post');
+                $post = $storage->load($targetId);
+                if ($post !== null) {
+                    $authorId = $post->get('user_id');
+                    if ($authorId !== null) {
+                        return 'user:' . $authorId;
+                    }
+                }
+            } catch (\Throwable) {
+                // Fall through
+            }
+        }
+
+        return $targetType . ':' . $targetId;
+    }
+}

--- a/src/Feed/Scoring/DecayCalculator.php
+++ b/src/Feed/Scoring/DecayCalculator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+/**
+ * Time-decay function for feed scoring.
+ *
+ * Uses exponential decay: score = e^(-lambda * age_hours)
+ * where lambda = ln(2) / halfLifeHours.
+ */
+final class DecayCalculator
+{
+    private readonly float $lambda;
+
+    public function __construct(
+        private readonly float $halfLifeHours = 24.0,
+    ) {
+        $this->lambda = log(2) / $this->halfLifeHours;
+    }
+
+    /**
+     * Compute decay factor for a given creation time.
+     *
+     * @return float Between 0.0 and 1.0 (1.0 = brand new)
+     */
+    public function compute(\DateTimeImmutable $createdAt, ?\DateTimeImmutable $now = null): float
+    {
+        $now ??= new \DateTimeImmutable();
+        $ageSeconds = $now->getTimestamp() - $createdAt->getTimestamp();
+
+        if ($ageSeconds <= 0) {
+            return 1.0;
+        }
+
+        $ageHours = $ageSeconds / 3600.0;
+
+        return exp(-$this->lambda * $ageHours);
+    }
+}

--- a/src/Feed/Scoring/DiversityReranker.php
+++ b/src/Feed/Scoring/DiversityReranker.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+use Minoo\Feed\FeedItem;
+
+/**
+ * Reranks scored feed items to ensure content diversity.
+ *
+ * Prevents consecutive items of the same type or community from clustering.
+ * Uses a sliding window approach: if the current item matches the previous
+ * item's type AND community, try to swap it with the next different item.
+ */
+final class DiversityReranker
+{
+    public function __construct(
+        private readonly int $windowSize = 3,
+    ) {}
+
+    /**
+     * Rerank items to improve diversity.
+     *
+     * @param list<FeedItem> $items Already sorted by score descending
+     * @return list<FeedItem>
+     */
+    public function rerank(array $items): array
+    {
+        $count = count($items);
+        if ($count <= 2) {
+            return $items;
+        }
+
+        for ($i = 1; $i < $count; $i++) {
+            $currentType = $items[$i]->type;
+            $currentCommunity = $items[$i]->communitySlug;
+            $prevType = $items[$i - 1]->type;
+            $prevCommunity = $items[$i - 1]->communitySlug;
+
+            // Only swap if both type AND community match the previous item
+            if ($currentType === $prevType && $currentCommunity === $prevCommunity) {
+                // Look ahead in window for a different item to swap with
+                $swapIdx = $this->findSwapCandidate($items, $i, $currentType, $currentCommunity);
+                if ($swapIdx !== null) {
+                    [$items[$i], $items[$swapIdx]] = [$items[$swapIdx], $items[$i]];
+                }
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Find the nearest item within the window that differs in type OR community.
+     */
+    private function findSwapCandidate(array $items, int $currentIdx, string $currentType, ?string $currentCommunity): ?int
+    {
+        $maxIdx = min($currentIdx + $this->windowSize, count($items) - 1);
+
+        for ($j = $currentIdx + 1; $j <= $maxIdx; $j++) {
+            if ($items[$j]->type !== $currentType || $items[$j]->communitySlug !== $currentCommunity) {
+                return $j;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Feed/Scoring/EngagementCalculator.php
+++ b/src/Feed/Scoring/EngagementCalculator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+/**
+ * Computes engagement weight for feed items based on reaction/comment counts.
+ *
+ * Uses log-dampened formula: 1 + ln(1 + reactionWeight*reactions + commentWeight*comments)
+ */
+final class EngagementCalculator
+{
+    public function __construct(
+        private readonly float $reactionWeight = 1.0,
+        private readonly float $commentWeight = 2.0,
+    ) {}
+
+    /**
+     * Compute engagement weight for a single target.
+     *
+     * @return float >= 1.0 (1.0 = no engagement)
+     */
+    public function compute(int $reactions, int $comments): float
+    {
+        $weighted = $this->reactionWeight * $reactions + $this->commentWeight * $comments;
+
+        return 1.0 + log(1.0 + $weighted);
+    }
+
+    /**
+     * Batch-compute engagement weights for multiple targets.
+     *
+     * @param array<string, array{reactions: int, comments: int}> $counts Keyed by "type:id"
+     * @return array<string, float> Keyed by "type:id"
+     */
+    public function computeBatch(array $counts): array
+    {
+        $result = [];
+        foreach ($counts as $key => $count) {
+            $result[$key] = $this->compute($count['reactions'], $count['comments']);
+        }
+        return $result;
+    }
+}

--- a/src/Feed/Scoring/FeedScorer.php
+++ b/src/Feed/Scoring/FeedScorer.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Feed\Scoring;
+
+use Minoo\Feed\EngagementCounter;
+use Minoo\Feed\FeedItem;
+
+/**
+ * Central orchestrator for feed ranking.
+ *
+ * Combines affinity, engagement, and time-decay signals into a single score
+ * per feed item. Applies diversity reranking after scoring.
+ */
+final class FeedScorer
+{
+    public function __construct(
+        private readonly AffinityCalculator $affinity,
+        private readonly EngagementCalculator $engagement,
+        private readonly DecayCalculator $decay,
+        private readonly DiversityReranker $reranker,
+        private readonly EngagementCounter $engagementCounter,
+        private readonly float $featuredBoost = 100.0,
+    ) {}
+
+    /**
+     * Score, sort, and rerank feed items.
+     *
+     * @param list<FeedItem> $items Unscored feed items
+     * @param int|null $userId Authenticated user ID (null for anonymous)
+     * @return list<FeedItem> Scored and reranked items
+     */
+    public function score(array $items, ?int $userId = null): array
+    {
+        if ($items === []) {
+            return [];
+        }
+
+        // Separate synthetic items (welcome, communities) — they get pinned to top
+        $synthetic = [];
+        $scorable = [];
+        foreach ($items as $item) {
+            if ($item->isSynthetic()) {
+                $synthetic[] = $item;
+            } else {
+                $scorable[] = $item;
+            }
+        }
+
+        if ($scorable === []) {
+            return $synthetic;
+        }
+
+        // 1. Resolve source keys and build target keys for batch operations
+        $sourceKeys = [];
+        $sourceMap = []; // itemIndex => sourceKey
+        $targetKeys = []; // [{type, id}]
+
+        foreach ($scorable as $idx => $item) {
+            $sourceKey = $this->resolveSourceKey($item);
+            $sourceMap[$idx] = $sourceKey;
+            $sourceKeys[$sourceKey] = true;
+            $targetKeys[] = ['type' => $item->type, 'id' => (int) $item->id];
+        }
+
+        // 2. Batch compute affinity scores
+        $affinityScores = [];
+        if ($userId !== null) {
+            $affinityScores = $this->affinity->computeBatch($userId, array_keys($sourceKeys));
+        }
+
+        // 3. Batch compute engagement counts and weights
+        $engagementCounts = $this->engagementCounter->getCounts($targetKeys);
+        $engagementWeights = $this->engagement->computeBatch($engagementCounts);
+
+        // 4. Compute per-item scores
+        $now = new \DateTimeImmutable();
+        $scored = [];
+
+        foreach ($scorable as $idx => $item) {
+            $decayFactor = $this->decay->compute($item->createdAt, $now);
+            $targetKey = $item->type . ':' . $item->id;
+
+            if ($item->weight >= 1000) {
+                $score = $this->featuredBoost * $decayFactor;
+            } else {
+                $sourceKey = $sourceMap[$idx];
+                $affinity = $affinityScores[$sourceKey] ?? 1.0;
+                $engWeight = $engagementWeights[$targetKey] ?? 1.0;
+
+                $score = $affinity * $engWeight * $decayFactor;
+            }
+
+            $counts = $engagementCounts[$targetKey] ?? null;
+
+            $scored[] = new FeedItem(
+                id: $item->id,
+                type: $item->type,
+                title: $item->title,
+                url: $item->url,
+                badge: $item->badge,
+                weight: $item->weight,
+                createdAt: $item->createdAt,
+                sortKey: sprintf('%020.10f_%s', 1e10 - $score, $item->id),
+                entity: $item->entity,
+                subtitle: $item->subtitle,
+                date: $item->date,
+                distance: $item->distance,
+                communityName: $item->communityName,
+                meta: $item->meta,
+                payload: $item->payload,
+                reactionCount: $counts !== null ? ($counts['reactions'] ?? 0) : $item->reactionCount,
+                commentCount: $counts !== null ? ($counts['comments'] ?? 0) : $item->commentCount,
+                userReaction: $item->userReaction,
+                relativeTime: $item->relativeTime,
+                communitySlug: $item->communitySlug,
+                communityInitial: $item->communityInitial,
+                authorName: $item->authorName,
+                score: $score,
+            );
+        }
+
+        // 5. Sort by score descending (via sortKey)
+        usort($scored, fn(FeedItem $a, FeedItem $b) => strcmp($a->sortKey, $b->sortKey));
+
+        // 6. Diversity reranking
+        $scored = $this->reranker->rerank($scored);
+
+        // 7. Pin synthetic items to top
+        return array_merge($synthetic, $scored);
+    }
+
+    /**
+     * Resolve the source key for affinity tracking.
+     *
+     * post -> user:{user_id}
+     * event/teaching -> community:{community_id} (fallback {type}:{id})
+     * group/business/person -> {type}:{id}
+     */
+    private function resolveSourceKey(FeedItem $item): string
+    {
+        if ($item->type === 'post' && $item->entity !== null) {
+            $userId = $item->entity->get('user_id');
+            if ($userId !== null) {
+                return 'user:' . $userId;
+            }
+        }
+
+        if (in_array($item->type, ['event', 'teaching'], true) && $item->entity !== null) {
+            $communityId = $item->entity->get('community_id');
+            if ($communityId !== null) {
+                return 'community:' . $communityId;
+            }
+        }
+
+        return $item->type . ':' . $item->id;
+    }
+}

--- a/src/Provider/FeedScoringServiceProvider.php
+++ b/src/Provider/FeedScoringServiceProvider.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Provider;
+
+use Minoo\Feed\EngagementCounter;
+use Minoo\Feed\Scoring\AffinityCache;
+use Minoo\Feed\Scoring\AffinityCalculator;
+use Minoo\Feed\Scoring\DecayCalculator;
+use Minoo\Feed\Scoring\DiversityReranker;
+use Minoo\Feed\Scoring\EngagementCalculator;
+use Minoo\Feed\Scoring\FeedScorer;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+final class FeedScoringServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $config = $this->loadConfig();
+
+        $this->singleton(AffinityCache::class, fn(): AffinityCache => new AffinityCache());
+
+        $this->singleton(DecayCalculator::class, fn(): DecayCalculator => new DecayCalculator(
+            halfLifeHours: (float) $config['decay_half_life_hours'],
+        ));
+
+        $this->singleton(EngagementCalculator::class, fn(): EngagementCalculator => new EngagementCalculator(
+            reactionWeight: (float) $config['reaction_weight'],
+            commentWeight: (float) $config['comment_weight'],
+        ));
+
+        $this->singleton(AffinityCalculator::class, fn(): AffinityCalculator => new AffinityCalculator(
+            entityTypeManager: $this->resolve(EntityTypeManager::class),
+            cache: $this->resolve(AffinityCache::class),
+            reactionAffinity: (float) $config['affinity_reaction_weight'],
+            commentAffinity: (float) $config['affinity_comment_weight'],
+            followAffinity: (float) $config['affinity_follow_weight'],
+        ));
+
+        $this->singleton(DiversityReranker::class, fn(): DiversityReranker => new DiversityReranker(
+            windowSize: (int) $config['diversity_window_size'],
+        ));
+
+        $this->singleton(FeedScorer::class, fn(): FeedScorer => new FeedScorer(
+            affinity: $this->resolve(AffinityCalculator::class),
+            engagement: $this->resolve(EngagementCalculator::class),
+            decay: $this->resolve(DecayCalculator::class),
+            reranker: $this->resolve(DiversityReranker::class),
+            engagementCounter: $this->resolve(EngagementCounter::class),
+            featuredBoost: (float) $config['featured_boost'],
+        ));
+    }
+
+    public function boot(): void
+    {
+        $dispatcher = $this->resolveEventDispatcher();
+        if ($dispatcher === null) {
+            return;
+        }
+
+        $cache = $this->resolve(AffinityCache::class);
+        $invalidateTypes = ['reaction', 'comment', 'follow'];
+
+        // Shared handler: invalidate affinity cache when engagement entities change
+        $invalidator = static function (object $event) use ($cache, $invalidateTypes): void {
+            $entity = $event->entity ?? null;
+            if ($entity === null) {
+                return;
+            }
+
+            $type = method_exists($entity, 'getEntityTypeId') ? $entity->getEntityTypeId() : '';
+            if (!in_array($type, $invalidateTypes, true)) {
+                return;
+            }
+
+            $userId = $entity->get('user_id');
+            if ($userId !== null) {
+                $cache->invalidate((int) $userId);
+            }
+        };
+
+        $dispatcher->addListener('entity.post_save', $invalidator);
+        $dispatcher->addListener('entity.post_delete', $invalidator);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadConfig(): array
+    {
+        $configPath = dirname(__DIR__, 2) . '/config/feed_scoring.php';
+        if (is_file($configPath)) {
+            return require $configPath;
+        }
+
+        return [
+            'decay_half_life_hours' => 24.0,
+            'reaction_weight' => 1.0,
+            'comment_weight' => 2.0,
+            'affinity_reaction_weight' => 1.0,
+            'affinity_comment_weight' => 2.0,
+            'affinity_follow_weight' => 5.0,
+            'featured_boost' => 100.0,
+            'diversity_window_size' => 3,
+        ];
+    }
+
+    private function resolveEventDispatcher(): ?object
+    {
+        try {
+            return $this->resolve(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Provider/FeedServiceProvider.php
+++ b/src/Provider/FeedServiceProvider.php
@@ -8,6 +8,7 @@ use Minoo\Feed\EntityLoaderService;
 use Minoo\Feed\FeedAssembler;
 use Minoo\Feed\FeedAssemblerInterface;
 use Minoo\Feed\FeedItemFactory;
+use Minoo\Feed\Scoring\FeedScorer;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
@@ -23,10 +24,20 @@ final class FeedServiceProvider extends ServiceProvider
 
         $this->singleton(FeedItemFactory::class, fn(): FeedItemFactory => new FeedItemFactory());
 
-        $this->singleton(FeedAssemblerInterface::class, fn(): FeedAssemblerInterface => new FeedAssembler(
-            $this->resolve(EntityLoaderService::class),
-            $this->resolve(FeedItemFactory::class),
-        ));
+        $this->singleton(FeedAssemblerInterface::class, function (): FeedAssemblerInterface {
+            $scorer = null;
+            try {
+                $scorer = $this->resolve(FeedScorer::class);
+            } catch (\Throwable) {
+                // FeedScoringServiceProvider may not be registered
+            }
+
+            return new FeedAssembler(
+                $this->resolve(EntityLoaderService::class),
+                $this->resolve(FeedItemFactory::class),
+                scorer: $scorer,
+            );
+        });
     }
 
     public function routes(WaaseyaaRouter $router, ?\Waaseyaa\Entity\EntityTypeManager $entityTypeManager = null): void

--- a/tests/Minoo/Integration/Feed/FeedScoringIntegrationTest.php
+++ b/tests/Minoo/Integration/Feed/FeedScoringIntegrationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Integration\Feed;
+
+use Minoo\Feed\Scoring\AffinityCache;
+use Minoo\Feed\Scoring\AffinityCalculator;
+use Minoo\Feed\Scoring\DecayCalculator;
+use Minoo\Feed\Scoring\DiversityReranker;
+use Minoo\Feed\Scoring\EngagementCalculator;
+use Minoo\Feed\Scoring\FeedScorer;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+#[CoversNothing]
+final class FeedScoringIntegrationTest extends TestCase
+{
+    private static string $projectRoot;
+    private static HttpKernel $kernel;
+
+    public static function setUpBeforeClass(): void
+    {
+        // tests/Minoo/Integration/Feed/ → 4 levels up to project root.
+        self::$projectRoot = dirname(__DIR__, 4);
+
+        // Delete stale manifest cache to force fresh compilation.
+        $cachePath = self::$projectRoot . '/storage/framework/packages.php';
+        if (is_file($cachePath)) {
+            unlink($cachePath);
+        }
+
+        // Use in-memory database for test isolation.
+        putenv('WAASEYAA_DB=:memory:');
+
+        self::$kernel = new HttpKernel(self::$projectRoot);
+        $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
+        $boot->invoke(self::$kernel);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('WAASEYAA_DB');
+
+        // Remove the manifest cache that was generated during test.
+        $cachePath = self::$projectRoot . '/storage/framework/packages.php';
+        if (is_file($cachePath)) {
+            unlink($cachePath);
+        }
+    }
+
+    #[Test]
+    public function scoring_components_are_resolvable_from_container(): void
+    {
+        $container = self::$kernel->getContainer();
+
+        $this->assertInstanceOf(DecayCalculator::class, $container->get(DecayCalculator::class));
+        $this->assertInstanceOf(EngagementCalculator::class, $container->get(EngagementCalculator::class));
+        $this->assertInstanceOf(AffinityCache::class, $container->get(AffinityCache::class));
+        $this->assertInstanceOf(AffinityCalculator::class, $container->get(AffinityCalculator::class));
+        $this->assertInstanceOf(DiversityReranker::class, $container->get(DiversityReranker::class));
+        $this->assertInstanceOf(FeedScorer::class, $container->get(FeedScorer::class));
+    }
+
+    #[Test]
+    public function feed_scorer_is_singleton(): void
+    {
+        $container = self::$kernel->getContainer();
+
+        $scorer1 = $container->get(FeedScorer::class);
+        $scorer2 = $container->get(FeedScorer::class);
+
+        $this->assertSame($scorer1, $scorer2);
+    }
+
+    #[Test]
+    public function affinity_cache_is_shared_singleton(): void
+    {
+        $container = self::$kernel->getContainer();
+
+        $cache1 = $container->get(AffinityCache::class);
+        $cache2 = $container->get(AffinityCache::class);
+
+        $this->assertSame($cache1, $cache2);
+    }
+}

--- a/tests/Minoo/Unit/Feed/Scoring/FeedScorerTest.php
+++ b/tests/Minoo/Unit/Feed/Scoring/FeedScorerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Feed\Scoring;
+
+use Minoo\Feed\EngagementCounter;
+use Minoo\Feed\FeedItem;
+use Minoo\Feed\Scoring\AffinityCalculator;
+use Minoo\Feed\Scoring\DecayCalculator;
+use Minoo\Feed\Scoring\DiversityReranker;
+use Minoo\Feed\Scoring\EngagementCalculator;
+use Minoo\Feed\Scoring\FeedScorer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FeedScorer::class)]
+final class FeedScorerTest extends TestCase
+{
+    private FeedScorer $scorer;
+    private AffinityCalculator $affinity;
+    private EngagementCounter $engagementCounter;
+
+    protected function setUp(): void
+    {
+        $this->affinity = $this->createMock(AffinityCalculator::class);
+        $this->engagementCounter = $this->createMock(EngagementCounter::class);
+
+        $this->scorer = new FeedScorer(
+            affinity: $this->affinity,
+            engagement: new EngagementCalculator(),
+            decay: new DecayCalculator(halfLifeHours: 24.0),
+            reranker: new DiversityReranker(),
+            engagementCounter: $this->engagementCounter,
+        );
+    }
+
+    #[Test]
+    public function it_returns_empty_array_for_empty_input(): void
+    {
+        $this->assertSame([], $this->scorer->score([]));
+    }
+
+    #[Test]
+    public function it_scores_items_and_sorts_by_score_descending(): void
+    {
+        $now = new \DateTimeImmutable();
+        $recentItem = $this->makeItem('1', 'post', $now->modify('-1 hour'));
+        $oldItem = $this->makeItem('2', 'event', $now->modify('-48 hours'));
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 0, 'comments' => 0],
+            'event:2' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$oldItem, $recentItem]);
+
+        $this->assertCount(2, $result);
+        // Recent item should score higher (less decay)
+        $this->assertSame('1', $result[0]->id);
+        $this->assertSame('2', $result[1]->id);
+    }
+
+    #[Test]
+    public function it_pins_synthetic_items_to_top(): void
+    {
+        $now = new \DateTimeImmutable();
+        $welcome = $this->makeItem('welcome:1', 'welcome', $now);
+        $post = $this->makeItem('1', 'post', $now->modify('-1 hour'));
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$post, $welcome]);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('welcome', $result[0]->type);
+        $this->assertSame('post', $result[1]->type);
+    }
+
+    #[Test]
+    public function it_boosts_featured_items(): void
+    {
+        $now = new \DateTimeImmutable();
+        $featured = $this->makeItem('1', 'featured', $now->modify('-2 hours'), weight: 1000);
+        $regular = $this->makeItem('2', 'post', $now->modify('-1 hour'));
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'featured:1' => ['reactions' => 0, 'comments' => 0],
+            'post:2' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$regular, $featured]);
+
+        $this->assertCount(2, $result);
+        // Featured should rank first due to boost
+        $this->assertSame('1', $result[0]->id);
+        $this->assertNotNull($result[0]->score);
+        $this->assertGreaterThan($result[1]->score, $result[0]->score);
+    }
+
+    #[Test]
+    public function it_incorporates_engagement_into_scoring(): void
+    {
+        $now = new \DateTimeImmutable();
+        $popular = $this->makeItem('1', 'post', $now->modify('-2 hours'));
+        $unpopular = $this->makeItem('2', 'post', $now->modify('-1 hour'));
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 50, 'comments' => 20],
+            'post:2' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$unpopular, $popular]);
+
+        // Popular item (despite being older) should score higher due to engagement
+        $this->assertSame('1', $result[0]->id);
+    }
+
+    #[Test]
+    public function it_uses_affinity_for_authenticated_users(): void
+    {
+        $now = new \DateTimeImmutable();
+        $item1 = $this->makeItem('1', 'event', $now->modify('-1 hour'));
+        $item2 = $this->makeItem('2', 'event', $now->modify('-1 hour'));
+
+        $this->affinity->method('computeBatch')->willReturn([
+            'event:1' => 10.0, // High affinity
+            'event:2' => 1.0,  // Base affinity
+        ]);
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'event:1' => ['reactions' => 0, 'comments' => 0],
+            'event:2' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$item2, $item1], userId: 42);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('1', $result[0]->id);
+    }
+
+    #[Test]
+    public function it_attaches_engagement_counts_to_items(): void
+    {
+        $now = new \DateTimeImmutable();
+        $item = $this->makeItem('1', 'post', $now);
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 5, 'comments' => 3],
+        ]);
+
+        $result = $this->scorer->score([$item]);
+
+        $this->assertSame(5, $result[0]->reactionCount);
+        $this->assertSame(3, $result[0]->commentCount);
+    }
+
+    #[Test]
+    public function it_sets_score_on_returned_items(): void
+    {
+        $now = new \DateTimeImmutable();
+        $item = $this->makeItem('1', 'post', $now);
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$item]);
+
+        $this->assertNotNull($result[0]->score);
+        $this->assertGreaterThan(0.0, $result[0]->score);
+    }
+
+    #[Test]
+    public function score_appears_in_toArray_output(): void
+    {
+        $now = new \DateTimeImmutable();
+        $item = $this->makeItem('1', 'post', $now);
+
+        $this->engagementCounter->method('getCounts')->willReturn([
+            'post:1' => ['reactions' => 0, 'comments' => 0],
+        ]);
+
+        $result = $this->scorer->score([$item]);
+        $array = $result[0]->toArray();
+
+        $this->assertArrayHasKey('score', $array);
+        $this->assertIsFloat($array['score']);
+    }
+
+    private function makeItem(string $id, string $type, \DateTimeImmutable $createdAt, int $weight = 0): FeedItem
+    {
+        return new FeedItem(
+            id: $id,
+            type: $type,
+            title: 'Test ' . $type . ' ' . $id,
+            url: '/' . $type . '/' . $id,
+            badge: ucfirst($type),
+            weight: $weight,
+            createdAt: $createdAt,
+            sortKey: sprintf('%010d_%05d_%s', 999999999 - $weight, 0, $id),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Implements FeedScorer orchestrator combining affinity, engagement, and time-decay signals into per-item scores
- Adds 6 scoring classes: DecayCalculator, EngagementCalculator, AffinityCalculator, AffinityCache, DiversityReranker, FeedScorer
- Integrates scoring into FeedAssembler pipeline, replacing manual sort when scorer is available
- Adds FeedScoringServiceProvider with config-driven parameters and cache invalidation on entity events
- Adds `score` property to FeedItem and `userId` to FeedContext for personalization

## Test plan
- [ ] Run `./vendor/bin/phpunit tests/Minoo/Unit/Feed/Scoring/FeedScorerTest.php` — 8 unit tests
- [ ] Run `./vendor/bin/phpunit --testsuite MinooUnit` — all unit tests pass
- [ ] Run `./vendor/bin/phpunit --testsuite MinooIntegration` — integration test verifies DI wiring
- [ ] Verify feed page loads with scoring active (scorer sorts by score, not sortKey)
- [ ] Verify anonymous users get engagement+decay scoring (no affinity)
- [ ] Verify authenticated users get personalized affinity-based ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)