### PR TITLE
feat(#575): add messaging JavaScript ES modules

### DIFF
--- a/public/js/messaging/compose.js
+++ b/public/js/messaging/compose.js
@@ -1,0 +1,59 @@
+/**
+ * Compose bar — auto-grow textarea, send on Enter, typing broadcast.
+ */
+export class ComposeBar {
+  /**
+   * @param {HTMLElement} containerEl — element to render the compose bar into
+   * @param {function} onSend — called with message body string
+   * @param {function} onTyping — called when user is typing (debounced externally)
+   */
+  constructor(containerEl, onSend, onTyping) {
+    this.containerEl = containerEl;
+    this.onSend = onSend;
+    this.onTyping = onTyping;
+    this.maxLength = 2000;
+  }
+
+  render() {
+    this.containerEl.innerHTML = `
+      <form class="messages-compose" id="messages-compose-form">
+        <label for="messages-compose-input" class="visually-hidden">Type a message</label>
+        <textarea id="messages-compose-input" class="messages-compose__input" rows="1" maxlength="${this.maxLength}" placeholder="Type a message..." required></textarea>
+        <button type="submit" class="messages-compose__send" aria-label="Send">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M3.5 2.5l14 7.5-14 7.5v-6l8-1.5-8-1.5z"/></svg>
+        </button>
+      </form>`;
+
+    const form = this.containerEl.querySelector('#messages-compose-form');
+    const input = this.containerEl.querySelector('#messages-compose-input');
+
+    // Auto-grow.
+    input.addEventListener('input', () => {
+      input.style.height = 'auto';
+      input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+      this.onTyping();
+    });
+
+    // Send on Enter (Shift+Enter for newline).
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        form.requestSubmit();
+      }
+    });
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const body = input.value.trim();
+      if (!body) return;
+      this.onSend(body);
+      input.value = '';
+      input.style.height = 'auto';
+    });
+  }
+
+  focus() {
+    const input = this.containerEl.querySelector('#messages-compose-input');
+    if (input) input.focus();
+  }
+}

