### PR TITLE
fix(#558): crossword practice mode graceful error for missing tiers

### DIFF
--- a/public/js/crossword.js
+++ b/public/js/crossword.js
@@ -112,6 +112,30 @@
     if (completeEl) completeEl.hidden = !show;
   }
 
+  function showNoPuzzles(tier) {
+    showGame(false);
+    showComplete(true);
+    completeTitleEl.textContent = 'No puzzles available yet';
+    completeTeachingsEl.innerHTML =
+      '<p>No ' + escapeHtml(tier) + ' puzzles have been generated yet. ' +
+      'Try an easy puzzle instead!</p>';
+    completeStatsEl.innerHTML = '';
+    completeActionsEl.innerHTML = '';
+
+    var easyBtn = document.createElement('button');
+    easyBtn.className = 'game-btn game-btn--primary';
+    easyBtn.textContent = 'Play Easy';
+    easyBtn.addEventListener('click', function () {
+      state.tier = 'easy';
+      var tiers = difficultyEl.querySelectorAll('.crossword__tier');
+      tiers.forEach(function (t) {
+        t.classList.toggle('crossword__tier--active', t.dataset.tier === 'easy');
+      });
+      startGame();
+    });
+    completeActionsEl.appendChild(easyBtn);
+  }
+
   // ── Grid building ──
   function buildGrid(size, placements) {
     // Initialize empty grid
@@ -1074,8 +1098,13 @@
     apiGet(endpoint).then(function (data) {
       if (data.error) {
         showLoading(false);
-        loadingEl.hidden = false;
-        loadingEl.querySelector('p').textContent = data.error;
+        if (data.error === 'no_puzzles') {
+          showNoPuzzles(data.tier || state.tier);
+        } else {
+          loadingEl.hidden = false;
+          var errP = loadingEl.querySelector('p');
+          if (errP) errP.textContent = data.error;
+        }
         return;
       }
 

--- a/src/Controller/CrosswordController.php
+++ b/src/Controller/CrosswordController.php
@@ -93,7 +93,7 @@ final class CrosswordController
         }
 
         if ($practiceIds === []) {
-            return $this->json(['error' => 'No puzzles available'], 503);
+            return $this->json(['error' => 'no_puzzles', 'tier' => $tier], 404);
         }
 
         $puzzleId = $practiceIds[array_rand($practiceIds)];

--- a/tests/Minoo/Unit/Controller/CrosswordControllerTest.php
+++ b/tests/Minoo/Unit/Controller/CrosswordControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Controller;
+
+use Minoo\Controller\CrosswordController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\GateInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+#[CoversClass(CrosswordController::class)]
+final class CrosswordControllerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private Environment $twig;
+    private GateInterface $gate;
+    private EntityStorageInterface $puzzleStorage;
+    private EntityQueryInterface $puzzleQuery;
+    private AccountInterface $account;
+    private HttpRequest $request;
+
+    protected function setUp(): void
+    {
+        $this->puzzleQuery = $this->createMock(EntityQueryInterface::class);
+        $this->puzzleQuery->method('condition')->willReturnSelf();
+        $this->puzzleQuery->method('sort')->willReturnSelf();
+        $this->puzzleQuery->method('range')->willReturnSelf();
+
+        $this->puzzleStorage = $this->createMock(EntityStorageInterface::class);
+        $this->puzzleStorage->method('getQuery')->willReturn($this->puzzleQuery);
+
+        $this->entityTypeManager = $this->createMock(EntityTypeManager::class);
+        $this->entityTypeManager->method('getStorage')
+            ->willReturnCallback(fn(string $type) => match ($type) {
+                'crossword_puzzle' => $this->puzzleStorage,
+                default => $this->createMock(EntityStorageInterface::class),
+            });
+
+        $this->twig = new Environment(new ArrayLoader([
+            'crossword.html.twig' => '{{ path }}',
+        ]));
+
+        $this->gate = $this->createMock(GateInterface::class);
+        $this->account = $this->createMock(AccountInterface::class);
+        $this->request = HttpRequest::create('/');
+    }
+
+    #[Test]
+    public function random_returns_404_when_no_puzzles_for_tier(): void
+    {
+        $this->puzzleQuery->method('execute')->willReturn([]);
+
+        $controller = new CrosswordController($this->entityTypeManager, $this->twig, $this->gate);
+        $response = $controller->random([], ['tier' => 'medium'], $this->account, $this->request);
+
+        $this->assertSame(404, $response->statusCode);
+        $content = json_decode($response->content, true);
+        $this->assertSame('no_puzzles', $content['error']);
+        $this->assertSame('medium', $content['tier']);
+    }
+
+    #[Test]
+    public function random_defaults_invalid_tier_to_easy(): void
+    {
+        $this->puzzleQuery->method('execute')->willReturn([]);
+
+        $controller = new CrosswordController($this->entityTypeManager, $this->twig, $this->gate);
+        $response = $controller->random([], ['tier' => 'extreme'], $this->account, $this->request);
+
+        $this->assertSame(404, $response->statusCode);
+        $content = json_decode($response->content, true);
+        $this->assertSame('easy', $content['tier']);
+    }
+}


### PR DESCRIPTION
## Summary
- Changed `/api/games/crossword/random` to return 404 with `{"error": "no_puzzles", "tier": "medium"}` instead of 503 with generic message when no puzzles exist for a tier
- Added `showNoPuzzles()` JS function that displays a friendly message and "Play Easy" fallback button
- Updated `startGame()` error handler to detect `no_puzzles` error code and route to the new UI

## Test plan
- [x] New `CrosswordControllerTest` with 2 tests: 404 on missing tier, invalid tier defaults to easy
- [x] Full suite passes (871 tests, 2476 assertions)
- [ ] Manual: visit crossword page, select medium/hard tier, verify friendly message appears with "Play Easy" button

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)