### PR TITLE
feat: add MatcherEngine with word selection and validation

### DIFF
--- a/src/Support/MatcherEngine.php
+++ b/src/Support/MatcherEngine.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+final class MatcherEngine
+{
+    private const POS_ABBREVIATIONS = [
+        'na', 'nad', 'ni', 'nid', 'vai', 'vii', 'vta', 'vti',
+        'pc', 'adv', 'pron', 'conj', 'interj', 'num',
+    ];
+
+    public static function pairCount(string $difficulty): int
+    {
+        return match ($difficulty) {
+            'easy' => 4,
+            'medium' => 6,
+            'hard' => 8,
+            default => 4,
+        };
+    }
+
+    /**
+     * Validate whether two IDs form a correct match.
+     *
+     * Both left and right refer to the same pair's `id` field when correct.
+     * The frontend sends the dictionary entry ID from each side.
+     *
+     * @param string $leftId  The ID selected on the Ojibwe side
+     * @param string $rightId The ID selected on the English side
+     * @param list<array{id: string, ojibwe: string, english: string}> $pairs
+     * @return array{correct: bool}
+     */
+    public static function validateMatch(string $leftId, string $rightId, array $pairs): array
+    {
+        return ['correct' => $leftId === $rightId];
+    }
+
+    public static function dailySeed(string $date): int
+    {
+        return crc32("matcher-{$date}");
+    }
+
+    /**
+     * Extract a clean definition string from a field that may be JSON-encoded.
+     *
+     * Replicates GameControllerTrait::cleanDefinition() as a static method
+     * so the engine can be used without a controller instance.
+     */
+    public static function cleanDefinition(string $raw): string
+    {
+        if ($raw === '') {
+            return '';
+        }
+
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            $raw = implode('; ', array_filter(array_map('trim', $decoded)));
+        }
+
+        $raw = str_replace(
+            ['h/self', 's/he', 'h/', 's.t.', 's.o.'],
+            ['himself/herself', 'she/he', 'him/her', 'something', 'someone'],
+            $raw,
+        );
+
+        return $raw;
+    }
+
+    /**
+     * Check if a definition string is only a linguistic part-of-speech abbreviation.
+     */
+    public static function isAbbreviationOnly(string $definition): bool
+    {
+        return in_array(strtolower(trim($definition)), self::POS_ABBREVIATIONS, true);
+    }
+
+    /**
+     * Select pairs from a list of raw dictionary entry data.
+     *
+     * @param list<array{id: int, word: string, definition: string}> $entries Raw entry data
+     * @param int $count Number of pairs to select
+     * @param int|null $seed Deterministic seed for daily mode (null = random)
+     * @return list<array{id: int, ojibwe: string, english: string}>
+     */
+    public static function selectPairs(array $entries, int $count, ?int $seed = null): array
+    {
+        // Filter: must have word, must have definition, definition must not be abbreviation-only
+        $valid = [];
+        $seenDefinitions = [];
+        foreach ($entries as $entry) {
+            if ($entry['word'] === '') {
+                continue;
+            }
+            if ($entry['definition'] === '') {
+                continue;
+            }
+
+            $cleaned = self::cleanDefinition($entry['definition']);
+            if ($cleaned === '' || self::isAbbreviationOnly($cleaned)) {
+                continue;
+            }
+
+            // Avoid duplicate definitions
+            $defKey = strtolower($cleaned);
+            if (isset($seenDefinitions[$defKey])) {
+                continue;
+            }
+            $seenDefinitions[$defKey] = true;
+
+            $valid[] = [
+                'id' => $entry['id'],
+                'ojibwe' => $entry['word'],
+                'english' => $cleaned,
+            ];
+        }
+
+        // Seed-based or random shuffle
+        if ($seed !== null) {
+            mt_srand($seed);
+            usort($valid, fn() => mt_rand(-1, 1));
+            mt_srand();
+        } else {
+            shuffle($valid);
+        }
+
+        return array_slice($valid, 0, $count);
+    }
+}

