### PR TITLE
feat: add crossword puzzle seeding script and integration tests

### DIFF
--- a/scripts/populate_crossword_puzzles.php
+++ b/scripts/populate_crossword_puzzles.php
@@ -1,0 +1,250 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Generate crossword puzzles from dictionary entries.
+ * Run: php scripts/populate_crossword_puzzles.php
+ *
+ * Creates:
+ * - One daily puzzle: daily-{today} (7x7, tier based on day of week)
+ * - Five practice puzzles: practice-001 through practice-005 (7x7, mixed tiers)
+ * - Themed puzzles if enough categorizable words exist
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Minoo\Support\CrosswordEngine;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+$kernel = new HttpKernel(dirname(__DIR__));
+$boot = new ReflectionMethod(AbstractKernel::class, 'boot');
+$boot->invoke($kernel);
+
+$entityTypeManager = $kernel->getEntityTypeManager();
+$puzzleStorage = $entityTypeManager->getStorage('crossword_puzzle');
+$dictStorage = $entityTypeManager->getStorage('dictionary_entry');
+
+// --- Load candidate words ---
+
+echo "Loading dictionary entries...\n";
+
+$ids = $dictStorage->getQuery()
+    ->condition('status', 1)
+    ->range(0, 200)
+    ->execute();
+
+$candidateWords = [];
+$wordMeta = [];
+$entries = $dictStorage->loadMultiple($ids);
+
+foreach ($entries as $entry) {
+    $word = mb_strtolower((string) $entry->get('word'));
+    $def = (string) $entry->get('definition');
+    $len = mb_strlen($word);
+
+    if ($def === '' || $len < 3 || $len > 7 || str_contains($word, '-')) {
+        continue;
+    }
+
+    $candidateWords[] = $word;
+    $wordMeta[$word] = [
+        'dictionary_entry_id' => (int) $entry->id(),
+        'definition' => $def,
+        'part_of_speech' => (string) $entry->get('part_of_speech'),
+    ];
+}
+
+echo sprintf("Found %d usable words (3-7 chars, no hyphens, with definitions).\n", count($candidateWords));
+
+if (count($candidateWords) < 4) {
+    echo "Error: Not enough dictionary entries to generate puzzles. Need at least 4.\n";
+    exit(1);
+}
+
+$created = 0;
+
+// --- Helper: build puzzle entity from grid result ---
+
+function buildPuzzle(
+    object $puzzleStorage,
+    string $puzzleId,
+    array $result,
+    array $wordMeta,
+    string $tier,
+    ?string $theme = null,
+): ?object {
+    $existing = $puzzleStorage->getQuery()
+        ->condition('id', $puzzleId)
+        ->execute();
+
+    if ($existing !== []) {
+        echo "  Skipping {$puzzleId} — already exists.\n";
+        return null;
+    }
+
+    $puzzleWords = [];
+    $clues = [];
+    foreach ($result['placements'] as $idx => $p) {
+        $meta = $wordMeta[$p['word']] ?? null;
+        $puzzleWords[] = [
+            'dictionary_entry_id' => $meta['dictionary_entry_id'] ?? null,
+            'row' => $p['row'],
+            'col' => $p['col'],
+            'direction' => $p['direction'],
+            'word' => $p['word'],
+        ];
+        $clues[(string) $idx] = [
+            'auto' => $meta !== null ? cleanDefinition($meta['definition']) : $p['word'],
+            'elder' => null,
+            'elder_author' => null,
+        ];
+    }
+
+    $values = [
+        'id' => $puzzleId,
+        'grid_size' => 7,
+        'words' => json_encode($puzzleWords),
+        'clues' => json_encode($clues),
+        'difficulty_tier' => $tier,
+    ];
+
+    if ($theme !== null) {
+        $values['theme'] = $theme;
+    }
+
+    $puzzle = $puzzleStorage->create($values);
+    $puzzleStorage->save($puzzle);
+
+    return $puzzle;
+}
+
+function cleanDefinition(string $raw): string
+{
+    if ($raw === '') {
+        return '';
+    }
+    $decoded = json_decode($raw, true);
+    if (is_array($decoded)) {
+        $raw = implode('; ', array_filter(array_map('trim', $decoded)));
+    }
+    $raw = str_replace(
+        ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
+        ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
+        $raw,
+    );
+    return $raw;
+}
+
+// --- 1. Daily puzzle ---
+
+echo "\n--- Daily Puzzle ---\n";
+$today = date('Y-m-d');
+$dayOfWeek = (int) date('w');
+$dailyTier = CrosswordEngine::dailyTier($dayOfWeek);
+$dailyId = "daily-{$today}";
+
+// Shuffle for variety then generate
+$dailyWords = $candidateWords;
+shuffle($dailyWords);
+
+$result = CrosswordEngine::generateGrid($dailyWords, 7, 4);
+if ($result !== null) {
+    $puzzle = buildPuzzle($puzzleStorage, $dailyId, $result, $wordMeta, $dailyTier);
+    if ($puzzle !== null) {
+        $wordCount = count($result['placements']);
+        echo "  Created {$dailyId} ({$dailyTier}, {$wordCount} words)\n";
+        $created++;
+    }
+} else {
+    echo "  Failed to generate daily puzzle grid.\n";
+}
+
+// --- 2. Practice puzzles ---
+
+echo "\n--- Practice Puzzles ---\n";
+$practiceTiers = ['easy', 'easy', 'medium', 'medium', 'hard'];
+
+for ($i = 1; $i <= 5; $i++) {
+    $practiceId = sprintf('practice-%03d', $i);
+    $tier = $practiceTiers[$i - 1];
+
+    $practiceWords = $candidateWords;
+    shuffle($practiceWords);
+
+    $result = CrosswordEngine::generateGrid($practiceWords, 7, 4);
+    if ($result !== null) {
+        $puzzle = buildPuzzle($puzzleStorage, $practiceId, $result, $wordMeta, $tier);
+        if ($puzzle !== null) {
+            $wordCount = count($result['placements']);
+            echo "  Created {$practiceId} ({$tier}, {$wordCount} words)\n";
+            $created++;
+        }
+    } else {
+        echo "  Failed to generate {$practiceId} grid.\n";
+    }
+}
+
+// --- 3. Themed puzzles (animals) ---
+
+echo "\n--- Themed Puzzles ---\n";
+
+$animalKeywords = ['bear', 'wolf', 'eagle', 'fish', 'deer', 'moose', 'turtle', 'rabbit', 'bird', 'fox', 'owl', 'beaver', 'otter'];
+$animalWords = [];
+
+foreach ($candidateWords as $word) {
+    $meta = $wordMeta[$word] ?? null;
+    if ($meta === null) {
+        continue;
+    }
+    $defLower = mb_strtolower($meta['definition']);
+    foreach ($animalKeywords as $keyword) {
+        if (str_contains($defLower, $keyword)) {
+            $animalWords[] = $word;
+            break;
+        }
+    }
+}
+
+if (count($animalWords) >= 4) {
+    echo sprintf("  Found %d animal-related words.\n", count($animalWords));
+
+    // Pad with random words if needed for better grid generation
+    $padded = $animalWords;
+    if (count($padded) < 10) {
+        $extras = array_diff($candidateWords, $animalWords);
+        shuffle($extras);
+        $padded = array_merge($padded, array_slice($extras, 0, 10 - count($padded)));
+    }
+
+    for ($i = 1; $i <= min(3, (int) floor(count($animalWords) / 4)); $i++) {
+        $themeId = sprintf('animals-%03d', $i);
+        shuffle($padded);
+
+        $result = CrosswordEngine::generateGrid($padded, 7, 4);
+        if ($result !== null) {
+            $puzzle = buildPuzzle($puzzleStorage, $themeId, $result, $wordMeta, 'easy', 'animals');
+            if ($puzzle !== null) {
+                $wordCount = count($result['placements']);
+                echo "  Created {$themeId} (animals theme, {$wordCount} words)\n";
+                $created++;
+            }
+        } else {
+            echo "  Failed to generate {$themeId} grid.\n";
+        }
+    }
+} else {
+    echo "  Not enough animal-related words for themed puzzles (found " . count($animalWords) . ", need 4).\n";
+}
+
+// --- Summary ---
+
+echo "\n=== Summary ===\n";
+echo "Created {$created} crossword puzzle(s).\n";
+
+$allIds = $puzzleStorage->getQuery()->execute();
+echo sprintf("Total puzzles in database: %d\n", count($allIds));
+
+echo "\nDone. Puzzles available at /games/crossword.\n";

