### PR TITLE
fix(#532): campfire roars on win regardless of remaining guesses

### DIFF
--- a/public/js/shkoda.js
+++ b/public/js/shkoda.js
@@ -132,6 +132,7 @@
   }
 
   function updateFire(wasWrong) {
+    if (state.gameOver) return;
     var remaining = state.maxWrong - state.wrongGuesses.length;
     if (remaining < 0) remaining = 0;
     fireEl.dataset.fireState = remaining;
@@ -259,8 +260,14 @@
     }
 
     if (allRevealed) {
+      state.gameOver = true;
+      fireEl.dataset.fireState = 'win';
+      spawnSparks();
       completeGame('won');
     } else if (state.wrongGuesses.length >= state.maxWrong) {
+      state.gameOver = true;
+      fireEl.dataset.fireState = '0';
+      spawnSmoke();
       completeGame('lost');
     }
   }
@@ -319,10 +326,11 @@
     showReveal(won, data, stats);
 
     // Trigger animation — override fire state for win/loss
-    if (won) {
+    // (practice mode may have set this already before async complete call)
+    if (won && fireEl.dataset.fireState !== 'win') {
       fireEl.dataset.fireState = 'win';
       spawnSparks();
-    } else {
+    } else if (!won && fireEl.dataset.fireState !== '0') {
       fireEl.dataset.fireState = '0';
       spawnSmoke();
     }


### PR DESCRIPTION
## Summary
- Guard `updateFire()` with `state.gameOver` check so `endGame()` has final say on fire state
- In practice mode, set fire state immediately on win/loss detection before async `completeGame()` call to prevent flash of dying fire
- Prevent double fire-state/animation set in `endGame()` when practice mode already applied it

Closes #532

## Test plan
- [ ] Play Shkoda practice mode, win with 1 guess remaining — campfire should show full roar + sparks
- [ ] Play Shkoda daily mode, win — campfire should show full roar
- [ ] Lose a game — fire should die + smoke animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)