### PR TITLE
feat: add CrosswordController with API endpoints and fix Shkoda stats

### DIFF
--- a/src/Controller/CrosswordController.php
+++ b/src/Controller/CrosswordController.php
@@ -1,0 +1,793 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Controller;
+
+use Minoo\Support\CrosswordEngine;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\SsrResponse;
+
+final class CrosswordController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {}
+
+    /** Render the crossword game page. */
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $html = $this->twig->render('crossword.html.twig', [
+            'path' => '/games/crossword',
+        ]);
+        return new SsrResponse(content: $html);
+    }
+
+    /** GET /api/games/crossword/daily — today's puzzle. */
+    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $today = date('Y-m-d');
+        $puzzleId = "daily-{$today}";
+
+        $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
+        $puzzle = $puzzleStorage->load($puzzleId);
+
+        if ($puzzle === null) {
+            // Fallback: generate on-the-fly when cron missed a run
+            $puzzle = $this->generateFallbackDaily($puzzleId, $today);
+            if ($puzzle === null) {
+                return $this->json(['error' => 'No words available to generate puzzle'], 503);
+            }
+        }
+
+        $tier = (string) $puzzle->get('difficulty_tier');
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $cluesData = json_decode((string) $puzzle->get('clues'), true) ?: [];
+
+        // Resolve clues (elder preferred over auto)
+        $clues = [];
+        foreach ($cluesData as $idx => $clueData) {
+            $clues[$idx] = CrosswordEngine::resolveClue($clueData);
+        }
+
+        // Build word bank (Ojibwe word + English meaning from dictionary)
+        $wordBank = $this->buildWordBank($words, $tier);
+
+        // Create game session
+        $sessionStorage = $this->entityTypeManager->getStorage('game_session');
+        $session = $sessionStorage->create([
+            'game_type' => 'crossword',
+            'mode' => 'daily',
+            'puzzle_id' => $puzzleId,
+            'user_id' => $account->isAuthenticated() ? $account->id() : null,
+            'daily_date' => $today,
+            'difficulty_tier' => $tier,
+        ]);
+        $sessionStorage->save($session);
+
+        // Strip answers from placements before sending to client
+        $clientPlacements = array_map(fn($w) => [
+            'row' => $w['row'],
+            'col' => $w['col'],
+            'direction' => $w['direction'],
+            'length' => mb_strlen($w['word']),
+        ], $words);
+
+        return $this->json([
+            'session_token' => $session->get('uuid'),
+            'puzzle_id' => $puzzleId,
+            'grid_size' => (int) $puzzle->get('grid_size'),
+            'placements' => $clientPlacements,
+            'clues' => $clues,
+            'word_bank' => $wordBank,
+            'difficulty' => $tier,
+            'max_hints' => CrosswordEngine::maxHints($tier),
+            'date' => $today,
+        ]);
+    }
+
+    /** GET /api/games/crossword/random — random practice puzzle. */
+    public function random(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $tier = $query['tier'] ?? 'easy';
+        if (!in_array($tier, ['easy', 'medium', 'hard'], true)) {
+            $tier = 'easy';
+        }
+
+        $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
+        $ids = $puzzleStorage->getQuery()
+            ->condition('difficulty_tier', $tier)
+            ->execute();
+
+        // Exclude daily puzzles and filter for non-themed practice grids
+        $practiceIds = array_filter($ids, fn($id) => !str_starts_with((string) $id, 'daily-'));
+
+        if ($practiceIds === []) {
+            // Fallback: use any puzzle at this tier
+            $practiceIds = $ids;
+        }
+
+        if ($practiceIds === []) {
+            return $this->json(['error' => 'No puzzles available'], 503);
+        }
+
+        $puzzleId = $practiceIds[array_rand($practiceIds)];
+        $puzzle = $puzzleStorage->load($puzzleId);
+
+        if ($puzzle === null) {
+            return $this->json(['error' => 'Puzzle not found'], 503);
+        }
+
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $cluesData = json_decode((string) $puzzle->get('clues'), true) ?: [];
+
+        $clues = [];
+        foreach ($cluesData as $idx => $clueData) {
+            $clues[$idx] = CrosswordEngine::resolveClue($clueData);
+        }
+
+        $wordBank = $this->buildWordBank($words, $tier);
+
+        $sessionStorage = $this->entityTypeManager->getStorage('game_session');
+        $session = $sessionStorage->create([
+            'game_type' => 'crossword',
+            'mode' => 'practice',
+            'puzzle_id' => (string) $puzzleId,
+            'user_id' => $account->isAuthenticated() ? $account->id() : null,
+            'difficulty_tier' => $tier,
+        ]);
+        $sessionStorage->save($session);
+
+        $clientPlacements = array_map(fn($w) => [
+            'row' => $w['row'],
+            'col' => $w['col'],
+            'direction' => $w['direction'],
+            'length' => mb_strlen($w['word']),
+        ], $words);
+
+        return $this->json([
+            'session_token' => $session->get('uuid'),
+            'puzzle_id' => (string) $puzzleId,
+            'grid_size' => (int) $puzzle->get('grid_size'),
+            'placements' => $clientPlacements,
+            'clues' => $clues,
+            'word_bank' => $wordBank,
+            'difficulty' => $tier,
+            'max_hints' => CrosswordEngine::maxHints($tier),
+        ]);
+    }
+
+    /** GET /api/games/crossword/themes — list theme packs with progress. */
+    public function themes(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
+        $allIds = $puzzleStorage->getQuery()->execute();
+
+        // Group by theme field (not by parsing IDs)
+        $themeCounts = [];
+        $puzzles = $puzzleStorage->loadMultiple($allIds);
+        foreach ($puzzles as $puzzle) {
+            $theme = (string) $puzzle->get('theme');
+            if ($theme === '') {
+                continue;
+            }
+            $themeCounts[$theme] = ($themeCounts[$theme] ?? 0) + 1;
+        }
+
+        // Load user's completed crossword sessions once (not per-theme)
+        $completedByTheme = [];
+        if ($account->isAuthenticated()) {
+            $sessionIds = $this->entityTypeManager->getStorage('game_session')->getQuery()
+                ->condition('game_type', 'crossword')
+                ->condition('user_id', $account->id())
+                ->condition('status', 'completed')
+                ->execute();
+            $sessions = $this->entityTypeManager->getStorage('game_session')->loadMultiple($sessionIds);
+            foreach ($sessions as $s) {
+                $pid = (string) $s->get('puzzle_id');
+                // Match puzzle_id to theme by loading the puzzle's theme
+                foreach ($puzzles as $p) {
+                    if ((string) $p->id() === $pid) {
+                        $t = (string) $p->get('theme');
+                        if ($t !== '') {
+                            $completedByTheme[$t] = ($completedByTheme[$t] ?? 0) + 1;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        $themes = [];
+        foreach ($themeCounts as $slug => $total) {
+            $entry = ['slug' => $slug, 'name' => ucfirst($slug), 'total' => $total];
+            if ($account->isAuthenticated()) {
+                $entry['completed'] = $completedByTheme[$slug] ?? 0;
+            }
+            $themes[] = $entry;
+        }
+
+        return $this->json(['themes' => $themes]);
+    }
+
+    /** GET /api/games/crossword/theme/{slug} — next unsolved puzzle in theme. */
+    public function theme(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $slug = $params['slug'] ?? '';
+        if ($slug === '') {
+            return $this->json(['error' => 'Missing theme slug'], 400);
+        }
+
+        $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
+        $allIds = $puzzleStorage->getQuery()
+            ->condition('theme', $slug)
+            ->execute();
+
+        if ($allIds === []) {
+            return $this->json(['error' => 'Theme not found'], 404);
+        }
+
+        // Determine completed puzzles
+        $completedPuzzleIds = [];
+        if ($account->isAuthenticated()) {
+            $sessionIds = $this->entityTypeManager->getStorage('game_session')->getQuery()
+                ->condition('game_type', 'crossword')
+                ->condition('user_id', $account->id())
+                ->condition('status', 'completed')
+                ->execute();
+            $sessions = $this->entityTypeManager->getStorage('game_session')->loadMultiple($sessionIds);
+            foreach ($sessions as $s) {
+                $completedPuzzleIds[] = (string) $s->get('puzzle_id');
+            }
+        } else {
+            // Anonymous: client sends completed IDs as query param
+            $completed = $query['completed'] ?? '';
+            if ($completed !== '') {
+                $completedPuzzleIds = explode(',', $completed);
+            }
+        }
+
+        // Find first unsolved
+        sort($allIds);
+        $nextId = null;
+        foreach ($allIds as $id) {
+            if (!in_array((string) $id, $completedPuzzleIds, true)) {
+                $nextId = $id;
+                break;
+            }
+        }
+
+        if ($nextId === null) {
+            return $this->json(['error' => 'All puzzles in this theme completed', 'theme_complete' => true], 200);
+        }
+
+        $puzzle = $puzzleStorage->load($nextId);
+        if ($puzzle === null) {
+            return $this->json(['error' => 'Puzzle not found'], 503);
+        }
+
+        $tier = (string) $puzzle->get('difficulty_tier');
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $cluesData = json_decode((string) $puzzle->get('clues'), true) ?: [];
+
+        $clues = [];
+        foreach ($cluesData as $idx => $clueData) {
+            $clues[$idx] = CrosswordEngine::resolveClue($clueData);
+        }
+
+        $wordBank = $this->buildWordBank($words, $tier);
+
+        $sessionStorage = $this->entityTypeManager->getStorage('game_session');
+        $session = $sessionStorage->create([
+            'game_type' => 'crossword',
+            'mode' => 'themed',
+            'puzzle_id' => (string) $nextId,
+            'user_id' => $account->isAuthenticated() ? $account->id() : null,
+            'difficulty_tier' => $tier,
+        ]);
+        $sessionStorage->save($session);
+
+        $clientPlacements = array_map(fn($w) => [
+            'row' => $w['row'],
+            'col' => $w['col'],
+            'direction' => $w['direction'],
+            'length' => mb_strlen($w['word']),
+        ], $words);
+
+        return $this->json([
+            'session_token' => $session->get('uuid'),
+            'puzzle_id' => (string) $nextId,
+            'grid_size' => (int) $puzzle->get('grid_size'),
+            'placements' => $clientPlacements,
+            'clues' => $clues,
+            'word_bank' => $wordBank,
+            'difficulty' => $tier,
+            'max_hints' => CrosswordEngine::maxHints($tier),
+            'theme' => $slug,
+        ]);
+    }
+
+    /** POST /api/games/crossword/check — validate a word. */
+    public function check(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $data = $this->jsonBody($request);
+        $token = $data['session_token'] ?? '';
+        $wordIndex = $data['word_index'] ?? null;
+        $letters = $data['letters'] ?? [];
+
+        if ($token === '' || $wordIndex === null || !is_array($letters)) {
+            return $this->json(['error' => 'Missing session_token, word_index, or letters'], 422);
+        }
+
+        $session = $this->loadSessionByToken($token);
+        if ($session === null) {
+            return $this->json(['error' => 'Invalid session'], 404);
+        }
+
+        $puzzleId = (string) $session->get('puzzle_id');
+        $puzzle = $this->entityTypeManager->getStorage('crossword_puzzle')->load($puzzleId);
+        if ($puzzle === null) {
+            return $this->json(['error' => 'Puzzle not found'], 500);
+        }
+
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $wordIndex = (int) $wordIndex;
+        if (!isset($words[$wordIndex])) {
+            return $this->json(['error' => 'Invalid word index'], 400);
+        }
+
+        $correctWord = $words[$wordIndex]['word'];
+        $result = CrosswordEngine::validateWord($letters, $correctWord);
+
+        // Update grid state
+        $gridState = json_decode((string) ($session->get('grid_state') ?? '{}'), true) ?: [];
+        if ($result['correct']) {
+            $gridState["word_{$wordIndex}"] = 'completed';
+        }
+        $session->set('grid_state', json_encode($gridState));
+        $session->set('updated_at', time());
+
+        // Check if all words completed
+        $allComplete = true;
+        foreach (array_keys($words) as $idx) {
+            if (($gridState["word_{$idx}"] ?? '') !== 'completed') {
+                $allComplete = false;
+                break;
+            }
+        }
+
+        if ($allComplete) {
+            $session->set('status', 'completed');
+        }
+
+        $this->entityTypeManager->getStorage('game_session')->save($session);
+
+        $response = [
+            'correct' => $result['correct'],
+            'word_index' => $wordIndex,
+            'correct_positions' => $result['correct_positions'],
+            'wrong_positions' => $result['wrong_positions'],
+            'puzzle_complete' => $allComplete,
+        ];
+
+        // Include teaching data for correct words
+        if ($result['correct'] && isset($words[$wordIndex]['dictionary_entry_id'])) {
+            $entry = $this->entityTypeManager->getStorage('dictionary_entry')
+                ->load((int) $words[$wordIndex]['dictionary_entry_id']);
+            if ($entry !== null) {
+                $response['teaching'] = [
+                    'word' => (string) $entry->get('word'),
+                    'meaning' => $this->cleanDefinition((string) $entry->get('definition')),
+                    'pos' => (string) $entry->get('part_of_speech'),
+                ];
+            }
+        }
+
+        return $this->json($response);
+    }
+
+    /** POST /api/games/crossword/complete — submit finished puzzle. */
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $data = $this->jsonBody($request);
+        $token = $data['session_token'] ?? '';
+
+        if ($token === '') {
+            return $this->json(['error' => 'Missing session_token'], 422);
+        }
+
+        $session = $this->loadSessionByToken($token);
+        if ($session === null) {
+            return $this->json(['error' => 'Invalid session'], 404);
+        }
+
+        if ($session->get('status') !== 'completed') {
+            return $this->json(['error' => 'Puzzle not yet completed'], 400);
+        }
+
+        $puzzleId = (string) $session->get('puzzle_id');
+        $puzzle = $this->entityTypeManager->getStorage('crossword_puzzle')->load($puzzleId);
+        if ($puzzle === null) {
+            return $this->json(['error' => 'Puzzle not found'], 500);
+        }
+
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $cluesData = json_decode((string) $puzzle->get('clues'), true) ?: [];
+
+        // Batch-load dictionary entries to avoid N+1 queries
+        $entryIds = array_filter(array_column($words, 'dictionary_entry_id'));
+        $dictEntries = $entryIds !== []
+            ? $this->entityTypeManager->getStorage('dictionary_entry')->loadMultiple($entryIds)
+            : [];
+
+        // Build teaching data for each word
+        $wordTeachings = [];
+        foreach ($words as $idx => $w) {
+            $teaching = ['word' => $w['word']];
+
+            if (isset($w['dictionary_entry_id'])) {
+                $entry = $dictEntries[(int) $w['dictionary_entry_id']] ?? null;
+                if ($entry !== null) {
+                    $teaching['meaning'] = $this->cleanDefinition((string) $entry->get('definition'));
+                    $teaching['pos'] = (string) $entry->get('part_of_speech');
+
+                    // Load example sentence
+                    $exampleIds = $this->entityTypeManager->getStorage('example_sentence')->getQuery()
+                        ->condition('dictionary_entry_id', $entry->id())
+                        ->condition('status', 1)
+                        ->range(0, 1)
+                        ->execute();
+                    $example = $exampleIds !== []
+                        ? $this->entityTypeManager->getStorage('example_sentence')->load(reset($exampleIds))
+                        : null;
+                    if ($example !== null) {
+                        $teaching['example_ojibwe'] = (string) $example->get('ojibwe_text');
+                        $teaching['example_english'] = (string) $example->get('english_text');
+                    }
+                }
+            }
+
+            // Include elder clue attribution
+            $clueData = $cluesData[(string) $idx] ?? null;
+            if ($clueData !== null && ($clueData['elder'] ?? null) !== null) {
+                $teaching['elder_clue'] = $clueData['elder'];
+                $teaching['elder_author'] = $clueData['elder_author'] ?? null;
+            }
+
+            $wordTeachings[] = $teaching;
+        }
+
+        $stats = $this->buildStats($account);
+
+        // Compute time from session creation to now
+        $timeSeconds = time() - (int) $session->get('created_at');
+
+        return $this->json([
+            'completed' => true,
+            'time_seconds' => $timeSeconds,
+            'hints_used' => (int) $session->get('hints_used'),
+            'words' => $wordTeachings,
+            'stats' => $stats,
+        ]);
+    }
+
+    /** GET /api/games/crossword/stats — player stats (auth required). */
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        return $this->json($this->buildStats($account));
+    }
+
+    /** POST /api/games/crossword/hint — reveal a letter (tracked server-side). */
+    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $data = $this->jsonBody($request);
+        $token = $data['session_token'] ?? '';
+        $wordIndex = $data['word_index'] ?? null;
+        $position = $data['position'] ?? null;
+
+        if ($token === '' || $wordIndex === null || $position === null) {
+            return $this->json(['error' => 'Missing required fields'], 422);
+        }
+
+        $session = $this->loadSessionByToken($token);
+        if ($session === null) {
+            return $this->json(['error' => 'Invalid session'], 404);
+        }
+
+        $tier = (string) $session->get('difficulty_tier');
+        $maxHints = CrosswordEngine::maxHints($tier);
+        $hintsUsed = (int) $session->get('hints_used');
+
+        if ($maxHints !== -1 && $hintsUsed >= $maxHints) {
+            return $this->json(['error' => 'No hints remaining'], 400);
+        }
+
+        $puzzle = $this->entityTypeManager->getStorage('crossword_puzzle')
+            ->load((string) $session->get('puzzle_id'));
+        if ($puzzle === null) {
+            return $this->json(['error' => 'Puzzle not found'], 500);
+        }
+
+        $words = json_decode((string) $puzzle->get('words'), true) ?: [];
+        $wordIndex = (int) $wordIndex;
+        if (!isset($words[$wordIndex])) {
+            return $this->json(['error' => 'Invalid word index'], 400);
+        }
+
+        $word = $words[$wordIndex]['word'];
+        $position = (int) $position;
+        $letter = mb_substr(mb_strtolower($word), $position, 1);
+
+        $session->set('hints_used', $hintsUsed + 1);
+        $session->set('updated_at', time());
+        $this->entityTypeManager->getStorage('game_session')->save($session);
+
+        return $this->json([
+            'letter' => $letter,
+            'position' => $position,
+            'word_index' => $wordIndex,
+            'hints_remaining' => $maxHints === -1 ? -1 : $maxHints - $hintsUsed - 1,
+        ]);
+    }
+
+    /** POST /api/games/crossword/abandon — give up on current puzzle. */
+    public function abandon(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    {
+        $data = $this->jsonBody($request);
+        $token = $data['session_token'] ?? '';
+
+        if ($token === '') {
+            return $this->json(['error' => 'Missing session_token'], 422);
+        }
+
+        $session = $this->loadSessionByToken($token);
+        if ($session === null) {
+            return $this->json(['error' => 'Invalid session'], 404);
+        }
+
+        if ($session->get('status') !== 'in_progress') {
+            return $this->json(['error' => 'Game already finished'], 400);
+        }
+
+        $session->set('status', 'abandoned');
+        $session->set('updated_at', time());
+        $this->entityTypeManager->getStorage('game_session')->save($session);
+
+        return $this->json(['abandoned' => true]);
+    }
+
+    // --- Private helpers ---
+
+    /**
+     * Generate a fallback daily puzzle when cron missed a run.
+     * Uses dictionary entries to build a quick grid on the fly.
+     */
+    private function generateFallbackDaily(string $puzzleId, string $today): ?object
+    {
+        $dayOfWeek = (int) date('w', strtotime($today));
+        $tier = CrosswordEngine::dailyTier($dayOfWeek);
+
+        // Load dictionary words with definitions
+        $dictStorage = $this->entityTypeManager->getStorage('dictionary_entry');
+        $ids = $dictStorage->getQuery()
+            ->condition('status', 1)
+            ->range(0, 200)
+            ->execute();
+
+        $words = [];
+        $wordMeta = [];
+        $entries = $dictStorage->loadMultiple($ids);
+        foreach ($entries as $entry) {
+            $word = mb_strtolower((string) $entry->get('word'));
+            $def = (string) $entry->get('definition');
+            $len = mb_strlen($word);
+            if ($def === '' || $len < 3 || $len > 7 || str_contains($word, '-')) {
+                continue;
+            }
+            $words[] = $word;
+            $wordMeta[$word] = [
+                'dictionary_entry_id' => (int) $entry->id(),
+                'definition' => $def,
+            ];
+        }
+
+        $result = CrosswordEngine::generateGrid($words, 7, 4);
+        if ($result === null) {
+            return null;
+        }
+
+        // Build puzzle data
+        $puzzleWords = [];
+        $clues = [];
+        foreach ($result['placements'] as $idx => $p) {
+            $meta = $wordMeta[$p['word']] ?? null;
+            $puzzleWords[] = [
+                'dictionary_entry_id' => $meta['dictionary_entry_id'] ?? null,
+                'row' => $p['row'],
+                'col' => $p['col'],
+                'direction' => $p['direction'],
+                'word' => $p['word'],
+            ];
+            $clues[(string) $idx] = [
+                'auto' => $meta !== null ? $this->cleanDefinition($meta['definition']) : $p['word'],
+                'elder' => null,
+                'elder_author' => null,
+            ];
+        }
+
+        $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
+        $puzzle = $puzzleStorage->create([
+            'id' => $puzzleId,
+            'grid_size' => 7,
+            'words' => json_encode($puzzleWords),
+            'clues' => json_encode($clues),
+            'difficulty_tier' => $tier,
+        ]);
+        $puzzleStorage->save($puzzle);
+
+        return $puzzle;
+    }
+
+    /**
+     * Build word bank based on difficulty tier.
+     *
+     * @param list<array{dictionary_entry_id?: int, word: string}> $words
+     * @return list<array{word: string, meaning?: string}>|null
+     */
+    private function buildWordBank(array $words, string $tier): ?array
+    {
+        if ($tier === 'hard') {
+            return null; // No word bank on hard
+        }
+
+        // Batch-load dictionary entries to avoid N+1 queries
+        $dictEntries = [];
+        if ($tier === 'easy') {
+            $entryIds = array_filter(array_column($words, 'dictionary_entry_id'));
+            if ($entryIds !== []) {
+                $dictEntries = $this->entityTypeManager->getStorage('dictionary_entry')
+                    ->loadMultiple($entryIds);
+            }
+        }
+
+        $bank = [];
+        foreach ($words as $w) {
+            $entry = ['word' => $w['word']];
+            if ($tier === 'easy' && isset($w['dictionary_entry_id'])) {
+                $dictEntry = $dictEntries[(int) $w['dictionary_entry_id']] ?? null;
+                if ($dictEntry !== null) {
+                    $entry['meaning'] = $this->cleanDefinition((string) $dictEntry->get('definition'));
+                }
+            }
+            $bank[] = $entry;
+        }
+
+        // Shuffle so word bank order doesn't match clue order
+        shuffle($bank);
+        return $bank;
+    }
+
+    private function loadSessionByToken(string $uuid): ?object
+    {
+        $storage = $this->entityTypeManager->getStorage('game_session');
+        $ids = $storage->getQuery()
+            ->condition('uuid', $uuid)
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        return $storage->load(reset($ids));
+    }
+
+    /** @return array<string, mixed> */
+    private function buildStats(AccountInterface $account): array
+    {
+        if (!$account->isAuthenticated()) {
+            return ['authenticated' => false];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('game_session');
+        $allIds = $storage->getQuery()
+            ->condition('user_id', $account->id())
+            ->condition('game_type', 'crossword')
+            ->execute();
+
+        if ($allIds === []) {
+            return [
+                'authenticated' => true,
+                'puzzles_completed' => 0,
+                'current_streak' => 0,
+                'best_streak' => 0,
+            ];
+        }
+
+        $sessions = array_values($storage->loadMultiple($allIds));
+        usort($sessions, fn($a, $b) => (int) $b->get('created_at') - (int) $a->get('created_at'));
+
+        $completed = array_filter($sessions, fn($s) => $s->get('status') === 'completed');
+
+        // Streak = consecutive daily completions
+        $currentStreak = 0;
+        foreach ($sessions as $s) {
+            if ($s->get('status') === 'completed') {
+                $currentStreak++;
+            } else {
+                break;
+            }
+        }
+
+        $bestStreak = 0;
+        $streak = 0;
+        foreach ($sessions as $s) {
+            if ($s->get('status') === 'completed') {
+                $streak++;
+                $bestStreak = max($bestStreak, $streak);
+            } elseif ($s->get('status') === 'abandoned') {
+                $streak = 0;
+            }
+        }
+
+        // Average completion time
+        $totalTime = 0;
+        foreach ($completed as $s) {
+            $totalTime += (int) $s->get('updated_at') - (int) $s->get('created_at');
+        }
+        $avgTime = count($completed) > 0 ? (int) round($totalTime / count($completed)) : 0;
+
+        return [
+            'authenticated' => true,
+            'puzzles_completed' => count($completed),
+            'avg_time' => $avgTime,
+            'current_streak' => $currentStreak,
+            'best_streak' => $bestStreak,
+        ];
+    }
+
+    private function cleanDefinition(string $raw): string
+    {
+        if ($raw === '') {
+            return '';
+        }
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $raw = implode('; ', array_filter(array_map('trim', $decoded)));
+        }
+        $raw = str_replace(
+            ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
+            ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
+            $raw,
+        );
+        return $raw;
+    }
+
+    /** @return array<string, mixed> */
+    private function jsonBody(HttpRequest $request): array
+    {
+        $content = $request->getContent();
+        if ($content === '' || $content === false) {
+            return [];
+        }
+        try {
+            return (array) json_decode((string) $content, true, 16, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+    }
+
+    /** @param array<string, mixed> $data */
+    private function json(array $data, int $status = 200): SsrResponse
+    {
+        return new SsrResponse(
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+            statusCode: $status,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/src/Controller/ShkodaController.php
+++ b/src/Controller/ShkodaController.php
@@ -446,6 +446,7 @@ final class ShkodaController
         $storage = $this->entityTypeManager->getStorage('game_session');
         $allIds = $storage->getQuery()
             ->condition('user_id', $account->id())
+            ->condition('game_type', 'shkoda')
             ->execute();
 
         if ($allIds === []) {

--- a/src/Provider/GameServiceProvider.php
+++ b/src/Provider/GameServiceProvider.php
@@ -123,5 +123,98 @@ final class GameServiceProvider extends ServiceProvider
                 ->methods('GET')
                 ->build(),
         );
+
+        // --- Crossword routes ---
+
+        $router->addRoute(
+            'games.crossword',
+            RouteBuilder::create('/games/crossword')
+                ->controller('Minoo\\Controller\\CrosswordController::page')
+                ->allowAll()
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.daily',
+            RouteBuilder::create('/api/games/crossword/daily')
+                ->controller('Minoo\\Controller\\CrosswordController::daily')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.random',
+            RouteBuilder::create('/api/games/crossword/random')
+                ->controller('Minoo\\Controller\\CrosswordController::random')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.themes',
+            RouteBuilder::create('/api/games/crossword/themes')
+                ->controller('Minoo\\Controller\\CrosswordController::themes')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.theme',
+            RouteBuilder::create('/api/games/crossword/theme/{slug}')
+                ->controller('Minoo\\Controller\\CrosswordController::theme')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.check',
+            RouteBuilder::create('/api/games/crossword/check')
+                ->controller('Minoo\\Controller\\CrosswordController::check')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.complete',
+            RouteBuilder::create('/api/games/crossword/complete')
+                ->controller('Minoo\\Controller\\CrosswordController::complete')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.hint',
+            RouteBuilder::create('/api/games/crossword/hint')
+                ->controller('Minoo\\Controller\\CrosswordController::hint')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.abandon',
+            RouteBuilder::create('/api/games/crossword/abandon')
+                ->controller('Minoo\\Controller\\CrosswordController::abandon')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.games.crossword.stats',
+            RouteBuilder::create('/api/games/crossword/stats')
+                ->controller('Minoo\\Controller\\CrosswordController::stats')
+                ->requireAuthentication()
+                ->methods('GET')
+                ->build(),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Created `CrosswordController` with all 10 API endpoints (page, daily, random, themes, theme, check, complete, hint, abandon, stats) following ShkodaController patterns exactly
- Registered 10 crossword routes in `GameServiceProvider` (routes section only, `register()` untouched)
- Fixed `ShkodaController::buildStats()` to filter by `game_type='shkoda'` to prevent cross-contamination with crossword sessions
- Optimized N+1 query patterns in `buildWordBank()` and `complete()` with batch `loadMultiple()` calls

## Test plan
- [x] `./vendor/bin/phpunit --testsuite MinooUnit` — 759 tests pass
- [ ] E2e testing skipped (needs puzzles in DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)