### PR TITLE
feat: extend GameSession for multi-game support (Shkoda + Crossword)

### DIFF
--- a/src/Entity/GameSession.php
+++ b/src/Entity/GameSession.php
@@ -16,24 +16,39 @@ final class GameSession extends ContentEntityBase
         'label' => 'mode',
     ];
 
-    private const VALID_MODES = ['daily', 'practice', 'streak'];
+    public const VALID_GAME_TYPES = ['shkoda', 'crossword'];
+    private const VALID_MODES = ['daily', 'practice', 'streak', 'themed'];
     private const VALID_DIRECTIONS = ['ojibwe_to_english', 'english_to_ojibwe'];
-    private const VALID_STATUSES = ['in_progress', 'won', 'lost'];
+    private const VALID_STATUSES = ['in_progress', 'won', 'lost', 'completed', 'abandoned'];
     private const VALID_TIERS = ['easy', 'medium', 'hard'];
 
     /** @param array<string, mixed> $values */
     public function __construct(array $values = [])
     {
-        foreach (['mode', 'direction', 'dictionary_entry_id'] as $field) {
-            if (!isset($values[$field])) {
-                throw new \InvalidArgumentException("Missing required field: {$field}");
+        if (!array_key_exists('game_type', $values)) {
+            $values['game_type'] = 'shkoda';
+        }
+
+        if (!in_array($values['game_type'], self::VALID_GAME_TYPES, true)) {
+            throw new \InvalidArgumentException("Invalid game_type: {$values['game_type']}");
+        }
+
+        if (!isset($values['mode'])) {
+            throw new \InvalidArgumentException('Missing required field: mode');
+        }
+
+        if ($values['game_type'] === 'shkoda') {
+            foreach (['direction', 'dictionary_entry_id'] as $field) {
+                if (!isset($values[$field])) {
+                    throw new \InvalidArgumentException("Missing required field: {$field}");
+                }
             }
         }
 
         if (!in_array($values['mode'], self::VALID_MODES, true)) {
             throw new \InvalidArgumentException("Invalid mode: {$values['mode']}");
         }
-        if (!in_array($values['direction'], self::VALID_DIRECTIONS, true)) {
+        if (isset($values['direction']) && !in_array($values['direction'], self::VALID_DIRECTIONS, true)) {
             throw new \InvalidArgumentException("Invalid direction: {$values['direction']}");
         }
         if (isset($values['status']) && !in_array($values['status'], self::VALID_STATUSES, true)) {
@@ -60,6 +75,15 @@ final class GameSession extends ContentEntityBase
         }
         if (!array_key_exists('difficulty_tier', $values)) {
             $values['difficulty_tier'] = 'easy';
+        }
+        if (!array_key_exists('puzzle_id', $values)) {
+            $values['puzzle_id'] = null;
+        }
+        if (!array_key_exists('grid_state', $values)) {
+            $values['grid_state'] = null;
+        }
+        if (!array_key_exists('hints_used', $values)) {
+            $values['hints_used'] = 0;
         }
         if (!array_key_exists('created_at', $values)) {
             $values['created_at'] = time();

--- a/tests/Minoo/Unit/Entity/GameSessionTest.php
+++ b/tests/Minoo/Unit/Entity/GameSessionTest.php
@@ -102,4 +102,90 @@ final class GameSessionTest extends TestCase
         $this->assertSame(2, $session->get('wrong_count'));
         $this->assertSame('won', $session->get('status'));
     }
+
+    #[Test]
+    public function it_defaults_game_type_to_shkoda(): void
+    {
+        $session = new GameSession([
+            'mode' => 'daily',
+            'direction' => 'english_to_ojibwe',
+            'dictionary_entry_id' => 42,
+        ]);
+
+        $this->assertSame('shkoda', $session->get('game_type'));
+    }
+
+    #[Test]
+    public function it_accepts_crossword_game_type(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'daily',
+        ]);
+
+        $this->assertSame('crossword', $session->get('game_type'));
+        $this->assertSame('daily', $session->get('mode'));
+        $this->assertNull($session->get('puzzle_id'));
+        $this->assertNull($session->get('grid_state'));
+        $this->assertSame(0, $session->get('hints_used'));
+    }
+
+    #[Test]
+    public function it_validates_game_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid game_type: bogus');
+        new GameSession([
+            'game_type' => 'bogus',
+            'mode' => 'daily',
+        ]);
+    }
+
+    #[Test]
+    public function crossword_accepts_themed_mode(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'themed',
+            'puzzle_id' => 'animals-2026-03',
+        ]);
+
+        $this->assertSame('themed', $session->get('mode'));
+        $this->assertSame('animals-2026-03', $session->get('puzzle_id'));
+    }
+
+    #[Test]
+    public function crossword_accepts_abandoned_status(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'daily',
+            'status' => 'abandoned',
+        ]);
+
+        $this->assertSame('abandoned', $session->get('status'));
+    }
+
+    #[Test]
+    public function crossword_accepts_completed_status(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'daily',
+            'status' => 'completed',
+        ]);
+
+        $this->assertSame('completed', $session->get('status'));
+    }
+
+    #[Test]
+    public function shkoda_still_requires_direction_and_entry(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required field: direction');
+        new GameSession([
+            'game_type' => 'shkoda',
+            'mode' => 'daily',
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `game_type` field to `GameSession` with `shkoda` and `crossword` support
- Add `themed` mode, `completed`/`abandoned` statuses for crossword gameplay
- Add crossword-specific fields: `puzzle_id`, `grid_state`, `hints_used`
- Backward compatible — existing Shkoda sessions default `game_type` to `shkoda`

## Test plan
- [x] All 7 existing tests still pass (backward compat)
- [x] 7 new tests cover crossword game type, themed mode, new statuses, validation
- [x] 14 tests total, 39 assertions, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)