### PR TITLE
fix(#554, #562): unify game btn/stat CSS, fix crossword layout shift

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -3188,6 +3188,57 @@
   }
 
   /* ══════════════════════════════════════════════
+     Shared Game Components
+     ══════════════════════════════════════════════ */
+
+  /* Game accent — set by each game's container */
+  .shkoda     { --game-accent: var(--shkoda-correct); }
+  .crossword  { --game-accent: var(--crossword-correct); }
+
+  /* Shared stat block (used in reveal/completion screens) */
+  .game-stat {
+    text-align: center;
+  }
+
+  .game-stat__value {
+    font-size: var(--text-lg);
+    font-weight: 700;
+    color: var(--game-accent, var(--text-primary));
+  }
+
+  .game-stat__label {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+  }
+
+  /* Shared game button */
+  .game-btn {
+    padding: var(--space-xs) var(--space-md);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: var(--text-sm);
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+
+    &:hover {
+      border-color: var(--game-accent);
+      color: var(--game-accent);
+    }
+  }
+
+  .game-btn--primary {
+    background: var(--game-accent);
+    border-color: var(--game-accent);
+    color: #fff;
+
+    &:hover {
+      background: oklch(from var(--game-accent) calc(l - 0.05) c h);
+    }
+  }
+
+  /* ══════════════════════════════════════════════
      Games Hub
      ══════════════════════════════════════════════ */
 
@@ -3842,51 +3893,10 @@
     margin-block-end: var(--space-md);
   }
 
-  .shkoda__stat {
-    text-align: center;
-
-    & .shkoda__stat-value {
-      font-size: var(--text-lg);
-      font-weight: 700;
-      color: var(--text-primary);
-    }
-
-    & .shkoda__stat-label {
-      font-size: var(--text-xs);
-      color: var(--text-muted);
-    }
-  }
-
   .shkoda__actions {
     display: flex;
     gap: var(--space-xs);
     justify-content: center;
-  }
-
-  .shkoda__btn {
-    padding: var(--space-xs) var(--space-md);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: var(--text-sm);
-    transition: background-color 0.2s, border-color 0.2s;
-
-    &:hover {
-      border-color: var(--shkoda-correct);
-      color: var(--shkoda-correct);
-    }
-
-    &--primary {
-      background: var(--shkoda-correct);
-      border-color: var(--shkoda-correct);
-      color: #fff;
-
-      &:hover {
-        background: oklch(from var(--shkoda-correct) calc(l - 0.05) c h);
-      }
-    }
   }
 
   /* Loading state */
@@ -4147,7 +4157,7 @@
     50% { box-shadow: 0 0 4px oklch(from var(--crossword-active) l c h / 0.2); }
   }
 
-  /* Active clue bar below grid */
+  /* Active clue bar below grid — fixed height prevents layout shift */
   .crossword__active-clue {
     border-left: 3px solid var(--crossword-active);
     background: oklch(1 0 0 / 0.05);
@@ -4156,6 +4166,7 @@
     margin-block: var(--space-sm);
     font-size: var(--text-sm);
     color: var(--text-secondary);
+    min-height: 2.5rem;
 
     & strong {
       color: var(--text-primary);
@@ -4163,10 +4174,13 @@
     }
   }
 
