### PR TITLE
feat(#508,#509,#510,#511): search result card redesign

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -98,6 +98,7 @@
     --color-programs: #c77dff;
     --color-businesses: oklch(0.65 0.18 25);
     --color-search: #d4a373;
+    --accent-surface: rgba(42, 157, 143, 0.1);
 
     /* ── Borders ── */
     --border-dark: #1e1e1e;
@@ -1371,10 +1372,62 @@
     max-inline-size: unset;
   }
 
+  .search-result-card__layout {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .search-result-card__image {
+    flex-shrink: 0;
+    width: 120px;
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .search-result-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .search-result-card__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
+  }
+
+  @media (max-width: 47.999em) {
+    .search-result-card__image {
+      display: none;
+    }
+  }
+
   .search-result-card__badges {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-3xs);
+  }
+
+  .card__meta-sep {
+    color: var(--text-muted);
+    margin-inline: var(--space-3xs);
+  }
+
+  .search-result-card mark {
+    background: rgba(42, 157, 143, 0.15);
+    color: var(--color-language);
+    padding-inline: 0.15em;
+    border-radius: 2px;
+  }
+
+  .search-result-card .card__body {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
   /* Pagination */

--- a/templates/components/search-result-card.html.twig
+++ b/templates/components/search-result-card.html.twig
@@ -11,33 +11,45 @@
 {% set badge_class = badge_map[type_key] ?? 'page' %}
 {% set badge_label_key = 'search.badge_' ~ (badge_map[type_key] ?? type_key) %}
 
-<article class="card search-result-card">
-  <div class="search-result-card__badges">
-    <span class="search-result__badge search-result__badge--{{ badge_class }}">{{ trans(badge_label_key) }}</span>
-    {% if topics is defined %}
-      {% for topic in topics[:3] %}
-        <span class="card__tag">{{ topic|replace({'_': ' '}) }}</span>
-      {% endfor %}
+<article class="card search-result-card card--{{ badge_class }}">
+  <div class="search-result-card__layout">
+    {% if og_image is defined and og_image %}
+      <div class="search-result-card__image">
+        <img src="{{ og_image }}" alt="" loading="lazy" decoding="async">
+      </div>
     {% endif %}
+    <div class="search-result-card__content">
+      <div class="search-result-card__badges">
+        {% if badge_class != 'page' %}
+          <span class="search-result__badge search-result__badge--{{ badge_class }}">{{ trans(badge_label_key) }}</span>
+        {% endif %}
+        {% if topics is defined %}
+          {% for topic in topics[:3] %}
+            <span class="card__tag">{{ topic|replace({'_': ' '}) }}</span>
+          {% endfor %}
+        {% endif %}
+      </div>
+      <h3 class="card__title">
+        <a href="{{ url }}" rel="noopener noreferrer" target="_blank">{{ title }}</a>
+      </h3>
+      <div class="card__meta">
+        <span>{{ source_name|replace({'_': ' '}) }}</span>
+        {% if crawled_at %}
+          <span class="card__meta-sep" aria-hidden="true">&middot;</span>
+          <span class="card__date">{{ crawled_at[:10] }}</span>
+        {% endif %}
+      </div>
+      {% if highlight %}
+        <div class="card__body">{{ highlight|striptags('<em><strong><mark>')|raw }}</div>
+      {% endif %}
+      {# Richer metadata per entity type #}
+      {% if type_key == 'event' and (date is defined and date) %}
+        <div class="search-result__meta">{{ date }}</div>
+      {% elseif type_key in ['person', 'resource_person'] and (community is defined and community) %}
+        <div class="search-result__meta">{{ community }}</div>
+      {% elseif type_key == 'business' and (city is defined and city) %}
+        <div class="search-result__meta">{{ city }}</div>
+      {% endif %}
+    </div>
   </div>
-  <h3 class="card__title">
-    <a href="{{ url }}" rel="noopener noreferrer" target="_blank">{{ title }}</a>
-  </h3>
-  <div class="card__meta">
-    <span>{{ source_name|replace({'_': ' '}) }}</span>
-    {% if crawled_at %}
-      <span class="card__date">{{ crawled_at[:10] }}</span>
-    {% endif %}
-  </div>
-  {% if highlight %}
-    <div class="card__body">{{ highlight|striptags('<em><strong><mark>')|raw }}</div>
-  {% endif %}
-  {# Richer metadata per entity type #}
-  {% if type_key == 'event' and (date is defined and date) %}
-    <div class="search-result__meta">{{ date }}</div>
-  {% elseif type_key in ['person', 'resource_person'] and (community is defined and community) %}
-    <div class="search-result__meta">{{ community }}</div>
-  {% elseif type_key == 'business' and (city is defined and city) %}
-    <div class="search-result__meta">{{ city }}</div>
-  {% endif %}
 </article>


### PR DESCRIPTION
## Summary
- **#510**: Hide "page" type badge — only domain-specific badges (event, teaching, group, etc.) now display
- **#511**: Source and date separated by dot (·) instead of raw adjacent spans
- **#509**: OG image support with horizontal layout, hidden on mobile (<768px)
- **#508**: Highlight snippet `<mark>` styled with accent color; body clamped to 2 lines
- Domain accent class (`card--{type}`) added to article element for left border color
- `--accent-surface` token defined in `@layer tokens`

Milestone: Search Experience (#45)

Closes #508, closes #509, closes #510, closes #511

## Test plan
- [ ] Visual: search results show domain-colored left border
- [ ] Visual: "page" badge no longer appears; other badges still show
- [ ] Visual: source · date separator renders correctly
- [ ] Visual: highlight marks show teal background
- [ ] Visual: OG images appear when present, hidden on mobile
- [ ] Regression: existing search functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)