### PR TITLE
a11y(#555): add aria-live announcements for game state changes

### DIFF
--- a/public/js/crossword.js
+++ b/public/js/crossword.js
@@ -73,6 +73,7 @@
   var api = g.api;
   var apiGet = g.apiGet;
   var escapeHtml = g.escapeHtml;
+  var announce = g.announce;
 
   function themeKey(slug) {
     return 'crossword-theme-' + slug;
@@ -697,6 +698,9 @@
       clueEl.classList.add('crossword__clue--complete');
     }
 
+    // Announce
+    announce('Correct! Word ' + (state.completedWords.size) + ' of ' + state.placements.length + ' completed.');
+
     // Move to next incomplete word
     selectNextWord();
   }
@@ -722,6 +726,7 @@
         }, 600, el);
       }
     });
+    announce('Not quite. Some letters are wrong. Try again.');
   }
 
   function markWordBankFound(bankIndex) {
@@ -795,6 +800,7 @@
   function endGame(data) {
     state.gameOver = true;
     data = data || {};
+    announce('Puzzle complete! All ' + state.placements.length + ' words solved.');
 
     var stats = loadStats();
     stats.games_played++;

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -76,6 +76,15 @@ var MinooGames = (function () {
       });
     }
 
+    /** Announce text to screen readers via the game's aria-live region. */
+    var announcerEl = document.getElementById(cssPrefix + '-announcer');
+    function announce(text) {
+      if (!announcerEl) return;
+      // Clear then set — forces re-announcement even if same text
+      announcerEl.textContent = '';
+      setTimeout(function () { announcerEl.textContent = text; }, 50);
+    }
+
     function renderStatsHtml(stats) {
       return '<div class="game-stat"><div class="game-stat__value">' + stats.games_played + '</div><div class="game-stat__label">Played</div></div>' +
         '<div class="game-stat"><div class="game-stat__value">' + stats.wins + '</div><div class="game-stat__label">Won</div></div>' +
@@ -90,7 +99,8 @@ var MinooGames = (function () {
       api: api,
       apiGet: apiGet,
       renderStatsHtml: renderStatsHtml,
-      escapeHtml: escapeHtml
+      escapeHtml: escapeHtml,
+      announce: announce
     };
   }
 

--- a/public/js/shkoda.js
+++ b/public/js/shkoda.js
@@ -64,6 +64,7 @@
   var saveStats = g.saveStats;
   var api = g.api;
   var apiGet = g.apiGet;
+  var announce = g.announce;
 
   // ── Rendering ──
   function showLoading(show) {
@@ -198,8 +199,12 @@
 
       if (data.correct) {
         revealLetterPositions(letter, data.positions);
+        var remaining = state.maxWrong - state.wrongGuesses.length;
+        announce('Correct! ' + letter.toUpperCase() + ' is in the word. ' + remaining + ' guesses remaining.');
       } else {
         state.wrongGuesses.push(letter);
+        var remaining2 = state.maxWrong - state.wrongGuesses.length;
+        announce('Wrong. ' + letter.toUpperCase() + ' is not in the word. ' + remaining2 + ' guesses remaining.');
       }
 
       updateFire(!data.correct);
@@ -231,8 +236,12 @@
     var isWrong = positions.length === 0;
     if (!isWrong) {
       revealLetterPositions(letter, positions);
+      var rem = state.maxWrong - state.wrongGuesses.length;
+      announce('Correct! ' + letter.toUpperCase() + ' is in the word. ' + rem + ' guesses remaining.');
     } else {
       state.wrongGuesses.push(letter);
+      var rem2 = state.maxWrong - state.wrongGuesses.length;
+      announce('Wrong. ' + letter.toUpperCase() + ' is not in the word. ' + rem2 + ' guesses remaining.');
     }
 
     updateFire(isWrong);
@@ -271,6 +280,10 @@
   function endGame(won, data) {
     state.gameOver = true;
     data = data || {};
+    var word = data.word || (state.word ? state.word : '');
+    announce(won
+      ? 'You won! The word was ' + word + '.'
+      : 'Game over. The word was ' + word + '.');
 
     // Update stats
     var stats = loadStats();

--- a/templates/crossword.html.twig
+++ b/templates/crossword.html.twig
@@ -86,6 +86,9 @@
     <div class="crossword__loading">
         <p>Loading puzzle...</p>
     </div>
+
+    {# Screen reader announcements #}
+    <div class="visually-hidden" aria-live="polite" id="crossword-announcer"></div>
 </div>
 
 <script src="/js/games-common.js" defer></script>

--- a/templates/shkoda.html.twig
+++ b/templates/shkoda.html.twig
@@ -81,6 +81,9 @@
 
     {# Loading state #}
     <div class="shkoda__loading" id="shkoda-loading">Loading...</div>
+
+    {# Screen reader announcements #}
+    <div class="visually-hidden" aria-live="polite" id="shkoda-announcer"></div>
 </div>
 
 <script src="/js/games-common.js" defer></script>


### PR DESCRIPTION
## Summary

- Add `aria-live="polite"` region to both Shkoda and Crossword templates
- Add shared `announce()` helper to `games-common.js` factory
- **Shkoda:** announces correct/wrong guess with remaining count, win/loss with revealed word
- **Crossword:** announces word correct with progress count, word wrong with retry prompt, puzzle complete

Screen readers now provide feedback at every key game moment.

Closes #555

## Test plan
- [x] 812 tests pass (4 skipped)
- [ ] Test with VoiceOver/NVDA: correct guess announces letter + remaining
- [ ] Test with VoiceOver/NVDA: wrong guess announces letter + remaining
- [ ] Test with VoiceOver/NVDA: win/loss announces word
- [ ] Test crossword word check announces progress


🤖 Generated with [Claude Code](https://claude.com/claude-code)