### PR TITLE
polish: matcher visual design — tokens, board frame, animations

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -111,6 +111,17 @@
     --shkoda-key-bg: oklch(0.25 0.01 250);
     --shkoda-key-hover: oklch(0.30 0.01 250);
 
+    /* ── Matcher game tokens ── */
+    --matcher-accent: oklch(0.72 0.14 55);
+    --matcher-accent-glow: oklch(0.72 0.14 55 / 0.3);
+    --matcher-correct: var(--color-language);
+    --matcher-correct-glow: oklch(0.65 0.15 170 / 0.25);
+    --matcher-wrong: var(--color-events);
+    --matcher-tile-bg: oklch(0.16 0.01 260);
+    --matcher-tile-border: oklch(0.28 0.02 260);
+    --matcher-tile-hover: oklch(0.20 0.02 260);
+    --matcher-line-glow: oklch(0.65 0.15 170 / 0.4);
+
     /* ── Crossword game tokens ── */
     --crossword-cell-size: 2.5rem;
     --crossword-cell-size-mobile: 2rem;
@@ -3229,6 +3240,7 @@
   /* Game accent — set by each game's container */
   .shkoda     { --game-accent: var(--shkoda-correct); }
   .crossword  { --game-accent: var(--crossword-correct); }
+  .matcher    { --game-accent: var(--matcher-accent); }
 
   /* Shared stat block (used in reveal/completion screens) */
   .game-stat {
@@ -4657,45 +4669,69 @@
   /* ── Matcher ── */
 
   .matcher {
-      --matcher-accent: oklch(0.75 0.15 280);
       max-width: 48rem;
       margin: 0 auto;
-      padding: var(--space-m);
-  }
-
-  .matcher__controls {
-      margin-block-end: var(--space-m);
+      padding: var(--space-md);
   }
 
   .matcher__controls {
       display: flex;
       flex-wrap: wrap;
-      gap: var(--space-s);
-      margin-block-end: var(--space-m);
+      gap: var(--space-xs);
+      margin-block-end: var(--space-md);
+  }
+
+  .matcher__controls[hidden] {
+      display: none;
   }
 
   .matcher__difficulty,
   .matcher__direction {
       display: flex;
-      gap: var(--space-xs);
+      gap: var(--space-3xs);
   }
+
+  /* ── Board area ── */
 
   .matcher__board {
       position: relative;
       display: flex;
-      gap: var(--space-l);
       justify-content: center;
-      align-items: flex-start;
+      gap: var(--space-xl);
       min-height: 20rem;
-      margin-block-end: var(--space-m);
+      margin-block-end: var(--space-md);
+      padding: var(--space-md) var(--space-lg);
+      background: oklch(0.10 0.005 260);
+      border: 1px solid var(--matcher-tile-border);
+      border-radius: var(--radius-lg);
   }
 
   .matcher__column {
       display: flex;
       flex-direction: column;
-      gap: var(--space-s);
-      flex: 0 1 14rem;
+      gap: var(--space-xs);
+      flex: 0 1 15rem;
       z-index: 1;
+  }
+
+  .matcher__column-header {
+      font-size: var(--text-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      text-align: center;
+      padding-block-end: var(--space-xs);
+      border-block-end: 1px solid var(--matcher-tile-border);
+      margin-block-end: var(--space-3xs);
+  }
+
+  .matcher__column--left .matcher__column-header {
+      color: var(--matcher-accent);
+  }
+
+  .matcher__column--right .matcher__column-header {
+      color: var(--matcher-correct);
   }
 
   .matcher__svg {
@@ -4704,68 +4740,154 @@
       width: 100%;
       height: 100%;
       pointer-events: none;
-      z-index: 0;
+      z-index: 2;
   }
 
+  /* ── Word tiles ── */
+
   .matcher-word {
-      padding: var(--space-xs) var(--space-s);
-      background: var(--surface-2);
-      border: 2px solid var(--border);
-      border-radius: var(--radius-m);
-      color: var(--text-1);
-      font-size: var(--step-0);
+      padding: var(--space-xs) var(--space-sm);
+      background: var(--matcher-tile-bg);
+      border: 1.5px solid var(--matcher-tile-border);
+      border-radius: var(--radius-md);
+      color: var(--text-primary);
+      font-size: var(--text-sm);
       text-align: center;
       cursor: grab;
-      transition: border-color 0.15s, opacity 0.3s, transform 0.15s;
       user-select: none;
+      position: relative;
+      transition:
+          border-color 0.2s ease,
+          background-color 0.2s ease,
+          box-shadow 0.2s ease,
+          transform 0.15s ease;
+      animation: matcher-tile-enter 0.35s ease both;
   }
 
   .matcher-word:hover:not(:disabled) {
       border-color: var(--matcher-accent);
+      background: var(--matcher-tile-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px oklch(0 0 0 / 0.3);
   }
 
   .matcher-word--active {
       border-color: var(--matcher-accent);
-      box-shadow: 0 0 0 3px oklch(0.75 0.15 280 / 0.3);
+      background: var(--matcher-tile-hover);
+      box-shadow:
+          0 0 0 2px var(--matcher-accent-glow),
+          0 0 12px var(--matcher-accent-glow);
+      transform: translateY(-1px);
   }
 
   .matcher-word--matched {
-      border-color: var(--color-correct);
-      opacity: 0.6;
+      border-color: var(--matcher-correct);
+      background: oklch(0.65 0.15 170 / 0.08);
+      box-shadow: 0 0 8px var(--matcher-correct-glow);
       cursor: default;
+      animation: matcher-match-pop 0.4s ease;
+  }
+
+  .matcher-word--matched::after {
+      content: "";
+      position: absolute;
+      inset: -2px;
+      border-radius: inherit;
+      border: 1.5px solid var(--matcher-correct);
+      opacity: 0;
+      animation: matcher-ring-fade 0.6s ease forwards;
   }
 
   .matcher-word--wrong {
-      border-color: var(--color-wrong);
-      animation: matcher-shake 0.4s ease-in-out;
+      border-color: var(--matcher-wrong);
+      background: oklch(0.55 0.15 25 / 0.08);
+      animation: matcher-shake 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  }
+
+  /* Stagger entrance per tile */
+  .matcher__column--left .matcher-word:nth-child(2) { animation-delay: 0.04s; }
+  .matcher__column--left .matcher-word:nth-child(3) { animation-delay: 0.08s; }
+  .matcher__column--left .matcher-word:nth-child(4) { animation-delay: 0.12s; }
+  .matcher__column--left .matcher-word:nth-child(5) { animation-delay: 0.16s; }
+  .matcher__column--left .matcher-word:nth-child(6) { animation-delay: 0.20s; }
+  .matcher__column--left .matcher-word:nth-child(7) { animation-delay: 0.24s; }
+  .matcher__column--left .matcher-word:nth-child(8) { animation-delay: 0.28s; }
+  .matcher__column--left .matcher-word:nth-child(9) { animation-delay: 0.32s; }
+
+  .matcher__column--right .matcher-word:nth-child(2) { animation-delay: 0.06s; }
+  .matcher__column--right .matcher-word:nth-child(3) { animation-delay: 0.10s; }
+  .matcher__column--right .matcher-word:nth-child(4) { animation-delay: 0.14s; }
+  .matcher__column--right .matcher-word:nth-child(5) { animation-delay: 0.18s; }
+  .matcher__column--right .matcher-word:nth-child(6) { animation-delay: 0.22s; }
+  .matcher__column--right .matcher-word:nth-child(7) { animation-delay: 0.26s; }
+  .matcher__column--right .matcher-word:nth-child(8) { animation-delay: 0.30s; }
+  .matcher__column--right .matcher-word:nth-child(9) { animation-delay: 0.34s; }
+
+  @keyframes matcher-tile-enter {
+      from {
+          opacity: 0;
+          transform: translateY(8px) scale(0.96);
+      }
+      to {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+      }
+  }
+
+  @keyframes matcher-match-pop {
+      0%   { transform: scale(1); }
+      40%  { transform: scale(1.06); }
+      100% { transform: scale(1); }
+  }
+
+  @keyframes matcher-ring-fade {
+      0%   { opacity: 0.6; transform: scale(1.05); }
+      100% { opacity: 0; transform: scale(1.15); }
   }
 
   @keyframes matcher-shake {
       0%, 100% { transform: translateX(0); }
-      20% { transform: translateX(-6px); }
-      40% { transform: translateX(6px); }
-      60% { transform: translateX(-4px); }
-      80% { transform: translateX(4px); }
+      15% { transform: translateX(-6px); }
+      30% { transform: translateX(6px); }
+      45% { transform: translateX(-5px); }
+      60% { transform: translateX(5px); }
+      75% { transform: translateX(-2px); }
+      90% { transform: translateX(2px); }
   }
+
+  /* ── SVG connecting lines ── */
 
   .matcher-line--drawing {
       stroke: var(--matcher-accent);
       stroke-width: 2;
       stroke-dasharray: 6 4;
-      opacity: 0.7;
+      opacity: 0.6;
+      filter: drop-shadow(0 0 3px var(--matcher-accent-glow));
   }
 
   .matcher-line--locked {
-      stroke: var(--color-correct);
-      stroke-width: 2.5;
-      opacity: 0.5;
+      stroke: var(--matcher-correct);
+      stroke-width: 2;
+      opacity: 0.6;
+      filter: drop-shadow(0 0 4px var(--matcher-line-glow));
+      animation: matcher-line-appear 0.3s ease;
   }
+
+  @keyframes matcher-line-appear {
+      from { opacity: 0; stroke-width: 0; }
+      to   { opacity: 0.6; stroke-width: 2; }
+  }
+
+  /* ── Stats row ── */
 
   .matcher__status {
       display: flex;
       justify-content: center;
-      gap: var(--space-l);
+      gap: var(--space-lg);
+      padding-block: var(--space-sm);
   }
+
+  /* ── Completion overlay ── */
 
   .matcher__complete[hidden] {
       display: none;
@@ -4777,42 +4899,66 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: oklch(0 0 0 / 0.6);
+      background: oklch(0 0 0 / 0.7);
+      backdrop-filter: blur(4px);
       z-index: 100;
+      animation: matcher-overlay-in 0.3s ease;
+  }
+
+  @keyframes matcher-overlay-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
   }
 
   .matcher__complete-card {
-      background: var(--surface-1);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-l);
-      padding: var(--space-l);
+      background: var(--surface-card);
+      border: 1px solid var(--matcher-tile-border);
+      border-radius: var(--radius-lg);
+      padding: var(--space-lg) var(--space-xl);
       text-align: center;
-      max-width: 24rem;
+      max-width: 26rem;
       width: 90%;
+      box-shadow:
+          0 4px 24px oklch(0 0 0 / 0.4),
+          0 0 48px var(--matcher-correct-glow);
+      animation: matcher-card-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  @keyframes matcher-card-pop {
+      from { opacity: 0; transform: scale(0.9) translateY(12px); }
+      to   { opacity: 1; transform: scale(1) translateY(0); }
   }
 
   .matcher__complete-title {
-      font-size: var(--step-2);
-      margin-block-end: var(--space-m);
+      font-size: var(--text-2xl);
+      font-weight: 700;
+      margin-block-end: var(--space-sm);
+      background: linear-gradient(135deg, var(--matcher-accent), var(--matcher-correct));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
   }
 
   .matcher__complete-stats {
       display: flex;
       justify-content: center;
-      gap: var(--space-l);
-      margin-block-end: var(--space-m);
+      gap: var(--space-lg);
+      margin-block-end: var(--space-md);
+      padding-block: var(--space-sm);
+      border-block: 1px solid var(--matcher-tile-border);
   }
 
   .matcher__complete-actions {
       display: flex;
-      gap: var(--space-s);
+      gap: var(--space-sm);
       justify-content: center;
   }
 
-  /* Matcher mobile */
+  /* ── Matcher mobile ── */
   @media (max-width: 40em) {
       .matcher__board {
-          gap: var(--space-s);
+          padding: var(--space-sm);
+          gap: 0;
       }
 
       .matcher__column {
@@ -4820,8 +4966,12 @@
       }
 
       .matcher-word {
-          font-size: var(--step--1);
-          padding: var(--space-xs);
+          font-size: var(--text-xs);
+          padding: var(--space-3xs) var(--space-xs);
+      }
+
+      .matcher__complete-card {
+          padding: var(--space-md);
       }
   }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,7 +17,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=28">
+  <link rel="stylesheet" href="/css/minoo.css?v=29">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   <script defer src="https://analytics.minoo.live/script.js" data-website-id="b357d196-9464-42e1-a93b-5f85743f20c9"></script>

--- a/templates/matcher.html.twig
+++ b/templates/matcher.html.twig
@@ -33,9 +33,13 @@
 
     {# Game board #}
     <div class="matcher__board" aria-label="Matching game board">
-        <div class="matcher__column matcher__column--left" data-side="left"></div>
+        <div class="matcher__column matcher__column--left" data-side="left">
+            <div class="matcher__column-header" data-col-label="left">Ojibwe</div>
+        </div>
         <svg class="matcher__svg" aria-hidden="true"></svg>
-        <div class="matcher__column matcher__column--right" data-side="right"></div>
+        <div class="matcher__column matcher__column--right" data-side="right">
+            <div class="matcher__column-header" data-col-label="right">English</div>
+        </div>
     </div>
 
     {# Stats row #}
@@ -237,9 +241,21 @@
     // --- Rendering ---
 
     function renderBoard() {
-        leftCol.innerHTML = '';
-        rightCol.innerHTML = '';
+        // Preserve headers, clear word tiles
+        leftCol.querySelectorAll('.matcher-word').forEach(el => el.remove());
+        rightCol.querySelectorAll('.matcher-word').forEach(el => el.remove());
         svg.innerHTML = '';
+
+        // Update column headers based on direction
+        const leftLabel = root.querySelector('[data-col-label="left"]');
+        const rightLabel = root.querySelector('[data-col-label="right"]');
+        if (state.direction === 'ojibwe_to_english') {
+            leftLabel.textContent = 'Ojibwe';
+            rightLabel.textContent = 'English';
+        } else {
+            leftLabel.textContent = 'English';
+            rightLabel.textContent = 'Ojibwe';
+        }
 
         state.pairs.left.forEach(item => {
             leftCol.appendChild(createWordEl(item, 'left'));
@@ -476,8 +492,8 @@
         state.matchCount = 0;
         state.totalPairs = 0;
         state.timerStart = null;
-        leftCol.innerHTML = '';
-        rightCol.innerHTML = '';
+        leftCol.querySelectorAll('.matcher-word').forEach(el => el.remove());
+        rightCol.querySelectorAll('.matcher-word').forEach(el => el.remove());
         svg.innerHTML = '';
         updateStats();
     }


### PR DESCRIPTION
## Summary

- Add matcher-specific design tokens (copper/teal palette) alongside Shkoda and Crossword, wire `--game-accent` so stats and buttons are properly themed
- Restyle board with framed play area, Ojibwe/English column headers, tactile word tiles with hover lift, glow active state, match pop + ring-fade animations, staggered tile entrance, glowing SVG connection lines
- Polish completion overlay with backdrop blur, card pop animation, gradient title, bordered stat sections, teal glow shadow
- Fix practice controls visible in Daily mode (CSS `display: flex` was overriding `hidden` attribute)
- Bump CSS cache bust v28→v29

## Test plan

- [x] All 777 unit tests pass
- [x] All 56 integration tests pass
- [x] Daily mode hides practice controls correctly
- [x] Practice mode shows difficulty/direction controls
- [x] Word selection shows amber glow active state
- [x] Correct match shows teal glow + SVG line + pop animation
- [x] Completion overlay renders with gradient title, stats, Play Again/Share buttons
- [ ] Verify on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)