### PR TITLE
feat: promote Word Match to featured game card

### DIFF
--- a/templates/games.html.twig
+++ b/templates/games.html.twig
@@ -55,17 +55,32 @@
                 <span class="game-card__cta">Play now</span>
             </div>
         </a>
+        <a href="/games/matcher" class="game-card game-card--featured">
+            <div class="game-card__icon">
+                <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
+                    <circle cx="16" cy="20" r="6" fill="currentColor" opacity="0.8"/>
+                    <circle cx="16" cy="40" r="6" fill="currentColor" opacity="0.8"/>
+                    <circle cx="16" cy="60" r="6" fill="currentColor" opacity="0.8"/>
+                    <circle cx="64" cy="20" r="6" fill="currentColor" opacity="0.8"/>
+                    <circle cx="64" cy="40" r="6" fill="currentColor" opacity="0.8"/>
+                    <circle cx="64" cy="60" r="6" fill="currentColor" opacity="0.8"/>
+                    <line x1="22" y1="20" x2="58" y2="40" stroke="currentColor" stroke-width="2" opacity="0.5"/>
+                    <line x1="22" y1="40" x2="58" y2="60" stroke="currentColor" stroke-width="2" opacity="0.5"/>
+                    <line x1="22" y1="60" x2="58" y2="20" stroke="currentColor" stroke-width="2" opacity="0.5"/>
+                </svg>
+            </div>
+            <div class="game-card__content">
+                <span class="game-card__badge">Word Game</span>
+                <h3 class="game-card__title">Word Match</h3>
+                <p class="game-card__description">Draw lines between Ojibwe words and English definitions. Daily challenges and practice mode.</p>
+                <span class="game-card__cta">Play now</span>
+            </div>
+        </a>
     </section>
 
     <section class="games-hub__coming">
         <h2 class="games-hub__section-title">More games coming</h2>
         <div class="games-hub__coming-grid">
-            <div class="game-card game-card--placeholder">
-                <div class="game-card__placeholder-icon">
-                    <svg viewBox="0 0 24 24" width="32" height="32" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12h8M12 8v8"/></svg>
-                </div>
-                <span class="game-card__placeholder-label">Word Match</span>
-            </div>
             <div class="game-card game-card--placeholder">
                 <div class="game-card__placeholder-icon">
                     <svg viewBox="0 0 24 24" width="32" height="32" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12h8M12 8v8"/></svg>


### PR DESCRIPTION
## Summary
- Add Word Match (Matcher) as a third featured game card in the games hub, with connected-dots SVG icon linking to `/games/matcher`
- Remove the Word Match placeholder from the coming-soon grid
- Remaining placeholders (Listening Quiz, Sentence Builder) unchanged

## Test plan
- [ ] Verify `/games` page renders three featured cards (Shkoda, Crossword, Word Match)
- [ ] Verify Word Match card links to `/games/matcher`
- [ ] Verify only two placeholders remain in "More games coming" section
- [ ] Verify SVG icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)