--- a/tests/Minoo/Integration/Controller/CrosswordControllerTest.php
+++ b/tests/Minoo/Integration/Controller/CrosswordControllerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Integration\Controller;
+
+use Minoo\Entity\CrosswordPuzzle;
+use Minoo\Entity\GameSession;
+use Minoo\Support\CrosswordEngine;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class CrosswordControllerTest extends TestCase
+{
+    #[Test]
+    public function validate_word_identifies_correct_answer(): void
+    {
+        $result = CrosswordEngine::validateWord(['s', 'h', 'k', 'o', 'd', 'a'], 'shkoda');
+        $this->assertTrue($result['correct']);
+        $this->assertSame([0, 1, 2, 3, 4, 5], $result['correct_positions']);
+        $this->assertSame([], $result['wrong_positions']);
+    }
+
+    #[Test]
+    public function validate_word_identifies_partial_answer(): void
+    {
+        $result = CrosswordEngine::validateWord(['s', 'h', 'k', 'x', 'x', 'x'], 'shkoda');
+        $this->assertFalse($result['correct']);
+        $this->assertSame([0, 1, 2], $result['correct_positions']);
+        $this->assertSame([3, 4, 5], $result['wrong_positions']);
+    }
+
+    #[Test]
+    public function validate_word_handles_case_insensitive_input(): void
+    {
+        $result = CrosswordEngine::validateWord(['S', 'H', 'K', 'O', 'D', 'A'], 'shkoda');
+        $this->assertTrue($result['correct']);
+    }
+
+    #[Test]
+    public function crossword_session_tracks_grid_state(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'daily',
+            'puzzle_id' => 'daily-2026-03-25',
+        ]);
+        $gridState = ['word_0' => 'completed', 'word_1' => 'completed'];
+        $session->set('grid_state', json_encode($gridState));
+        $decoded = json_decode((string) $session->get('grid_state'), true);
+        $this->assertSame('completed', $decoded['word_0']);
+        $this->assertSame('completed', $decoded['word_1']);
+    }
+
+    #[Test]
+    public function crossword_session_defaults_to_in_progress(): void
+    {
+        $session = new GameSession([
+            'game_type' => 'crossword',
+            'mode' => 'practice',
+            'puzzle_id' => 'practice-001',
+        ]);
+        $this->assertSame('in_progress', $session->get('status'));
+        $this->assertSame(0, $session->get('hints_used'));
+    }
+
+    #[Test]
+    public function crossword_puzzle_stores_and_retrieves_words(): void
+    {
+        $words = [
+            [
+                'dictionary_entry_id' => 1,
+                'row' => 0,
+                'col' => 0,
+                'direction' => 'across',
+                'word' => 'shkoda',
+            ],
+        ];
+        $clues = [
+            '0' => ['auto' => 'fire', 'elder' => null, 'elder_author' => null],
+        ];
+        $puzzle = new CrosswordPuzzle([
+            'id' => 'test-1',
+            'grid_size' => 7,
+            'words' => json_encode($words),
+            'clues' => json_encode($clues),
+        ]);
+        $decoded = json_decode((string) $puzzle->get('words'), true);
+        $this->assertCount(1, $decoded);
+        $this->assertSame('shkoda', $decoded[0]['word']);
+        $this->assertSame('across', $decoded[0]['direction']);
+    }
+
+    #[Test]
+    public function crossword_puzzle_validates_difficulty_tier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid difficulty_tier');
+
+        new CrosswordPuzzle([
+            'id' => 'bad-tier',
+            'grid_size' => 7,
+            'words' => '[]',
+            'clues' => '{}',
+            'difficulty_tier' => 'impossible',
+        ]);
+    }
+
+    #[Test]
+    public function crossword_puzzle_defaults_to_easy_tier(): void
+    {
+        $puzzle = new CrosswordPuzzle([
+            'id' => 'default-tier',
+            'grid_size' => 7,
+            'words' => '[]',
+            'clues' => '{}',
+        ]);
+        $this->assertSame('easy', $puzzle->get('difficulty_tier'));
+    }
+
+    #[Test]
+    public function resolve_clue_prefers_elder_authored(): void
+    {
+        $clueData = [
+            'auto' => 'fire',
+            'elder' => 'The warmth that gathers our people',
+            'elder_author' => 'Elder Mary',
+        ];
+        $resolved = CrosswordEngine::resolveClue($clueData);
+        $this->assertSame('The warmth that gathers our people', $resolved['text']);
+        $this->assertSame('Elder Mary', $resolved['author']);
+    }
+
+    #[Test]
+    public function resolve_clue_falls_back_to_auto(): void
+    {
+        $clueData = ['auto' => 'fire', 'elder' => null, 'elder_author' => null];
+        $resolved = CrosswordEngine::resolveClue($clueData);
+        $this->assertSame('fire', $resolved['text']);
+        $this->assertNull($resolved['author']);
+    }
+
+    #[Test]
+    public function max_hints_varies_by_tier(): void
+    {
+        $this->assertSame(-1, CrosswordEngine::maxHints('easy'));
+        $this->assertSame(2, CrosswordEngine::maxHints('medium'));
+        $this->assertSame(0, CrosswordEngine::maxHints('hard'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `scripts/populate_crossword_puzzles.php` — generates daily, practice, and themed crossword puzzles from dictionary entries using `CrosswordEngine::generateGrid()`
- Add `tests/Minoo/Integration/Controller/CrosswordControllerTest.php` — 11 smoke tests covering word validation, session state tracking, puzzle entity storage, clue resolution, difficulty tiers, and hint limits
- All 801 tests pass (2306 assertions)

## Test plan
- [x] `composer dump-autoload && ./vendor/bin/phpunit` — full suite green (801 tests, 2306 assertions)
- [ ] Run `php scripts/populate_crossword_puzzles.php` against a populated DB to verify puzzle generation
- [ ] Verify generated puzzles load via `/api/games/crossword/daily`

🤖 Generated with [Claude Code](https://claude.com/claude-code)