### PR TITLE
refactor(#546, #547, #548): GameControllerTrait, stats/difficulty extraction, GateInterface

### DIFF
--- a/src/Controller/CrosswordController.php
+++ b/src/Controller/CrosswordController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minoo\Controller;
 
 use Minoo\Support\CrosswordEngine;
+use Minoo\Support\GameStatsCalculator;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
@@ -13,10 +14,17 @@ use Waaseyaa\SSR\SsrResponse;
 
 final class CrosswordController
 {
+    use GameControllerTrait;
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly Environment $twig,
     ) {}
+
+    private function getEntityTypeManager(): EntityTypeManager
+    {
+        return $this->entityTypeManager;
+    }
 
     /** Render the crossword game page. */
     public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -381,7 +389,7 @@ final class CrosswordController
             $wordTeachings[] = $teaching;
         }
 
-        $stats = $this->buildStats($account);
+        $stats = GameStatsCalculator::build($this->entityTypeManager, $account, 'crossword', ['abandoned'], ['completed']);
 
         // Compute time from session creation to now
         $timeSeconds = time() - (int) $session->get('created_at');
@@ -398,7 +406,7 @@ final class CrosswordController
     /** GET /api/games/crossword/stats — player stats (auth required). */
     public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        return $this->json($this->buildStats($account));
+        return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'crossword', ['abandoned'], ['completed']));
     }
 
     /** POST /api/games/crossword/hint — reveal a letter (tracked server-side). */
@@ -551,7 +559,7 @@ final class CrosswordController
     private function generateFallbackDaily(string $puzzleId, string $today): ?object
     {
         $dayOfWeek = (int) date('w', strtotime($today));
-        $tier = CrosswordEngine::dailyTier($dayOfWeek);
+        $tier = \Minoo\Support\GameDifficulty::dailyTier($dayOfWeek);
 
         // Load dictionary words with definitions
         $dictStorage = $this->entityTypeManager->getStorage('dictionary_entry');
@@ -653,123 +661,4 @@ final class CrosswordController
         return $bank;
     }
 
-    private function loadSessionByToken(string $uuid): ?object
-    {
-        $storage = $this->entityTypeManager->getStorage('game_session');
-        $ids = $storage->getQuery()
-            ->condition('uuid', $uuid)
-            ->range(0, 1)
-            ->execute();
-
-        if ($ids === []) {
-            return null;
-        }
-
-        return $storage->load(reset($ids));
-    }
-
-    /** @return array<string, mixed> */
-    private function buildStats(AccountInterface $account): array
-    {
-        if (!$account->isAuthenticated()) {
-            return ['authenticated' => false];
-        }
-
-        $storage = $this->entityTypeManager->getStorage('game_session');
-        $allIds = $storage->getQuery()
-            ->condition('user_id', $account->id())
-            ->condition('game_type', 'crossword')
-            ->execute();
-
-        if ($allIds === []) {
-            return [
-                'authenticated' => true,
-                'puzzles_completed' => 0,
-                'current_streak' => 0,
-                'best_streak' => 0,
-            ];
-        }
-
-        $sessions = array_values($storage->loadMultiple($allIds));
-        usort($sessions, fn($a, $b) => (int) $b->get('created_at') - (int) $a->get('created_at'));
-
-        $completed = array_filter($sessions, fn($s) => $s->get('status') === 'completed');
-
-        // Streak = consecutive daily completions
-        $currentStreak = 0;
-        foreach ($sessions as $s) {
-            if ($s->get('status') === 'completed') {
-                $currentStreak++;
-            } else {
-                break;
-            }
-        }
-
-        $bestStreak = 0;
-        $streak = 0;
-        foreach ($sessions as $s) {
-            if ($s->get('status') === 'completed') {
-                $streak++;
-                $bestStreak = max($bestStreak, $streak);
-            } elseif ($s->get('status') === 'abandoned') {
-                $streak = 0;
-            }
-        }
-
-        // Average completion time
-        $totalTime = 0;
-        foreach ($completed as $s) {
-            $totalTime += (int) $s->get('updated_at') - (int) $s->get('created_at');
-        }
-        $avgTime = count($completed) > 0 ? (int) round($totalTime / count($completed)) : 0;
-
-        return [
-            'authenticated' => true,
-            'puzzles_completed' => count($completed),
-            'avg_time' => $avgTime,
-            'current_streak' => $currentStreak,
-            'best_streak' => $bestStreak,
-        ];
-    }
-
-    private function cleanDefinition(string $raw): string
-    {
-        if ($raw === '') {
-            return '';
-        }
-        $decoded = json_decode($raw, true);
-        if (is_array($decoded)) {
-            $raw = implode('; ', array_filter(array_map('trim', $decoded)));
-        }
-        $raw = str_replace(
-            ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
-            ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
-            $raw,
-        );
-        return $raw;
-    }
-
-    /** @return array<string, mixed> */
-    private function jsonBody(HttpRequest $request): array
-    {
-        $content = $request->getContent();
-        if ($content === '' || $content === false) {
-            return [];
-        }
-        try {
-            return (array) json_decode((string) $content, true, 16, JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
-            return [];
-        }
-    }
-
-    /** @param array<string, mixed> $data */
-    private function json(array $data, int $status = 200): SsrResponse
-    {
-        return new SsrResponse(
-            content: json_encode($data, JSON_THROW_ON_ERROR),
-            statusCode: $status,
-            headers: ['Content-Type' => 'application/json'],
-        );
-    }
 }