--- a/public/js/messaging/index.js
+++ b/public/js/messaging/index.js
@@ -1,0 +1,135 @@
+/**
+ * Messaging entry point — wires all modules together.
+ * Loaded on /messages page via <script type="module">.
+ */
+import { MercureConnection } from './mercure.js';
+import { ThreadList } from './thread-list.js';
+import { MessageView } from './message-view.js';
+import { ComposeBar } from './compose.js';
+import { TypingIndicator } from './typing.js';
+
+const app = document.getElementById('messages-app');
+if (app) {
+  const userId = Number(app.dataset.userId);
+  const hubUrl = app.dataset.hubUrl || '/hub';
+
+  const threadListEl = document.getElementById('messages-thread-list');
+  const threadViewEl = document.getElementById('messages-thread-view');
+  const composeEl = document.getElementById('messages-compose-area');
+  const typingEl = document.getElementById('messages-typing-area');
+
+  if (!threadListEl || !threadViewEl || !composeEl || !typingEl) {
+    throw new Error('Missing required DOM elements');
+  }
+
+  const threadList = new ThreadList(threadListEl, openThread);
+  const messageView = new MessageView(threadViewEl, userId);
+  const composeBar = new ComposeBar(composeEl, sendMessage, () => typing.localTyping());
+  const typing = new TypingIndicator(typingEl, userId);
+
+  let currentThreadId = null;
+  let mercure = null;
+
+  // Initial load.
+  loadThreads();
+
+  async function loadThreads() {
+    try {
+      const response = await fetch('/api/messaging/threads');
+      if (!response.ok) throw new Error('Failed');
+      const json = await response.json();
+      const threads = Array.isArray(json.threads) ? json.threads : [];
+      threadList.render(threads);
+
+      // Subscribe to all thread topics + user unread.
+      const topics = threads.map((t) => `/threads/${t.id}`);
+      topics.push(`/users/${userId}/unread`);
+
+      if (mercure) mercure.disconnect();
+      mercure = new MercureConnection(hubUrl, handleMercureEvent);
+      mercure.subscribe(topics, loadThreads);
+    } catch {
+      threadListEl.innerHTML = '<p class="messages-empty-note">Failed to load conversations</p>';
+    }
+  }
+
+  async function openThread(threadId) {
+    currentThreadId = threadId;
+    typing.setThread(threadId);
+
+    try {
+      const response = await fetch(`/api/messaging/threads/${threadId}/messages?limit=100`);
+      if (!response.ok) throw new Error('Failed');
+      const json = await response.json();
+      const messages = Array.isArray(json.messages) ? json.messages : [];
+      messageView.render(threadId, messages);
+      composeBar.render();
+      composeBar.focus();
+
+      // Mark as read.
+      fetch(`/api/messaging/threads/${threadId}/read`, { method: 'POST' }).catch(() => {});
+    } catch {
+      threadViewEl.innerHTML = '<p class="messages-empty-note">Failed to load messages</p>';
+    }
+  }
+
+  async function sendMessage(body) {
+    if (!currentThreadId) return;
+
+    // Optimistic append.
+    const tempMsg = {
+      id: Date.now(),
+      thread_id: currentThreadId,
+      sender_id: userId,
+      body,
+      created_at: Math.floor(Date.now() / 1000),
+      edited_at: null,
+      deleted_at: null,
+    };
+    messageView.appendMessage(tempMsg);
+
+    try {
+      await fetch(`/api/messaging/threads/${currentThreadId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      });
+    } catch {
+      // Message will appear via Mercure or next load.
+    }
+
+    threadList.updateThread(currentThreadId, { lastMessage: { body }, unreadCount: 0 });
+  }
+
+  function handleMercureEvent(data) {
+    switch (data.type) {
+      case 'message':
+        if (data.message.thread_id === currentThreadId && data.message.sender_id !== userId) {
+          messageView.appendMessage(data.message);
+          fetch(`/api/messaging/threads/${currentThreadId}/read`, { method: 'POST' }).catch(() => {});
+        }
+        threadList.updateThread(data.message.thread_id, { lastMessage: data.message });
+        break;
+
+      case 'message_edited':
+        messageView.updateMessage(data.id, data.body, data.edited_at);
+        break;
+
+      case 'message_deleted':
+        messageView.markDeleted(data.id);
+        break;
+
+      case 'typing':
+        typing.remoteTyping(data.user_id, data.display_name);
+        break;
+
+      case 'read':
+        // Could update read receipt indicators here in future.
+        break;
+
+      case 'unread':
+        // Handled by popover module.
+        break;
+    }
+  }
+}

--- a/public/js/messaging/mercure.js
+++ b/public/js/messaging/mercure.js
@@ -1,0 +1,83 @@
+/**
+ * Mercure SSE connection manager.
+ * Handles subscribe, reconnect, and polling fallback.
+ */
+export class MercureConnection {
+  /** @param {string} hubUrl */
+  /** @param {function} onEvent */
+  /** @param {number} pollingInterval — fallback polling interval in ms */
+  constructor(hubUrl, onEvent, pollingInterval = 10000) {
+    this.hubUrl = hubUrl;
+    this.onEvent = onEvent;
+    this.pollingInterval = pollingInterval;
+    this.topics = [];
+    this.eventSource = null;
+    this.pollTimer = null;
+    this.pollFn = null;
+  }
+
+  /**
+   * Subscribe to Mercure topics via EventSource.
+   * @param {string[]} topics
+   * @param {function} [pollFallback] — called during polling fallback
+   */
+  subscribe(topics, pollFallback = null) {
+    this.topics = topics;
+    this.pollFn = pollFallback;
+    this.connect();
+  }
+
+  connect() {
+    this.disconnect();
+
+    const url = new URL(this.hubUrl);
+    for (const topic of this.topics) {
+      url.searchParams.append('topic', topic);
+    }
+
+    this.eventSource = new EventSource(url, { withCredentials: true });
+
+    this.eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        this.onEvent(data);
+      } catch {
+        // Ignore malformed events.
+      }
+    };
+
+    this.eventSource.onerror = () => {
+      this.startPolling();
+    };
+
+    this.eventSource.onopen = () => {
+      this.stopPolling();
+    };
+  }
+
+  startPolling() {
+    if (this.pollTimer || !this.pollFn) return;
+    this.pollTimer = setInterval(() => this.pollFn(), this.pollingInterval);
+  }
+
+  stopPolling() {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  disconnect() {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.stopPolling();
+  }
+
+  /** Reconnect with new topic list (e.g., after joining/leaving a thread). */
+  updateTopics(topics) {
+    this.topics = topics;
+    this.connect();
+  }
+}

--- a/public/js/messaging/message-view.js
+++ b/public/js/messaging/message-view.js
@@ -1,0 +1,136 @@
+/**
+ * Chat area — renders message bubbles, handles scroll, edit/delete UI.
+ */
+import { escapeHtml } from './utils.js';
+
+export class MessageView {
+  /**
+   * @param {HTMLElement} containerEl
+   * @param {number} currentUserId
+   */
+  constructor(containerEl, currentUserId) {
+    this.containerEl = containerEl;
+    this.currentUserId = currentUserId;
+    this.messages = [];
+    this.threadId = null;
+
+    this.containerEl.addEventListener('click', (event) => {
+      const editBtn = event.target.closest('[data-action="edit"]');
+      const deleteBtn = event.target.closest('[data-action="delete"]');
+
+      if (editBtn) this.handleEdit(Number(editBtn.dataset.messageId));
+      if (deleteBtn) this.handleDelete(Number(deleteBtn.dataset.messageId));
+    });
+  }
+
+  /** @param {number} threadId */
+  /** @param {Array} messages */
+  render(threadId, messages) {
+    this.threadId = threadId;
+    this.messages = messages;
+
+    if (messages.length === 0) {
+      this.containerEl.innerHTML = '<p class="messages-empty-note">No messages yet. Say hello!</p>';
+      return;
+    }
+
+    const html = messages.map((msg) => this.renderBubble(msg)).join('');
+    this.containerEl.innerHTML = `<div class="messages-message-list">${html}</div>`;
+    this.scrollToBottom();
+  }
+
+  renderBubble(msg) {
+    const isOwn = msg.sender_id === this.currentUserId;
+    const isDeleted = msg.deleted_at !== null && msg.deleted_at !== undefined;
+    const isEdited = msg.edited_at !== null && msg.edited_at !== undefined;
+    const direction = isOwn ? 'outgoing' : 'incoming';
+    const body = isDeleted ? '<em>This message was deleted</em>' : escapeHtml(msg.body);
+    const time = new Date(msg.created_at * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const editedLabel = isEdited && !isDeleted ? ' · (edited)' : '';
+
+    const actions = isOwn && !isDeleted
+      ? `<span class="messages-bubble__actions">
+          <button data-action="edit" data-message-id="${msg.id}" title="Edit">&#x270E;</button>
+          <button data-action="delete" data-message-id="${msg.id}" title="Delete">&#x2715;</button>
+        </span>`
+      : '';
+
+    return `<article class="messages-bubble messages-bubble--${direction} ${isDeleted ? 'messages-bubble--deleted' : ''}" data-message-id="${msg.id}">
+      <div class="messages-bubble__content">${body}</div>
+      <div class="messages-bubble__meta">${time}${editedLabel}${actions}</div>
+    </article>`;
+  }
+
+  /** Append a new message (optimistic or from Mercure). */
+  appendMessage(msg) {
+    this.messages.push(msg);
+    const list = this.containerEl.querySelector('.messages-message-list');
+    if (list) {
+      list.insertAdjacentHTML('beforeend', this.renderBubble(msg));
+      this.scrollToBottom();
+    }
+  }
+
+  /** Update a message in place (edit event). */
+  updateMessage(messageId, body, editedAt) {
+    const el = this.containerEl.querySelector(`[data-message-id="${messageId}"]`);
+    if (!el) return;
+
+    const msg = this.messages.find((m) => m.id === messageId);
+    if (msg) {
+      msg.body = body;
+      msg.edited_at = editedAt;
+    }
+
+    el.outerHTML = this.renderBubble(msg || { id: messageId, body, edited_at: editedAt, sender_id: 0, created_at: 0 });
+  }
+
+  /** Mark a message as deleted in place. */
+  markDeleted(messageId) {
+    const msg = this.messages.find((m) => m.id === messageId);
+    if (msg) {
+      msg.deleted_at = Math.floor(Date.now() / 1000);
+      msg.body = '';
+    }
+
+    const el = this.containerEl.querySelector(`[data-message-id="${messageId}"]`);
+    if (el && msg) {
+      el.outerHTML = this.renderBubble(msg);
+    }
+  }
+
+  async handleEdit(messageId) {
+    const msg = this.messages.find((m) => m.id === messageId);
+    if (!msg) return;
+
+    const newBody = prompt('Edit message:', msg.body);
+    if (newBody === null || newBody.trim() === '' || newBody === msg.body) return;
+
+    const response = await fetch(`/api/messaging/threads/${this.threadId}/messages/${messageId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: newBody.trim() }),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      this.updateMessage(messageId, data.body, data.edited_at);
+    }
+  }
+
+  async handleDelete(messageId) {
+    if (!confirm('Delete this message?')) return;
+
+    const response = await fetch(`/api/messaging/threads/${this.threadId}/messages/${messageId}`, {
+      method: 'DELETE',
+    });
+
+    if (response.ok) {
+      this.markDeleted(messageId);
+    }
+  }
+
+  scrollToBottom() {
+    this.containerEl.scrollTop = this.containerEl.scrollHeight;
+  }
+}

