### PR TITLE
feat(#575): add MercurePublisher service and messaging config

### DIFF
--- a/config/messaging.php
+++ b/config/messaging.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'max_message_length' => 2000,
+    'typing_indicator_ttl' => 5,
+    'digest_interval' => '4h',
+    'digest_debounce' => 15,
+    'digest_active_skip' => 30,
+    'mercure_hub_url' => env('MERCURE_HUB_URL', 'http://localhost:3000/.well-known/mercure'),
+    'mercure_publisher_jwt' => env('MERCURE_PUBLISHER_JWT', ''),
+    'mercure_subscriber_jwt_secret' => env('MERCURE_SUBSCRIBER_JWT_SECRET', ''),
+    'polling_fallback_interval' => 10,
+];

--- a/src/Support/MercurePublisher.php
+++ b/src/Support/MercurePublisher.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support;
+
+final class MercurePublisher
+{
+    public function __construct(
+        private readonly string $hubUrl,
+        private readonly string $publisherJwt,
+    ) {}
+
+    public function publish(string $topic, array $data): bool
+    {
+        if (!$this->isConfigured()) {
+            return false;
+        }
+
+        $ch = curl_init($this->hubUrl);
+        if ($ch === false) {
+            return false;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $this->buildPostBody($topic, $data),
+            CURLOPT_HTTPHEADER => [
+                'Authorization: Bearer ' . $this->publisherJwt,
+                'Content-Type: application/x-www-form-urlencoded',
+            ],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 5,
+        ]);
+
+        $result = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return $result !== false && $httpCode >= 200 && $httpCode < 300;
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->hubUrl !== '' && $this->publisherJwt !== '';
+    }
+
+    public function buildPostBody(string $topic, array $data): string
+    {
+        return http_build_query([
+            'topic' => $topic,
+            'data' => json_encode($data, JSON_THROW_ON_ERROR),
+        ]);
+    }
+}

--- a/tests/Minoo/Unit/Support/MercurePublisherTest.php
+++ b/tests/Minoo/Unit/Support/MercurePublisherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Support;
+
+use Minoo\Support\MercurePublisher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MercurePublisher::class)]
+final class MercurePublisherTest extends TestCase
+{
+    #[Test]
+    public function build_post_body_produces_correct_url_encoded_string(): void
+    {
+        $publisher = new MercurePublisher('http://hub.example.com/.well-known/mercure', 'test-jwt');
+
+        $body = $publisher->buildPostBody('/threads/42', ['type' => 'new_message', 'threadId' => 42]);
+
+        $parsed = [];
+        parse_str($body, $parsed);
+
+        $this->assertSame('/threads/42', $parsed['topic']);
+        $this->assertSame('{"type":"new_message","threadId":42}', $parsed['data']);
+    }
+
+    #[Test]
+    public function is_configured_returns_false_when_jwt_is_empty(): void
+    {
+        $publisher = new MercurePublisher('http://hub.example.com/.well-known/mercure', '');
+
+        $this->assertFalse($publisher->isConfigured());
+    }
+
+    #[Test]
+    public function is_configured_returns_false_when_hub_url_is_empty(): void
+    {
+        $publisher = new MercurePublisher('', 'some-jwt');
+
+        $this->assertFalse($publisher->isConfigured());
+    }
+
+    #[Test]
+    public function is_configured_returns_true_when_both_values_set(): void
+    {
+        $publisher = new MercurePublisher('http://hub.example.com/.well-known/mercure', 'test-jwt');
+
+        $this->assertTrue($publisher->isConfigured());
+    }
+
+    #[Test]
+    public function publish_returns_false_when_not_configured(): void
+    {
+        $publisher = new MercurePublisher('', '');
+
+        $this->assertFalse($publisher->publish('/threads/1', ['msg' => 'hello']));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MercurePublisher` service (`src/Support/MercurePublisher.php`) for publishing real-time events to a Mercure hub via SSE
- Add `config/messaging.php` with messaging constants (message length, typing TTL, digest settings, Mercure connection)
- Add unit tests for `MercurePublisher` (5 tests, 6 assertions)

## Test plan
- [x] `MercurePublisherTest` passes (5 tests, 6 assertions)
- [x] Full test suite passes (876 tests, 2482 assertions, 4 skipped)

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)