### PR TITLE
feat: add crossword game to games hub and sidebar nav

### DIFF
--- a/templates/components/sidebar-nav.html.twig
+++ b/templates/components/sidebar-nav.html.twig
@@ -33,6 +33,12 @@
       <svg class="sidebar-nav__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
       Games
     </a>
+    <a href="{{ lang_url('/games/shkoda') }}" class="sidebar-nav__item{% if current_path is defined and current_path == '/games/shkoda' %} sidebar-nav__item--active{% endif %}">
+      Shkoda
+    </a>
+    <a href="{{ lang_url('/games/crossword') }}" class="sidebar-nav__item{% if current_path is defined and current_path == '/games/crossword' %} sidebar-nav__item--active{% endif %}">
+      Crossword
+    </a>
   </div>
 
   <div class="sidebar-nav__group">

--- a/templates/games.html.twig
+++ b/templates/games.html.twig
@@ -31,6 +31,30 @@
                 <span class="game-card__cta">Play now</span>
             </div>
         </a>
+        <a href="/games/crossword" class="game-card game-card--featured">
+            <div class="game-card__icon">
+                <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
+                    <rect x="8" y="8" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="26" y="8" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="44" y="8" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="62" y="8" width="10" height="16" fill="currentColor" opacity="0.15" rx="2"/>
+                    <rect x="8" y="26" width="16" height="16" fill="currentColor" opacity="0.15" rx="2"/>
+                    <rect x="26" y="26" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="44" y="26" width="16" height="16" fill="currentColor" opacity="0.15" rx="2"/>
+                    <rect x="8" y="44" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="26" y="44" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="44" y="44" width="16" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="62" y="44" width="10" height="16" fill="currentColor" opacity="0.8" rx="2"/>
+                    <rect x="26" y="62" width="16" height="10" fill="currentColor" opacity="0.8" rx="2"/>
+                </svg>
+            </div>
+            <div class="game-card__content">
+                <span class="game-card__badge">Word Game</span>
+                <h3 class="game-card__title">Crossword</h3>
+                <p class="game-card__description">Fill the grid with Ojibwe words. Clues in English, answers in Anishinaabemowin — a new puzzle each day.</p>
+                <span class="game-card__cta">Play now</span>
+            </div>
+        </a>
     </section>
 
     <section class="games-hub__coming">


### PR DESCRIPTION
## Summary
- Add crossword as a second featured game card on the games hub page with inline SVG grid icon
- Add Shkoda and Crossword sub-links to the sidebar navigation under Games
- Crossword card links to `/games/crossword`

## Test plan
- [ ] Visit `/games` and verify crossword card appears alongside Shkoda
- [ ] Verify crossword SVG icon renders a grid pattern
- [ ] Verify clicking crossword card navigates to `/games/crossword`
- [ ] Verify sidebar nav shows Shkoda and Crossword links under Games
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)