--- a/public/js/messaging/popover.js
+++ b/public/js/messaging/popover.js
@@ -1,0 +1,89 @@
+/**
+ * Header message popover — badge + dropdown.
+ * Loaded on every page via base.html.twig.
+ */
+import { escapeHtml } from './utils.js';
+
+const trigger = document.getElementById('messages-popover-trigger');
+const badge = document.getElementById('messages-badge');
+const dropdown = document.getElementById('messages-popover-dropdown');
+
+if (trigger && badge && dropdown) {
+  const userId = Number(trigger.dataset.userId);
+  const hubUrl = trigger.dataset.hubUrl || '/hub';
+
+  // Load initial unread count.
+  updateBadge();
+
+  // Subscribe to unread topic via EventSource.
+  try {
+    const url = new URL(hubUrl, window.location.origin);
+    url.searchParams.append('topic', `/users/${userId}/unread`);
+    const es = new EventSource(url, { withCredentials: true });
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'unread') {
+          setBadge(data.count);
+        }
+      } catch {}
+    };
+  } catch {}
+
+  // Toggle dropdown.
+  trigger.addEventListener('click', async (event) => {
+    event.stopPropagation();
+    const isOpen = !dropdown.hidden;
+    dropdown.hidden = isOpen;
+    trigger.setAttribute('aria-expanded', String(!isOpen));
+
+    if (!isOpen) {
+      await loadRecentThreads();
+    }
+  });
+
+  // Close on outside click.
+  document.addEventListener('click', () => {
+    dropdown.hidden = true;
+    trigger.setAttribute('aria-expanded', 'false');
+  });
+  dropdown.addEventListener('click', (event) => event.stopPropagation());
+
+  async function updateBadge() {
+    try {
+      const response = await fetch('/api/messaging/unread-count');
+      if (!response.ok) return;
+      const data = await response.json();
+      setBadge(data.count || 0);
+    } catch {}
+  }
+
+  function setBadge(count) {
+    badge.textContent = count > 99 ? '99+' : String(count);
+    badge.hidden = count === 0;
+  }
+
+  async function loadRecentThreads() {
+    try {
+      const response = await fetch('/api/messaging/threads?limit=5');
+      if (!response.ok) return;
+      const data = await response.json();
+      const threads = Array.isArray(data.threads) ? data.threads : [];
+
+      if (threads.length === 0) {
+        dropdown.innerHTML = '<div class="messages-popover__empty">No conversations yet</div><a href="/messages" class="messages-popover__link">Open Messages</a>';
+        return;
+      }
+
+      dropdown.innerHTML = threads.map((thread) => {
+        const title = thread.title?.trim() || `Thread #${thread.id}`;
+        const preview = thread.last_message?.body || 'No messages';
+        const isUnread = thread.unread_count > 0;
+        return `<a href="/messages#thread-${thread.id}" class="messages-popover__item ${isUnread ? 'messages-popover__item--unread' : ''}">
+          <span class="messages-popover__title">${escapeHtml(title)}</span>
+          <span class="messages-popover__preview">${escapeHtml(preview)}</span>
+        </a>`;
+      }).join('') + '<a href="/messages" class="messages-popover__link">Open Messages</a>';
+    } catch {}
+  }
+}

