### PR TITLE
refactor(#553): extract shared game JS utilities

### DIFF
--- a/public/js/crossword.js
+++ b/public/js/crossword.js
@@ -16,15 +16,10 @@
 (function () {
   'use strict';
 
-  // ── Constants ──
-  var KEYBOARD_ROWS = [
-    ['A', 'B', 'C', 'D', 'E', 'G', 'H', 'I', 'J'],
-    ['K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R'],
-    ['S', 'T', 'W', 'Y', 'Z', '\u02BC'] // ʼ = glottal stop; HINT, DEL, CHECK added programmatically
-  ];
-  var VALID_LETTERS = new Set(KEYBOARD_ROWS.flat().map(function (k) { return k.toLowerCase(); }));
-  var STATS_KEY = 'crossword-stats';
-  var API_BASE = '/api/games/crossword';
+  // ── Constants (shared from games-common.js) ──
+  var g = MinooGames.create({ statsKey: 'crossword-stats', apiBase: '/api/games/crossword', cssPrefix: 'crossword' });
+  var KEYBOARD_ROWS = MinooGames.KEYBOARD_ROWS;
+  var VALID_LETTERS = MinooGames.VALID_LETTERS;
 
   // ── DOM refs ──
   var root = document.querySelector('[data-game="crossword"]');
@@ -71,51 +66,16 @@
     gameOver: false
   };
 
-  // ── Helpers ──
-  function todayKey() {
-    return 'crossword-daily-' + new Date().toISOString().slice(0, 10);
-  }
+  // ── Helpers (delegated to games-common.js) ──
+  var todayKey = g.todayKey;
+  var loadStats = g.loadStats;
+  var saveStats = g.saveStats;
+  var api = g.api;
+  var apiGet = g.apiGet;
+  var escapeHtml = g.escapeHtml;
 
   function themeKey(slug) {
     return 'crossword-theme-' + slug;
-  }
-
-  function loadStats() {
-    try {
-      return JSON.parse(localStorage.getItem(STATS_KEY)) || {
-        games_played: 0, wins: 0, current_streak: 0, best_streak: 0
-      };
-    } catch (_) {
-      return { games_played: 0, wins: 0, current_streak: 0, best_streak: 0 };
-    }
-  }
-
-  function saveStats(s) {
-    try { localStorage.setItem(STATS_KEY, JSON.stringify(s)); } catch (_) { /* quota */ }
-  }
-
-  function api(path, body) {
-    return fetch(API_BASE + path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    }).then(function (r) {
-      if (!r.ok) throw new Error('API error: ' + r.status);
-      return r.json();
-    });
-  }
-
-  function apiGet(path) {
-    return fetch(API_BASE + path).then(function (r) {
-      if (!r.ok) throw new Error('API error: ' + r.status);
-      return r.json();
-    });
-  }
-
-  function escapeHtml(str) {
-    var div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
   }
 
   function formatTime(ms) {
@@ -908,10 +868,7 @@
   }
 
   function renderStatsHtml(stats, elapsed) {
-    var html = '<div class="crossword__stat"><div class="crossword__stat-value">' + stats.games_played + '</div><div class="crossword__stat-label">Played</div></div>' +
-      '<div class="crossword__stat"><div class="crossword__stat-value">' + stats.wins + '</div><div class="crossword__stat-label">Won</div></div>' +
-      '<div class="crossword__stat"><div class="crossword__stat-value">' + stats.current_streak + '</div><div class="crossword__stat-label">Streak</div></div>' +
-      '<div class="crossword__stat"><div class="crossword__stat-value">' + stats.best_streak + '</div><div class="crossword__stat-label">Best</div></div>';
+    var html = g.renderStatsHtml(stats);
 
     if (elapsed !== undefined) {
       html += '<div class="crossword__stat"><div class="crossword__stat-value">' + formatTime(elapsed) + '</div><div class="crossword__stat-label">Time</div></div>';

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -1,0 +1,104 @@
+/**
+ * Games Common — Shared utilities for Minoo game engines.
+ *
+ * Provides: API helpers, localStorage stats, HTML escaping, date keys,
+ * stats rendering. Each game calls MinooGames.create({ ... }) to get
+ * an instance configured with its own stats key, API base, and CSS prefix.
+ *
+ * @example
+ *   var g = MinooGames.create({
+ *     statsKey: 'shkoda-stats',
+ *     apiBase: '/api/games/shkoda',
+ *     cssPrefix: 'shkoda'
+ *   });
+ *   g.api('/guess', { letter: 'a' });
+ *   g.loadStats();
+ */
+var MinooGames = (function () {
+  'use strict';
+
+  var KEYBOARD_ROWS = [
+    ['A', 'B', 'C', 'D', 'E', 'G', 'H', 'I', 'J'],
+    ['K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R'],
+    ['S', 'T', 'W', 'Y', 'Z', '\u02BC'] // ʼ = glottal stop
+  ];
+
+  var VALID_LETTERS = new Set(KEYBOARD_ROWS.flat().map(function (k) {
+    return k.toLowerCase();
+  }));
+
+  var DEFAULT_STATS = {
+    games_played: 0, wins: 0, current_streak: 0, best_streak: 0
+  };
+
+  function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  function create(config) {
+    var statsKey = config.statsKey;
+    var apiBase = config.apiBase;
+    var cssPrefix = config.cssPrefix;
+
+    function todayKey() {
+      return cssPrefix + '-daily-' + new Date().toISOString().slice(0, 10);
+    }
+
+    function loadStats() {
+      try {
+        return JSON.parse(localStorage.getItem(statsKey)) || Object.assign({}, DEFAULT_STATS);
+      } catch (_) {
+        return Object.assign({}, DEFAULT_STATS);
+      }
+    }
+
+    function saveStats(s) {
+      try { localStorage.setItem(statsKey, JSON.stringify(s)); } catch (_) { /* quota */ }
+    }
+
+    function api(path, body) {
+      return fetch(apiBase + path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }).then(function (r) {
+        if (!r.ok) throw new Error('API error: ' + r.status);
+        return r.json();
+      });
+    }
+
+    function apiGet(path) {
+      return fetch(apiBase + path).then(function (r) {
+        if (!r.ok) throw new Error('API error: ' + r.status);
+        return r.json();
+      });
+    }
+
+    function renderStatsHtml(stats) {
+      var p = cssPrefix;
+      return '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.games_played + '</div><div class="' + p + '__stat-label">Played</div></div>' +
+        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.wins + '</div><div class="' + p + '__stat-label">Won</div></div>' +
+        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.current_streak + '</div><div class="' + p + '__stat-label">Streak</div></div>' +
+        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.best_streak + '</div><div class="' + p + '__stat-label">Best</div></div>';
+    }
+
+    return {
+      todayKey: todayKey,
+      loadStats: loadStats,
+      saveStats: saveStats,
+      api: api,
+      apiGet: apiGet,
+      renderStatsHtml: renderStatsHtml,
+      escapeHtml: escapeHtml
+    };
+  }
+
+  return {
+    create: create,
+    KEYBOARD_ROWS: KEYBOARD_ROWS,
+    VALID_LETTERS: VALID_LETTERS,
+    escapeHtml: escapeHtml
+  };
+})();

--- a/public/js/shkoda.js
+++ b/public/js/shkoda.js
@@ -17,20 +17,15 @@
 (function () {
   'use strict';
 
-  // ── Constants ──
-  var KEYBOARD_ROWS = [
-    ['A', 'B', 'C', 'D', 'E', 'G', 'H', 'I', 'J'],
-    ['K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R'],
-    ['S', 'T', 'W', 'Y', 'Z', '\u02BC'] // ʼ = glottal stop
-  ];
-  var VALID_LETTERS = new Set(KEYBOARD_ROWS.flat().map(function (k) { return k.toLowerCase(); }));
-  var STATS_KEY = 'shkoda-stats';
+  // ── Constants (shared from games-common.js) ──
+  var g = MinooGames.create({ statsKey: 'shkoda-stats', apiBase: '/api/games/shkoda', cssPrefix: 'shkoda' });
+  var KEYBOARD_ROWS = MinooGames.KEYBOARD_ROWS;
+  var VALID_LETTERS = MinooGames.VALID_LETTERS;
 
   // ── DOM refs ──
   var game = document.getElementById('shkoda-game');
   if (!game) return;
 
-  var apiBase = game.dataset.apiBase || '/api/games/shkoda';
   var fireEl = document.getElementById('shkoda-fire');
   var remainingEl = document.getElementById('shkoda-remaining');
   var clueWordEl = document.getElementById('shkoda-clue-word');
@@ -63,42 +58,12 @@
     challengeData: null
   };
 
-  // ── Helpers ──
-  function todayKey() {
-    return 'shkoda-daily-' + new Date().toISOString().slice(0, 10);
-  }
-
-  function loadStats() {
-    try {
-      return JSON.parse(localStorage.getItem(STATS_KEY)) || {
-        games_played: 0, wins: 0, current_streak: 0, best_streak: 0
-      };
-    } catch (_) {
-      return { games_played: 0, wins: 0, current_streak: 0, best_streak: 0 };
-    }
-  }
-
-  function saveStats(s) {
-    try { localStorage.setItem(STATS_KEY, JSON.stringify(s)); } catch (_) { /* quota */ }
-  }
-
-  function api(path, body) {
-    return fetch(apiBase + path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    }).then(function (r) {
-      if (!r.ok) throw new Error('API error: ' + r.status);
-      return r.json();
-    });
-  }
-
-  function apiGet(path) {
-    return fetch(apiBase + path).then(function (r) {
-      if (!r.ok) throw new Error('API error: ' + r.status);
-      return r.json();
-    });
-  }
+  // ── Helpers (delegated to games-common.js) ──
+  var todayKey = g.todayKey;
+  var loadStats = g.loadStats;
+  var saveStats = g.saveStats;
+  var api = g.api;
+  var apiGet = g.apiGet;
 
   // ── Rendering ──
   function showLoading(show) {
@@ -402,18 +367,8 @@
     }
   }
 
-  function renderStatsHtml(stats) {
-    return '<div class="shkoda__stat"><div class="shkoda__stat-value">' + stats.games_played + '</div><div class="shkoda__stat-label">Played</div></div>' +
-      '<div class="shkoda__stat"><div class="shkoda__stat-value">' + stats.wins + '</div><div class="shkoda__stat-label">Won</div></div>' +
-      '<div class="shkoda__stat"><div class="shkoda__stat-value">' + stats.current_streak + '</div><div class="shkoda__stat-label">Streak</div></div>' +
-      '<div class="shkoda__stat"><div class="shkoda__stat-value">' + stats.best_streak + '</div><div class="shkoda__stat-label">Best</div></div>';
-  }
-
-  function escapeHtml(str) {
-    var div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
-  }
+  var renderStatsHtml = g.renderStatsHtml;
+  var escapeHtml = g.escapeHtml;
 
   function shareResult(won, btn) {
     // Build guess-by-guess emoji sequence per spec

--- a/templates/crossword.html.twig
+++ b/templates/crossword.html.twig
@@ -88,5 +88,6 @@
     </div>
 </div>
 
+<script src="/js/games-common.js" defer></script>
 <script src="/js/crossword.js" defer></script>
 {% endblock %}

--- a/templates/shkoda.html.twig
+++ b/templates/shkoda.html.twig
@@ -83,5 +83,6 @@
     <div class="shkoda__loading" id="shkoda-loading">Loading...</div>
 </div>
 
+<script src="/js/games-common.js" defer></script>
 <script src="/js/shkoda.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Extract duplicated JS helpers (api, stats, keyboard, escapeHtml) into `public/js/games-common.js`
- Both `shkoda.js` and `crossword.js` now use `MinooGames.create()` factory instead of copy-pasted functions
- Crossword's `renderStatsHtml` extends the shared base with time/hints stats
- Templates load `games-common.js` before game-specific scripts via `defer`

Closes #553

## Test plan
- [x] 812 tests pass (4 skipped)
- [ ] Verify Shkoda game loads and plays correctly
- [ ] Verify Crossword game loads and plays correctly
- [ ] Verify stats persist across page reloads


🤖 Generated with [Claude Code](https://claude.com/claude-code)