--- a/tests/Minoo/Unit/Support/MatcherEngineTest.php
+++ b/tests/Minoo/Unit/Support/MatcherEngineTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Support;
+
+use Minoo\Support\MatcherEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MatcherEngine::class)]
+final class MatcherEngineTest extends TestCase
+{
+    #[Test]
+    public function pair_count_for_easy(): void
+    {
+        $this->assertSame(4, MatcherEngine::pairCount('easy'));
+    }
+
+    #[Test]
+    public function pair_count_for_medium(): void
+    {
+        $this->assertSame(6, MatcherEngine::pairCount('medium'));
+    }
+
+    #[Test]
+    public function pair_count_for_hard(): void
+    {
+        $this->assertSame(8, MatcherEngine::pairCount('hard'));
+    }
+
+    #[Test]
+    public function pair_count_defaults_to_easy(): void
+    {
+        $this->assertSame(4, MatcherEngine::pairCount('invalid'));
+    }
+
+    #[Test]
+    public function validate_match_correct(): void
+    {
+        $pairs = [
+            ['id' => 'deid_1', 'ojibwe' => 'makwa', 'english' => 'bear'],
+            ['id' => 'deid_2', 'ojibwe' => 'nibi', 'english' => 'water'],
+        ];
+
+        $result = MatcherEngine::validateMatch('deid_1', 'deid_1', $pairs);
+        $this->assertTrue($result['correct']);
+    }
+
+    #[Test]
+    public function validate_match_incorrect(): void
+    {
+        $pairs = [
+            ['id' => 'deid_1', 'ojibwe' => 'makwa', 'english' => 'bear'],
+            ['id' => 'deid_2', 'ojibwe' => 'nibi', 'english' => 'water'],
+        ];
+
+        $result = MatcherEngine::validateMatch('deid_1', 'deid_2', $pairs);
+        $this->assertFalse($result['correct']);
+    }
+
+    #[Test]
+    public function daily_seed_is_deterministic(): void
+    {
+        $seed1 = MatcherEngine::dailySeed('2026-03-25');
+        $seed2 = MatcherEngine::dailySeed('2026-03-25');
+        $this->assertSame($seed1, $seed2);
+    }
+
+    #[Test]
+    public function daily_seed_differs_across_dates(): void
+    {
+        $seed1 = MatcherEngine::dailySeed('2026-03-25');
+        $seed2 = MatcherEngine::dailySeed('2026-03-26');
+        $this->assertNotSame($seed1, $seed2);
+    }
+
+    #[Test]
+    public function clean_definition_unwraps_json_array(): void
+    {
+        $this->assertSame('bear', MatcherEngine::cleanDefinition('["bear"]'));
+    }
+
+    #[Test]
+    public function clean_definition_joins_multiple_values(): void
+    {
+        $this->assertSame('bear; grizzly', MatcherEngine::cleanDefinition('["bear", "grizzly"]'));
+    }
+
+    #[Test]
+    public function clean_definition_expands_abbreviations(): void
+    {
+        $this->assertSame('she/he walks', MatcherEngine::cleanDefinition('s/he walks'));
+    }
+
+    #[Test]
+    public function clean_definition_handles_plain_string(): void
+    {
+        $this->assertSame('bear', MatcherEngine::cleanDefinition('bear'));
+    }
+
+    #[Test]
+    public function clean_definition_handles_empty_string(): void
+    {
+        $this->assertSame('', MatcherEngine::cleanDefinition(''));
+    }
+
+    #[Test]
+    public function is_abbreviation_only_detects_pos_tags(): void
+    {
+        $this->assertTrue(MatcherEngine::isAbbreviationOnly('na'));
+        $this->assertTrue(MatcherEngine::isAbbreviationOnly('vti'));
+        $this->assertTrue(MatcherEngine::isAbbreviationOnly('ni'));
+        $this->assertFalse(MatcherEngine::isAbbreviationOnly('bear'));
+        $this->assertFalse(MatcherEngine::isAbbreviationOnly('a big bear'));
+    }
+
+    #[Test]
+    public function select_pairs_filters_and_shuffles(): void
+    {
+        // Build mock entries: array of [id, word, definition]
+        $entries = [
+            ['id' => 1, 'word' => 'makwa', 'definition' => '["bear"]'],
+            ['id' => 2, 'word' => 'nibi', 'definition' => '["water"]'],
+            ['id' => 3, 'word' => 'giizis', 'definition' => '["sun"]'],
+            ['id' => 4, 'word' => 'waabshki', 'definition' => '["white"]'],
+            ['id' => 5, 'word' => 'goon', 'definition' => '["snow"]'],
+            ['id' => 6, 'word' => '', 'definition' => '["empty word"]'],     // no word — filtered
+            ['id' => 7, 'word' => 'test', 'definition' => ''],               // no def — filtered
+            ['id' => 8, 'word' => 'test2', 'definition' => 'na'],            // abbreviation only — filtered
+        ];
+
+        $pairs = MatcherEngine::selectPairs($entries, 4);
+        $this->assertCount(4, $pairs);
+
+        // Each pair has required keys
+        foreach ($pairs as $pair) {
+            $this->assertArrayHasKey('id', $pair);
+            $this->assertArrayHasKey('ojibwe', $pair);
+            $this->assertArrayHasKey('english', $pair);
+            $this->assertNotEmpty($pair['ojibwe']);
+            $this->assertNotEmpty($pair['english']);
+        }
+    }
+
+    #[Test]
+    public function select_pairs_with_seed_is_deterministic(): void
+    {
+        $entries = [
+            ['id' => 1, 'word' => 'makwa', 'definition' => '["bear"]'],
+            ['id' => 2, 'word' => 'nibi', 'definition' => '["water"]'],
+            ['id' => 3, 'word' => 'giizis', 'definition' => '["sun"]'],
+            ['id' => 4, 'word' => 'waabshki', 'definition' => '["white"]'],
+            ['id' => 5, 'word' => 'goon', 'definition' => '["snow"]'],
+        ];
+
+        $seed = MatcherEngine::dailySeed('2026-03-25');
+        $pairs1 = MatcherEngine::selectPairs($entries, 4, $seed);
+        $pairs2 = MatcherEngine::selectPairs($entries, 4, $seed);
+        $this->assertSame($pairs1, $pairs2);
+    }
+
+    #[Test]
+    public function select_pairs_avoids_duplicate_definitions(): void
+    {
+        $entries = [
+            ['id' => 1, 'word' => 'makwa', 'definition' => '["bear"]'],
+            ['id' => 2, 'word' => 'mkwa', 'definition' => '["bear"]'],  // duplicate def
+            ['id' => 3, 'word' => 'nibi', 'definition' => '["water"]'],
+            ['id' => 4, 'word' => 'giizis', 'definition' => '["sun"]'],
+            ['id' => 5, 'word' => 'goon', 'definition' => '["snow"]'],
+        ];
+
+        $pairs = MatcherEngine::selectPairs($entries, 4);
+        $definitions = array_map(fn($p) => $p['english'], $pairs);
+        $this->assertSame(count($definitions), count(array_unique($definitions)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MatcherEngine` static utility class for the matcher word game
- Pair counting by difficulty (easy=4, medium=6, hard=8), match validation, deterministic daily seeding via CRC32
- Definition cleaning: JSON unwrap, OPD abbreviation expansion, POS-only filtering, duplicate-definition dedup
- `selectPairs()` filters invalid entries and supports seeded deterministic shuffle for daily mode

## Test plan
- [x] 17 unit tests, 41 assertions — all pass
- [x] Full suite (830 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)