### PR TITLE
fix(#559): add empty state to crossword themes tab

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -4584,6 +4584,26 @@
     margin-block-start: var(--space-md);
   }
 
+  .crossword__themes-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: var(--space-xl) var(--space-md);
+    color: var(--text-muted);
+  }
+
+  .crossword__themes-empty-title {
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-block-end: var(--space-xs);
+  }
+
+  .crossword__themes-empty-body {
+    font-size: var(--text-sm);
+    max-inline-size: 36ch;
+    margin-inline: auto;
+  }
+
   /* Loading state */
   .crossword__loading {
     text-align: center;

--- a/public/js/crossword.js
+++ b/public/js/crossword.js
@@ -991,6 +991,17 @@
   function renderThemes(themes) {
     themesListEl.innerHTML = '';
 
+    if (!themes || themes.length === 0) {
+      themesListEl.innerHTML =
+        '<div class="crossword__themes-empty">' +
+          '<p class="crossword__themes-empty-title">Themed Puzzle Packs Coming Soon</p>' +
+          '<p class="crossword__themes-empty-body">' +
+            'We\u2019re working on themed collections like Animals, Family, and Seasons.' +
+          '</p>' +
+        '</div>';
+      return;
+    }
+
     themes.forEach(function (theme) {
       var card = document.createElement('div');
       card.className = 'crossword__theme-card';

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,7 +17,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=40">
+  <link rel="stylesheet" href="/css/minoo.css?v=41">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   <script defer src="https://analytics.minoo.live/script.js" data-website-id="b357d196-9464-42e1-a93b-5f85743f20c9"></script>


### PR DESCRIPTION
## Summary
- Add empty state message to `renderThemes()` in crossword.js when no themed puzzle packs exist
- Add CSS styles for the empty state (title + body) following existing BEM conventions
- Bump CSS cache version from v=40 to v=41

Closes #559

## Test plan
- [ ] Navigate to /games/crossword and click the Themes tab
- [ ] Verify "Themed Puzzle Packs Coming Soon" message displays centered in the tab
- [ ] Verify no JS console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)