### PR TITLE
feat: register CrosswordPuzzle entity type and crossword session fields

### DIFF
--- a/migrations/20260324_100000_add_crossword_fields_to_game_session.php
+++ b/migrations/20260324_100000_add_crossword_fields_to_game_session.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Add crossword fields to game_session.
+ *
+ * No-op: game_type, puzzle_id, grid_state, hints_used live in the _data JSON blob.
+ * This migration exists for version tracking only.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        // Fields stored in _data JSON blob — no schema change needed.
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // No-op — nothing to reverse.
+    }
+};

--- a/migrations/20260324_100100_create_crossword_puzzle_table.php
+++ b/migrations/20260324_100100_create_crossword_puzzle_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Create the crossword_puzzle config entity table.
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        if ($schema->hasTable('crossword_puzzle')) {
+            return;
+        }
+
+        $schema->getConnection()->executeStatement("
+            CREATE TABLE crossword_puzzle (
+                id TEXT PRIMARY KEY,
+                bundle CLOB,
+                langcode CLOB,
+                _data CLOB
+            )
+        ");
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        if ($schema->hasTable('crossword_puzzle')) {
+            $schema->getConnection()->executeStatement('DROP TABLE crossword_puzzle');
+        }
+    }
+};

--- a/src/Access/GameAccessPolicy.php
+++ b/src/Access/GameAccessPolicy.php
@@ -10,10 +10,10 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 
-#[PolicyAttribute(entityType: ['game_session', 'daily_challenge'])]
+#[PolicyAttribute(entityType: ['game_session', 'daily_challenge', 'crossword_puzzle'])]
 final class GameAccessPolicy implements AccessPolicyInterface
 {
-    private const ENTITY_TYPES = ['game_session', 'daily_challenge'];
+    private const ENTITY_TYPES = ['game_session', 'daily_challenge', 'crossword_puzzle'];
 
     public function appliesTo(string $entityTypeId): bool
     {

--- a/src/Provider/GameServiceProvider.php
+++ b/src/Provider/GameServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Minoo\Provider;
 
+use Minoo\Entity\CrosswordPuzzle;
 use Minoo\Entity\DailyChallenge;
 use Minoo\Entity\GameSession;
 use Waaseyaa\Entity\EntityType;
@@ -31,6 +32,10 @@ final class GameServiceProvider extends ServiceProvider
                 'status' => ['type' => 'string', 'label' => 'Status', 'weight' => 15, 'default' => 'in_progress'],
                 'daily_date' => ['type' => 'string', 'label' => 'Daily Date', 'weight' => 16],
                 'difficulty_tier' => ['type' => 'string', 'label' => 'Difficulty', 'weight' => 17, 'default' => 'easy'],
+                'game_type' => ['type' => 'string', 'label' => 'Game Type', 'weight' => 18, 'default' => 'shkoda'],
+                'puzzle_id' => ['type' => 'string', 'label' => 'Puzzle ID', 'weight' => 19],
+                'grid_state' => ['type' => 'text_long', 'label' => 'Grid State', 'description' => 'JSON crossword grid fill state.', 'weight' => 20],
+                'hints_used' => ['type' => 'integer', 'label' => 'Hints Used', 'weight' => 21, 'default' => 0],
                 'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
                 'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
             ],
@@ -47,6 +52,21 @@ final class GameServiceProvider extends ServiceProvider
                 'dictionary_entry_id' => ['type' => 'entity_reference', 'label' => 'Dictionary Entry', 'settings' => ['target_type' => 'dictionary_entry'], 'weight' => 5],
                 'direction' => ['type' => 'string', 'label' => 'Direction', 'weight' => 10, 'default' => 'english_to_ojibwe'],
                 'difficulty_tier' => ['type' => 'string', 'label' => 'Difficulty', 'weight' => 15, 'default' => 'easy'],
+            ],
+        ));
+
+        $this->entityType(new EntityType(
+            id: 'crossword_puzzle',
+            label: 'Crossword Puzzle',
+            class: CrosswordPuzzle::class,
+            keys: ['id' => 'id', 'label' => 'id'],
+            group: 'games',
+            fieldDefinitions: [
+                'grid_size' => ['type' => 'integer', 'label' => 'Grid Size', 'weight' => 0],
+                'words' => ['type' => 'text_long', 'label' => 'Words', 'description' => 'JSON array of word placements.', 'weight' => 5],
+                'clues' => ['type' => 'text_long', 'label' => 'Clues', 'description' => 'JSON map of word index to clue data.', 'weight' => 10],
+                'theme' => ['type' => 'string', 'label' => 'Theme', 'weight' => 15],
+                'difficulty_tier' => ['type' => 'string', 'label' => 'Difficulty', 'weight' => 20, 'default' => 'easy'],
             ],
         ));
     }


### PR DESCRIPTION
## Summary
- Register `crossword_puzzle` config entity type in `GameServiceProvider`
- Add crossword-specific fields (`game_type`, `puzzle_id`, `grid_state`, `hints_used`) to `game_session` entity type
- Extend `GameAccessPolicy` to cover `crossword_puzzle`
- Create two migrations: no-op for game_session fields (stored in `_data` JSON blob) and `crossword_puzzle` table creation

## Test plan
- [x] All 759 unit tests pass (1 pre-existing skip)
- [x] Manifest cache cleared
- [ ] Run `bin/waaseyaa migrate` to create crossword_puzzle table
- [ ] Verify crossword_puzzle entity CRUD via storage API

🤖 Generated with [Claude Code](https://claude.com/claude-code)