--- a/src/Controller/GameControllerTrait.php
+++ b/src/Controller/GameControllerTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Controller;
+
+use Minoo\Entity\GameSession;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\SsrResponse;
+
+/**
+ * Shared helpers for game controllers (Shkoda, Crossword).
+ *
+ * Requires the using class to have a readonly $entityTypeManager property.
+ */
+trait GameControllerTrait
+{
+    abstract private function getEntityTypeManager(): EntityTypeManager;
+
+    /** @return array<string, mixed> */
+    private function jsonBody(HttpRequest $request): array
+    {
+        $content = $request->getContent();
+        if ($content === '' || $content === false) {
+            return [];
+        }
+        try {
+            return (array) json_decode((string) $content, true, 16, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+    }
+
+    /** @param array<string, mixed> $data */
+    private function json(array $data, int $status = 200): SsrResponse
+    {
+        return new SsrResponse(
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+            statusCode: $status,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+
+    /** Extract a clean definition string from a field that may be JSON-encoded. */
+    private function cleanDefinition(string $raw): string
+    {
+        if ($raw === '') {
+            return '';
+        }
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $raw = implode('; ', array_filter(array_map('trim', $decoded)));
+        }
+
+        // Expand OPD linguistic abbreviations for readability
+        // Order matters: longer patterns first to avoid partial replacement
+        $raw = str_replace(
+            ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
+            ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
+            $raw,
+        );
+
+        return $raw;
+    }
+
+    private function loadSessionByToken(string $uuid): ?GameSession
+    {
+        $entity = $this->getEntityTypeManager()->getStorage('game_session')->loadByKey('uuid', $uuid);
+        return $entity instanceof GameSession ? $entity : null;
+    }
+}

--- a/src/Controller/ShkodaController.php
+++ b/src/Controller/ShkodaController.php
@@ -4,20 +4,29 @@ declare(strict_types=1);
 
 namespace Minoo\Controller;
 
-use Minoo\Entity\GameSession;
+use Minoo\Support\GameStatsCalculator;
 use Minoo\Support\ShkodaEngine;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\SsrResponse;
 
 final class ShkodaController
 {
+    use GameControllerTrait;
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly Environment $twig,
+        private readonly GateInterface $gate,
     ) {}
+
+    private function getEntityTypeManager(): EntityTypeManager
+    {
+        return $this->entityTypeManager;
+    }
 
     /** Redirect legacy /games/ishkode URL to /games/shkoda. */
     public function redirectLegacy(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
@@ -51,7 +60,7 @@ final class ShkodaController
             $tier = (string) $challenge->get('difficulty_tier');
         } else {
             // Fallback: deterministic random selection seeded by date
-            $tier = ShkodaEngine::dailyTier($dayOfWeek);
+            $tier = \Minoo\Support\GameDifficulty::dailyTier($dayOfWeek);
             $direction = $dayOfWeek % 2 === 0 ? 'english_to_ojibwe' : 'ojibwe_to_english';
             $entryId = $this->selectRandomWord($tier, $today);
             if ($entryId === null) {
@@ -255,9 +264,8 @@ final class ShkodaController
             return $this->json(['error' => 'Invalid session'], 404);
         }
 
-        // Verify session ownership for authenticated users
-        if ($account->isAuthenticated() && $session->get('user_id') !== null
-            && (int) $session->get('user_id') !== (int) $account->id()) {
+        // Verify session ownership via access policy
+        if ($this->gate->denies('update', $session, $account)) {
             return $this->json(['error' => 'Forbidden'], 403);
         }
 
@@ -295,7 +303,7 @@ final class ShkodaController
         $example = $exampleIds !== [] ? $exampleStorage->load(reset($exampleIds)) : null;
 
         // Build stats for authenticated users
-        $stats = $this->buildStats($account);
+        $stats = GameStatsCalculator::build($this->entityTypeManager, $account, 'shkoda');
 
         return $this->json([
             'word' => $word,
@@ -312,7 +320,7 @@ final class ShkodaController
     /** GET /api/games/shkoda/stats — player stats (auth required). */
     public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
     {
-        return $this->json($this->buildStats($account));
+        return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'shkoda'));
     }
 
     // --- Private helpers ---
@@ -377,22 +385,6 @@ final class ShkodaController
         return $filtered[array_rand($filtered)];
     }
 
-    private function loadSessionByToken(string $uuid): ?GameSession
-    {
-        $storage = $this->entityTypeManager->getStorage('game_session');
-        $ids = $storage->getQuery()
-            ->condition('uuid', $uuid)
-            ->range(0, 1)
-            ->execute();
-
-        if ($ids === []) {
-            return null;
-        }
-
-        $entity = $storage->load(reset($ids));
-        return $entity instanceof GameSession ? $entity : null;
-    }
-
     /** @param list<string> $guesses */
     private function isWordFullyRevealed(string $word, array $guesses): bool
     {
@@ -434,113 +426,4 @@ final class ShkodaController
         return $positions;
     }
 
-    /** @return array<string, mixed> */
-    private function buildStats(AccountInterface $account): array
-    {
-        if (!$account->isAuthenticated()) {
-            return ['authenticated' => false];
-        }
-
-        $storage = $this->entityTypeManager->getStorage('game_session');
-        $allIds = $storage->getQuery()
-            ->condition('user_id', $account->id())
-            ->condition('game_type', 'shkoda')
-            ->execute();
-
-        if ($allIds === []) {
-            return [
-                'authenticated' => true,
-                'games_played' => 0,
-                'win_rate' => 0.0,
-                'current_streak' => 0,
-                'best_streak' => 0,
-            ];
-        }
-
-        $sessions = array_values($storage->loadMultiple($allIds));
-
-        // Sort by created_at DESC for streak calculation
-        usort($sessions, fn($a, $b) => (int) $b->get('created_at') - (int) $a->get('created_at'));
-
-        $completed = array_filter($sessions, fn($s) => $s->get('status') !== 'in_progress');
-        $wins = array_filter($completed, fn($s) => $s->get('status') === 'won');
-        $gamesPlayed = count($completed);
-        $winRate = $gamesPlayed > 0 ? round(count($wins) / $gamesPlayed, 2) : 0.0;
-
-        // Current streak
-        $currentStreak = 0;
-        foreach ($sessions as $s) {
-            if ($s->get('status') === 'won') {
-                $currentStreak++;
-            } elseif ($s->get('status') === 'lost') {
-                break;
-            }
-        }
-
-        // Best streak
-        $bestStreak = 0;
-        $streak = 0;
-        foreach ($sessions as $s) {
-            if ($s->get('status') === 'won') {
-                $streak++;
-                $bestStreak = max($bestStreak, $streak);
-            } elseif ($s->get('status') === 'lost') {
-                $streak = 0;
-            }
-        }
-
-        return [
-            'authenticated' => true,
-            'games_played' => $gamesPlayed,
-            'win_rate' => $winRate,
-            'current_streak' => $currentStreak,
-            'best_streak' => $bestStreak,
-        ];
-    }
-
-    /** @return array<string, mixed> */
-    private function jsonBody(HttpRequest $request): array
-    {
-        $content = $request->getContent();
-        if ($content === '' || $content === false) {
-            return [];
-        }
-        try {
-            return (array) json_decode((string) $content, true, 16, JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
-            return [];
-        }
-    }
-
-    /** Extract a clean definition string from a field that may be JSON-encoded. */
-    private function cleanDefinition(string $raw): string
-    {
-        if ($raw === '') {
-            return '';
-        }
-        $decoded = json_decode($raw, true);
-        if (is_array($decoded)) {
-            $raw = implode('; ', array_filter(array_map('trim', $decoded)));
-        }
-
-        // Expand OPD linguistic abbreviations for readability
-        // Order matters: longer patterns first to avoid partial replacement
-        $raw = str_replace(
-            ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
-            ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
-            $raw,
-        );
-
-        return $raw;
-    }
-
-    /** @param array<string, mixed> $data */
-    private function json(array $data, int $status = 200): SsrResponse
-    {
-        return new SsrResponse(
-            content: json_encode($data, JSON_THROW_ON_ERROR),
-            statusCode: $status,
-            headers: ['Content-Type' => 'application/json'],
-        );
-    }
 }

--- a/src/Support/CrosswordEngine.php
+++ b/src/Support/CrosswordEngine.php
@@ -147,10 +147,10 @@ final class CrosswordEngine
         ];
     }
 
-    /** Reuse Shkoda's day-of-week difficulty pattern. */
+    /** @deprecated Use GameDifficulty::dailyTier() directly. */
     public static function dailyTier(int $dayOfWeek): string
     {
-        return ShkodaEngine::dailyTier($dayOfWeek);
+        return GameDifficulty::dailyTier($dayOfWeek);
     }
 
     /**

--- a/src/Support/GameDifficulty.php
+++ b/src/Support/GameDifficulty.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+/**
+ * Shared difficulty tier logic for all games.
+ */
+final class GameDifficulty
+{
+    /** Get difficulty tier for a day of the week (0=Sun, 1=Mon, etc.). */
+    public static function dailyTier(int $dayOfWeek): string
+    {
+        return match ($dayOfWeek) {
+            1, 3, 5 => 'easy',    // Mon, Wed, Fri
+            2, 4 => 'medium',     // Tue, Thu
+            default => 'hard',    // Sat, Sun
+        };
+    }
+}

--- a/src/Support/GameStatsCalculator.php
+++ b/src/Support/GameStatsCalculator.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Calculates player statistics for any game type.
+ */
+final class GameStatsCalculator
+{
+    /**
+     * Build stats for a game type.
+     *
+     * @param string $gameType Entity game_type value (e.g. 'shkoda', 'crossword')
+     * @param list<string> $streakBreakers Status values that break a streak
+     * @param list<string> $winStatuses Status values that count as wins
+     * @return array<string, mixed>
+     */
+    public static function build(
+        EntityTypeManager $entityTypeManager,
+        AccountInterface $account,
+        string $gameType,
+        array $streakBreakers = ['lost'],
+        array $winStatuses = ['won'],
+    ): array {
+        if (!$account->isAuthenticated()) {
+            return ['authenticated' => false];
+        }
+
+        $storage = $entityTypeManager->getStorage('game_session');
+        $allIds = $storage->getQuery()
+            ->condition('user_id', $account->id())
+            ->condition('game_type', $gameType)
+            ->execute();
+
+        if ($allIds === []) {
+            return [
+                'authenticated' => true,
+                'games_played' => 0,
+                'win_rate' => 0.0,
+                'current_streak' => 0,
+                'best_streak' => 0,
+            ];
+        }
+
+        $sessions = array_values($storage->loadMultiple($allIds));
+
+        // Sort by created_at DESC for streak calculation
+        usort($sessions, fn($a, $b) => (int) $b->get('created_at') - (int) $a->get('created_at'));
+
+        $completed = array_filter($sessions, fn($s) => $s->get('status') !== 'in_progress');
+        $wins = array_filter($completed, fn($s) => in_array($s->get('status'), $winStatuses, true));
+        $gamesPlayed = count($completed);
+        $winRate = $gamesPlayed > 0 ? round(count($wins) / $gamesPlayed, 2) : 0.0;
+
+        // Current streak
+        $currentStreak = 0;
+        foreach ($sessions as $s) {
+            if (in_array($s->get('status'), $winStatuses, true)) {
+                $currentStreak++;
+            } elseif (in_array($s->get('status'), $streakBreakers, true)) {
+                break;
+            }
+        }
+
+        // Best streak
+        $bestStreak = 0;
+        $streak = 0;
+        foreach ($sessions as $s) {
+            if (in_array($s->get('status'), $winStatuses, true)) {
+                $streak++;
+                $bestStreak = max($bestStreak, $streak);
+            } elseif (in_array($s->get('status'), $streakBreakers, true)) {
+                $streak = 0;
+            }
+        }
+
+        $stats = [
+            'authenticated' => true,
+            'games_played' => $gamesPlayed,
+            'win_rate' => $winRate,
+            'current_streak' => $currentStreak,
+            'best_streak' => $bestStreak,
+        ];
+
+        // Average completion time for completed games
+        if ($gamesPlayed > 0) {
+            $totalTime = 0;
+            foreach ($completed as $s) {
+                $totalTime += (int) $s->get('updated_at') - (int) $s->get('created_at');
+            }
+            $stats['avg_time'] = (int) round($totalTime / $gamesPlayed);
+        }
+
+        return $stats;
+    }
+}

--- a/src/Support/ShkodaEngine.php
+++ b/src/Support/ShkodaEngine.php
@@ -77,14 +77,10 @@ final class ShkodaEngine
         ];
     }
 
