### PR TITLE
feat(#560): expand practice puzzle pool to 9 (3 per tier)

### DIFF
--- a/scripts/populate_crossword_puzzles.php
+++ b/scripts/populate_crossword_puzzles.php
@@ -165,9 +165,14 @@ if ($result !== null) {
 // --- 2. Practice puzzles ---
 
 echo "\n--- Practice Puzzles ---\n";
-$practiceTiers = ['easy', 'easy', 'medium', 'medium', 'hard'];
+$practiceTiers = [
+    'easy', 'easy', 'easy',
+    'medium', 'medium', 'medium',
+    'hard', 'hard', 'hard',
+];
 
-for ($i = 1; $i <= 5; $i++) {
+$practiceTierCount = count($practiceTiers);
+for ($i = 1; $i <= $practiceTierCount; $i++) {
     $practiceId = sprintf('practice-%03d', $i);
     $tier = $practiceTiers[$i - 1];
 


### PR DESCRIPTION
## Summary
- Expand practice puzzles from 5 (2 easy, 2 medium, 1 hard) to 9 (3 per tier)
- Cache `count()` outside loop for efficiency
- Script remains idempotent — skips existing puzzles

Closes #560

## Test plan
- [ ] Run `php scripts/populate_crossword_puzzles.php` locally — should create practice-001 through practice-009
- [ ] Existing puzzles should be skipped with "Skipping" message
- [ ] Run on production after deploy to populate medium/hard tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)