-  /* Clue panels */
+  /* Clue panels — scrollable to prevent page-level scrollIntoView shifts */
   .crossword__clues {
     font-size: var(--text-sm);
     line-height: 1.5;
+    max-height: 50vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .crossword__clues-heading {
@@ -4335,51 +4349,10 @@
     margin-block-end: var(--space-md);
   }
 
-  .crossword__stat {
-    text-align: center;
-
-    & .crossword__stat-value {
-      font-size: var(--text-lg);
-      font-weight: 700;
-      color: var(--crossword-correct);
-    }
-
-    & .crossword__stat-label {
-      font-size: var(--text-xs);
-      color: var(--text-muted);
-    }
-  }
-
   .crossword__actions {
     display: flex;
     gap: var(--space-xs);
     justify-content: center;
-  }
-
-  .crossword__btn {
-    padding: var(--space-xs) var(--space-md);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: var(--text-sm);
-    transition: background-color 0.2s, border-color 0.2s;
-
-    &:hover {
-      border-color: var(--crossword-correct);
-      color: var(--crossword-correct);
-    }
-
-    &--primary {
-      background: var(--crossword-correct);
-      border-color: var(--crossword-correct);
-      color: #fff;
-
-      &:hover {
-        background: oklch(from var(--crossword-correct) calc(l - 0.05) c h);
-      }
-    }
   }
 
   /* Theme browser card grid */

--- a/public/js/crossword.js
+++ b/public/js/crossword.js
@@ -871,11 +871,11 @@
     var html = g.renderStatsHtml(stats);
 
     if (elapsed !== undefined) {
-      html += '<div class="crossword__stat"><div class="crossword__stat-value">' + formatTime(elapsed) + '</div><div class="crossword__stat-label">Time</div></div>';
+      html += '<div class="game-stat"><div class="game-stat__value">' + formatTime(elapsed) + '</div><div class="game-stat__label">Time</div></div>';
     }
 
     if (state.hintsUsed > 0) {
-      html += '<div class="crossword__stat"><div class="crossword__stat-value">' + state.hintsUsed + '</div><div class="crossword__stat-label">Hints</div></div>';
+      html += '<div class="game-stat"><div class="game-stat__value">' + state.hintsUsed + '</div><div class="game-stat__label">Hints</div></div>';
     }
 
     return html;

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -77,11 +77,10 @@ var MinooGames = (function () {
     }
 
     function renderStatsHtml(stats) {
-      var p = cssPrefix;
-      return '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.games_played + '</div><div class="' + p + '__stat-label">Played</div></div>' +
-        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.wins + '</div><div class="' + p + '__stat-label">Won</div></div>' +
-        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.current_streak + '</div><div class="' + p + '__stat-label">Streak</div></div>' +
-        '<div class="' + p + '__stat"><div class="' + p + '__stat-value">' + stats.best_streak + '</div><div class="' + p + '__stat-label">Best</div></div>';
+      return '<div class="game-stat"><div class="game-stat__value">' + stats.games_played + '</div><div class="game-stat__label">Played</div></div>' +
+        '<div class="game-stat"><div class="game-stat__value">' + stats.wins + '</div><div class="game-stat__label">Won</div></div>' +
+        '<div class="game-stat"><div class="game-stat__value">' + stats.current_streak + '</div><div class="game-stat__label">Streak</div></div>' +
+        '<div class="game-stat"><div class="game-stat__value">' + stats.best_streak + '</div><div class="game-stat__label">Best</div></div>';
     }
 
     return {

--- a/public/js/shkoda.js
+++ b/public/js/shkoda.js
@@ -347,20 +347,20 @@
     actionsEl.innerHTML = '';
 
     var shareBtn = document.createElement('button');
-    shareBtn.className = 'shkoda__btn';
+    shareBtn.className = 'game-btn';
     shareBtn.textContent = 'Share';
     shareBtn.addEventListener('click', function () { shareResult(won, shareBtn); });
     actionsEl.appendChild(shareBtn);
 
     if (state.mode === 'practice' || (state.mode === 'streak' && won)) {
       var nextBtn = document.createElement('button');
-      nextBtn.className = 'shkoda__btn shkoda__btn--primary';
+      nextBtn.className = 'game-btn game-btn--primary';
       nextBtn.textContent = 'Next Word';
       nextBtn.addEventListener('click', function () { startGame(); });
       actionsEl.appendChild(nextBtn);
     } else if (state.mode === 'streak' && !won) {
       var replayBtn = document.createElement('button');
-      replayBtn.className = 'shkoda__btn shkoda__btn--primary';
+      replayBtn.className = 'game-btn game-btn--primary';
       replayBtn.textContent = 'Streak Over \u2014 Play Again';
       replayBtn.addEventListener('click', function () { startGame(); });
       actionsEl.appendChild(replayBtn);

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,7 +17,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=24">
+  <link rel="stylesheet" href="/css/minoo.css?v=25">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   <script defer src="https://analytics.minoo.live/script.js" data-website-id="b357d196-9464-42e1-a93b-5f85743f20c9"></script>

--- a/templates/crossword.html.twig
+++ b/templates/crossword.html.twig
@@ -77,8 +77,8 @@
         <div class="crossword__complete-stats"></div>
         <div class="crossword__complete-teachings"></div>
         <div class="crossword__complete-actions">
-            <button class="crossword__btn crossword__btn--primary" data-action="next">Next Puzzle</button>
-            <button class="crossword__btn" data-action="share">Share</button>
+            <button class="game-btn game-btn--primary" data-action="next">Next Puzzle</button>
+            <button class="game-btn" data-action="share">Share</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

- **Shared components (#554):** Replace duplicate `.shkoda__btn`/`.crossword__btn` and `.shkoda__stat`/`.crossword__stat` with shared `.game-btn` and `.game-stat` components using `--game-accent` token
- **Layout shift fix (#562):** Make crossword clue panels scrollable (`max-height + overflow-y`) so `scrollIntoView` stays within the panel. Add `min-height` to active clue bar to prevent reflow

Net -28 lines of CSS duplication removed.

Closes #554, closes #562

## Test plan
- [x] 812 tests pass (4 skipped)
- [ ] Verify Shkoda reveal screen buttons render correctly
- [ ] Verify Crossword completion buttons render correctly
- [ ] Verify clicking Across/Down clues no longer shifts the layout
- [ ] Verify stat blocks show accent color in both games


🤖 Generated with [Claude Code](https://claude.com/claude-code)