-    /** Get difficulty tier for a day of the week (0=Sun, 1=Mon, etc.). */
+    /** @deprecated Use GameDifficulty::dailyTier() directly. */
     public static function dailyTier(int $dayOfWeek): string
     {
-        return match ($dayOfWeek) {
-            1, 3, 5 => 'easy',    // Mon, Wed, Fri
-            2, 4 => 'medium',     // Tue, Thu
-            default => 'hard',    // Sat, Sun
-        };
+        return GameDifficulty::dailyTier($dayOfWeek);
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes out the remaining 3 issues in the **Games — Quality & Patterns** milestone.

- **GameControllerTrait** (#546): `jsonBody()`, `json()`, `cleanDefinition()`, `loadSessionByToken()` extracted into a shared trait. `loadSessionByToken()` now uses framework `loadByKey()` (single method call vs 5-line query+load). Both controllers use the trait.
- **GameStatsCalculator** (#547): Replaces duplicate `buildStats()` in both controllers. Configurable streak-breaker and win statuses. `GameDifficulty::dailyTier()` replaces engine-specific implementations — CrosswordEngine no longer depends on ShkodaEngine.
- **GateInterface** (#548): ShkodaController injects `GateInterface` via constructor DI. Hand-rolled ownership check replaced with `$gate->denies('update', $session, $account)`, properly delegating to `GameAccessPolicy`.

Net: +224 / -262 lines (38 lines removed)

Closes #546
Closes #547
Closes #548

## Test plan

- [x] Full test suite passes (812 tests, 2330 assertions)
- [x] Unit + integration tests pass via pre-push hook
- [ ] Verify daily/random/theme crossword endpoints unchanged
- [ ] Verify Shkoda ownership check still returns 403 for wrong user

🤖 Generated with [Claude Code](https://claude.com/claude-code)