### PR TITLE
fix(#571): feed mix buries user posts under system content

### DIFF
--- a/config/feed_scoring.php
+++ b/config/feed_scoring.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'decay_half_life_hours' => 96,
-    'featured_boost' => 100.0,
+    'featured_boost' => 15.0,
     'affinity_cache_ttl' => 900,
     'interaction_weights' => [
         'reaction' => 1.0,
@@ -25,8 +25,9 @@ return [
     ],
     'base_affinity' => 1.0,
     'diversity' => [
-        'max_consecutive_type' => 3,
-        'max_consecutive_community' => 5,
+        'max_consecutive_type' => 2,
+        'max_consecutive_community' => 2,
+        'post_guarantee_slot' => 3,
     ],
     'lookback_days' => 30,
 ];

--- a/src/Feed/Scoring/DiversityReranker.php
+++ b/src/Feed/Scoring/DiversityReranker.php
@@ -11,8 +11,9 @@ final class DiversityReranker
     private const SCAN_LIMIT = 10;
 
     public function __construct(
-        private readonly int $maxConsecutiveType = 3,
-        private readonly int $maxConsecutiveCommunity = 5,
+        private readonly int $maxConsecutiveType = 2,
+        private readonly int $maxConsecutiveCommunity = 2,
+        private readonly int $postGuaranteeSlot = 3,
     ) {}
 
     /**
@@ -76,6 +77,78 @@ final class DiversityReranker
                 }
             }
         }
+
+        return $this->guaranteePost($items);
+    }
+
+    /**
+     * Ensure at least one post appears in the first N non-synthetic slots.
+     *
+     * @param FeedItem[] $items
+     * @return FeedItem[]
+     */
+    private function guaranteePost(array $items): array
+    {
+        if ($this->postGuaranteeSlot <= 0) {
+            return $items;
+        }
+
+        $nonSyntheticSeen = 0;
+        $hasPost = false;
+
+        foreach ($items as $item) {
+            if ($item->isSynthetic()) {
+                continue;
+            }
+            $nonSyntheticSeen++;
+            if ($item->type === 'post') {
+                $hasPost = true;
+                break;
+            }
+            if ($nonSyntheticSeen >= $this->postGuaranteeSlot) {
+                break;
+            }
+        }
+
+        if ($hasPost) {
+            return $items;
+        }
+
+        // Find the first post anywhere in the list
+        $postIdx = null;
+        foreach ($items as $idx => $item) {
+            if (!$item->isSynthetic() && $item->type === 'post') {
+                $postIdx = $idx;
+                break;
+            }
+        }
+
+        if ($postIdx === null) {
+            return $items; // No posts at all
+        }
+
+        // Find the target slot (the Nth non-synthetic position)
+        $targetIdx = null;
+        $nonSyntheticSeen = 0;
+        foreach ($items as $idx => $item) {
+            if ($item->isSynthetic()) {
+                continue;
+            }
+            $nonSyntheticSeen++;
+            if ($nonSyntheticSeen === $this->postGuaranteeSlot) {
+                $targetIdx = $idx;
+                break;
+            }
+        }
+
+        if ($targetIdx === null || $postIdx <= $targetIdx) {
+            return $items;
+        }
+
+        // Pull the post into the target slot
+        $post = $items[$postIdx];
+        array_splice($items, $postIdx, 1);
+        array_splice($items, $targetIdx, 0, [$post]);
 
         return $items;
     }

--- a/src/Provider/FeedScoringServiceProvider.php
+++ b/src/Provider/FeedScoringServiceProvider.php
@@ -59,8 +59,9 @@ final class FeedScoringServiceProvider extends ServiceProvider
 
         $diversity = $config['diversity'] ?? [];
         $this->singleton(DiversityReranker::class, fn(): DiversityReranker => new DiversityReranker(
-            maxConsecutiveType: (int) ($diversity['max_consecutive_type'] ?? 3),
-            maxConsecutiveCommunity: (int) ($diversity['max_consecutive_community'] ?? 5),
+            maxConsecutiveType: (int) ($diversity['max_consecutive_type'] ?? 2),
+            maxConsecutiveCommunity: (int) ($diversity['max_consecutive_community'] ?? 2),
+            postGuaranteeSlot: (int) ($diversity['post_guarantee_slot'] ?? 3),
         ));
 
         $this->singleton(FeedScorer::class, fn(): FeedScorer => new FeedScorer(

--- a/tests/Minoo/Unit/Feed/Scoring/DiversityRerankerTest.php
+++ b/tests/Minoo/Unit/Feed/Scoring/DiversityRerankerTest.php
@@ -17,7 +17,11 @@ final class DiversityRerankerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->reranker = new DiversityReranker();
+        $this->reranker = new DiversityReranker(
+            maxConsecutiveType: 2,
+            maxConsecutiveCommunity: 2,
+            postGuaranteeSlot: 3,
+        );
     }
 
     #[Test]
@@ -42,21 +46,20 @@ final class DiversityRerankerTest extends TestCase
     #[Test]
     public function swapsWhenTypeThresholdExceeded(): void
     {
-        // 4 consecutive posts (exceeds maxConsecutiveType=3), then an event
+        // 3 consecutive posts (exceeds maxConsecutiveType=2), then an event
         $items = [
             $this->makeItem('1', 'post', 'c1'),
             $this->makeItem('2', 'post', 'c2'),
             $this->makeItem('3', 'post', 'c3'),
-            $this->makeItem('4', 'post', 'c4'),
-            $this->makeItem('5', 'event', 'c5'),
+            $this->makeItem('4', 'event', 'c4'),
         ];
 
         $result = $this->reranker->rerank($items);
 
-        // Item 5 (event) should be swapped forward to break the run
+        // Item 4 (event) should be swapped forward to break the run
         $ids = array_map(fn(FeedItem $item) => $item->id, $result);
-        $this->assertSame('5', $ids[3], 'Event should be swapped into position 3 to break type run');
-        $this->assertSame('4', $ids[4], 'Displaced post should move to position 4');
+        $this->assertSame('4', $ids[2], 'Event should be swapped into position 2 to break type run');
+        $this->assertSame('3', $ids[3], 'Displaced post should move to position 3');
     }
 
     #[Test]
@@ -102,22 +105,75 @@ final class DiversityRerankerTest extends TestCase
     #[Test]
     public function communityConsecutiveThresholdTriggersSwap(): void
     {
-        // 6 items from same community (exceeds maxConsecutiveCommunity=5), different types
+        // 3 items from same community (exceeds maxConsecutiveCommunity=2), different types
         $items = [
             $this->makeItem('1', 'post', 'c1'),
             $this->makeItem('2', 'event', 'c1'),
             $this->makeItem('3', 'teaching', 'c1'),
-            $this->makeItem('4', 'post', 'c1'),
-            $this->makeItem('5', 'event', 'c1'),
-            $this->makeItem('6', 'teaching', 'c1'),
-            $this->makeItem('7', 'post', 'c2'),
+            $this->makeItem('4', 'post', 'c2'),
         ];
 
         $result = $this->reranker->rerank($items);
 
-        // Item 7 (different community) should be swapped forward
+        // Item 4 (different community) should be swapped forward
         $ids = array_map(fn(FeedItem $item) => $item->id, $result);
-        $this->assertSame('7', $ids[5], 'Item from different community should be swapped into position 5');
+        $this->assertSame('4', $ids[2], 'Item from different community should be swapped into position 2');
+    }
+
+    #[Test]
+    public function postGuaranteePromotesFirstPostIntoTopSlots(): void
+    {
+        // Top 3 non-synthetic items are all non-posts; first post is at position 4
+        $items = [
+            $this->makeItem('1', 'featured', 'c1'),
+            $this->makeItem('2', 'person', 'c2'),
+            $this->makeItem('3', 'event', 'c3'),
+            $this->makeItem('4', 'post', 'c4'),
+            $this->makeItem('5', 'event', 'c5'),
+        ];
+
+        $result = $this->reranker->rerank($items);
+
+        $ids = array_map(fn(FeedItem $item) => $item->id, $result);
+        // Post should be pulled into slot 3 (the guarantee position)
+        $this->assertSame('4', $ids[2], 'Post should be promoted into position 2 (third slot)');
+    }
+
+    #[Test]
+    public function postGuaranteeNoOpWhenPostAlreadyPresent(): void
+    {
+        // A post already in the top 3
+        $items = [
+            $this->makeItem('1', 'featured', 'c1'),
+            $this->makeItem('2', 'post', 'c2'),
+            $this->makeItem('3', 'event', 'c3'),
+            $this->makeItem('4', 'person', 'c4'),
+        ];
+
+        $result = $this->reranker->rerank($items);
+
+        $ids = array_map(fn(FeedItem $item) => $item->id, $result);
+        $this->assertSame('2', $ids[1], 'Post stays in place — already in top 3');
+    }
+
+    #[Test]
+    public function postGuaranteeSkipsSyntheticItems(): void
+    {
+        // Synthetic at top, then 3 non-posts, then a post
+        $items = [
+            $this->makeSynthetic('welcome:0', 'welcome'),
+            $this->makeItem('1', 'featured', 'c1'),
+            $this->makeItem('2', 'person', 'c2'),
+            $this->makeItem('3', 'event', 'c3'),
+            $this->makeItem('4', 'post', 'c4'),
+        ];
+
+        $result = $this->reranker->rerank($items);
+
+        $ids = array_map(fn(FeedItem $item) => $item->id, $result);
+        // Synthetic stays at 0, post pulled into slot 3 (third non-synthetic)
+        $this->assertSame('welcome:0', $ids[0]);
+        $this->assertSame('4', $ids[3], 'Post promoted to third non-synthetic slot');
     }
 
     private function makeItem(string $id, string $type, string $community): FeedItem


### PR DESCRIPTION
## Summary

Closes #571

- Reduce `featured_boost` 100→15 — featured items still rank high but don't dominate with a 100× multiplier
- Tighten `max_consecutive_type` 3→2 and `max_consecutive_community` 5→2 — forces more interleaving
- Add **post guarantee**: `DiversityReranker` ensures at least one user post appears in the first 3 non-synthetic feed slots. If no post is found, the first post from deeper in the feed is pulled up.
- Wire `post_guarantee_slot` config through `FeedScoringServiceProvider`

**Before:** Featured(1) → Person(2) → Person(3) → User post(4)
**After:** Featured(1) → Event(2) → User post(3) — guaranteed

## Test plan

- [x] 8 DiversityReranker tests pass (5 updated + 3 new post guarantee tests)
- [x] 90 total Feed tests pass
- [x] 777 unit + 56 integration tests pass
- [ ] Visual verify feed order on localhost after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)