--- a/public/js/messaging/thread-list.js
+++ b/public/js/messaging/thread-list.js
@@ -1,0 +1,91 @@
+/**
+ * Thread list sidebar — renders threads, handles selection, unread state.
+ */
+import { escapeHtml } from './utils.js';
+
+export class ThreadList {
+  /**
+   * @param {HTMLElement} containerEl
+   * @param {function} onSelectThread — called with threadId when a thread is clicked
+   */
+  constructor(containerEl, onSelectThread) {
+    this.containerEl = containerEl;
+    this.onSelectThread = onSelectThread;
+    this.threads = [];
+    this.activeThreadId = null;
+
+    this.containerEl.addEventListener('click', (event) => {
+      const button = event.target.closest('[data-thread-id]');
+      if (!button) return;
+      const threadId = Number(button.dataset.threadId);
+      this.setActive(threadId);
+      this.onSelectThread(threadId);
+    });
+  }
+
+  /** @param {Array} threads */
+  render(threads) {
+    this.threads = threads;
+
+    if (threads.length === 0) {
+      this.containerEl.innerHTML = '<p class="messages-empty-note">No conversations yet</p>';
+      return;
+    }
+
+    this.containerEl.innerHTML = threads.map((thread) => {
+      const isActive = this.activeThreadId === thread.id;
+      const isUnread = thread.unread_count > 0;
+      const title = thread.title?.trim() || `Thread #${thread.id}`;
+      const preview = thread.last_message?.body || 'No messages yet';
+      const time = thread.last_message_at ? this.formatTime(thread.last_message_at) : '';
+      const avatarClass = thread.thread_type === 'group' ? 'messages-avatar--group' : '';
+
+      return `<button class="messages-thread-list__item ${isActive ? 'messages-thread-list__item--active' : ''} ${isUnread ? 'messages-thread-list__item--unread' : ''}" data-thread-id="${thread.id}">
+        <span class="messages-avatar ${avatarClass}">${escapeHtml(this.initials(title))}</span>
+        <span class="messages-thread-list__body">
+          <span class="messages-thread-list__header">
+            <span class="messages-thread-list__title">${escapeHtml(title)}</span>
+            <span class="messages-thread-list__time">${escapeHtml(time)}</span>
+          </span>
+          <span class="messages-thread-list__preview">${escapeHtml(preview)}</span>
+        </span>
+        ${isUnread ? '<span class="messages-unread-dot"></span>' : ''}
+      </button>`;
+    }).join('');
+  }
+
+  setActive(threadId) {
+    this.activeThreadId = threadId;
+    this.containerEl.querySelectorAll('[data-thread-id]').forEach((el) => {
+      el.classList.toggle('messages-thread-list__item--active', Number(el.dataset.threadId) === threadId);
+    });
+  }
+
+  /** Update a single thread's preview and unread state without full re-render. */
+  updateThread(threadId, { lastMessage, unreadCount }) {
+    const thread = this.threads.find((t) => t.id === threadId);
+    if (!thread) return;
+
+    if (lastMessage) thread.last_message = lastMessage;
+    if (unreadCount !== undefined) thread.unread_count = unreadCount;
+    thread.last_message_at = Math.floor(Date.now() / 1000);
+
+    // Re-sort by recency and re-render.
+    this.threads.sort((a, b) => (b.last_message_at || 0) - (a.last_message_at || 0));
+    this.render(this.threads);
+  }
+
+  /** @param {string} name */
+  initials(name) {
+    return name.split(/\s+/).slice(0, 2).map((w) => w[0] || '').join('').toUpperCase() || '?';
+  }
+
+  /** @param {number} timestamp */
+  formatTime(timestamp) {
+    const diff = Math.floor(Date.now() / 1000) - timestamp;
+    if (diff < 60) return 'now';
+    if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+    return `${Math.floor(diff / 86400)}d`;
+  }
+}

--- a/public/js/messaging/typing.js
+++ b/public/js/messaging/typing.js
@@ -1,0 +1,69 @@
+/**
+ * Typing indicators — debounced POST to server, render/expire display.
+ */
+export class TypingIndicator {
+  /**
+   * @param {HTMLElement} containerEl — element to render typing indicator into
+   * @param {number} currentUserId
+   */
+  constructor(containerEl, currentUserId) {
+    this.containerEl = containerEl;
+    this.currentUserId = currentUserId;
+    this.typingUsers = new Map(); // userId -> { displayName, timer }
+    this.sendTimer = null;
+    this.sendDebounceMs = 2000;
+    this.expireMs = 5000;
+    this.threadId = null;
+  }
+
+  setThread(threadId) {
+    this.threadId = threadId;
+    this.typingUsers.clear();
+    this.render();
+  }
+
+  /** Call when the local user types — debounces the POST. */
+  localTyping() {
+    if (!this.threadId) return;
+
+    if (this.sendTimer) return;
+
+    this.sendTimer = setTimeout(() => {
+      this.sendTimer = null;
+    }, this.sendDebounceMs);
+
+    fetch(`/api/messaging/threads/${this.threadId}/typing`, {
+      method: 'POST',
+    }).catch(() => {});
+  }
+
+  /** Called when a Mercure typing event arrives. */
+  remoteTyping(userId, displayName) {
+    if (userId === this.currentUserId) return;
+
+    const existing = this.typingUsers.get(userId);
+    if (existing?.timer) clearTimeout(existing.timer);
+
+    const timer = setTimeout(() => {
+      this.typingUsers.delete(userId);
+      this.render();
+    }, this.expireMs);
+
+    this.typingUsers.set(userId, { displayName, timer });
+    this.render();
+  }
+
+  render() {
+    if (this.typingUsers.size === 0) {
+      this.containerEl.innerHTML = '';
+      return;
+    }
+
+    const names = [...this.typingUsers.values()].map((u) => u.displayName);
+    const text = names.length === 1
+      ? `${names[0]} is typing`
+      : `${names.join(', ')} are typing`;
+
+    this.containerEl.innerHTML = `<div class="messages-typing">${text}<span class="messages-typing__dots">...</span></div>`;
+  }
+}

--- a/public/js/messaging/utils.js
+++ b/public/js/messaging/utils.js
@@ -1,0 +1,13 @@
+/**
+ * Shared utilities for messaging modules.
+ */
+
+/** @param {string} text */
+export function escapeHtml(text) {
+  return String(text)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}


### PR DESCRIPTION
## Summary
- Create 8 vanilla JS ES modules in `public/js/messaging/` for the real-time messaging frontend
- Modules: MercureConnection (SSE + polling fallback), ThreadList (sidebar), MessageView (chat bubbles with edit/delete), ComposeBar (auto-grow textarea), TypingIndicator (debounced POST + display), entry point (wires all modules), popover (header unread badge), and shared utils
- Extracted `escapeHtml()` into shared `utils.js` to eliminate triplication across thread-list, message-view, and popover modules

## Test plan
- [x] All 8 files pass `node --input-type=module --check` syntax validation
- [ ] Manual test on /messages page after backend controllers and templates are wired (separate PRs)
- [ ] Verify Mercure SSE subscription connects and falls back to polling when hub unavailable
- [ ] Verify optimistic message sending, edit/delete UI, and typing indicators

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)