### PR TITLE
feat(#575): update templates and CSS for messaging UI

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -7,109 +7,400 @@
 }
 
 @layer components {
+  /* === Messaging === */
   .messages-page {
     display: grid;
     gap: var(--space-md);
-  }
-
-  .messages-page__header p {
-    color: var(--text-secondary);
-    margin-block-start: var(--space-2xs);
+    height: calc(100dvh - var(--header-height, 4rem) - var(--space-lg));
   }
 
   .messages-layout {
     display: grid;
     grid-template-columns: minmax(16rem, 22rem) 1fr;
-    gap: var(--space-sm);
-    align-items: start;
-  }
-
-  .messages-sidebar,
-  .messages-main {
+    gap: 0;
+    height: 100%;
     background: var(--surface-card);
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+
+  .messages-sidebar {
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .messages-sidebar__header {
     padding: var(--space-sm);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    & h2 { margin: 0; font-size: var(--text-lg); }
+  }
+
+  .messages-compose-btn {
+    background: var(--surface-elevated);
+    border: none;
+    color: var(--text-secondary);
+    border-radius: 50%;
+    width: 2rem;
+    height: 2rem;
+    cursor: pointer;
+    font-size: var(--text-base);
   }
 
   .messages-thread-list {
-    display: grid;
-    gap: var(--space-2xs);
-    margin-top: var(--space-xs);
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-2xs);
   }
 
   .messages-thread-list__item {
-    text-align: left;
-    background: transparent;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
+    display: flex;
+    gap: var(--space-xs);
     padding: var(--space-xs);
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
     color: inherit;
+    text-align: left;
     cursor: pointer;
-    display: grid;
-    gap: 0.25rem;
+    width: 100%;
+    align-items: center;
+
+    &:hover { background: var(--surface-elevated); }
+    &.messages-thread-list__item--active { background: var(--surface-elevated); }
+    &.messages-thread-list__item--unread .messages-thread-list__title { font-weight: 700; }
+    &.messages-thread-list__item--unread .messages-thread-list__preview { color: var(--text-primary); font-weight: 600; }
   }
 
-  .messages-thread-list__item--active {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent);
+  .messages-avatar {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 50%;
+    background: var(--accent);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: var(--text-sm);
+    flex-shrink: 0;
+
+    &.messages-avatar--group { border-radius: var(--radius-md); }
+  }
+
+  .messages-thread-list__body {
+    flex: 1;
+    min-width: 0;
+    display: grid;
+    gap: 0.125rem;
+  }
+
+  .messages-thread-list__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
   }
 
   .messages-thread-list__title {
     font-weight: 600;
+    font-size: var(--text-sm);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .messages-thread-list__time {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    flex-shrink: 0;
   }
 
   .messages-thread-list__preview {
+    font-size: var(--text-xs);
     color: var(--text-secondary);
-    font-size: var(--text-sm);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .messages-unread-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+  }
+
+  .messages-main {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .messages-thread-view {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-sm);
+  }
+
+  .messages-thread-view__placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--text-tertiary);
   }
 
   .messages-message-list {
-    display: grid;
-    gap: var(--space-xs);
-    max-height: 45dvh;
-    overflow: auto;
-    margin-bottom: var(--space-sm);
-  }
-
-  .messages-message {
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    padding: var(--space-xs);
-    background: var(--surface-raised);
-  }
-
-  .messages-message__meta {
-    color: var(--text-secondary);
-    font-size: var(--text-sm);
-    margin-bottom: 0.25rem;
-  }
-
-  .messages-send-form {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: var(--space-2xs);
   }
 
-  .messages-send-form textarea {
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    background: var(--surface);
-    color: inherit;
-    padding: var(--space-xs);
-    resize: vertical;
+  .messages-bubble {
+    max-width: 70%;
+    display: flex;
+    flex-direction: column;
+
+    &.messages-bubble--outgoing {
+      align-self: flex-end;
+
+      & .messages-bubble__content {
+        background: var(--accent);
+        color: white;
+        border-radius: 1.125rem 1.125rem 0.25rem 1.125rem;
+      }
+
+      & .messages-bubble__meta { text-align: right; }
+    }
+
+    &.messages-bubble--incoming {
+      align-self: flex-start;
+
+      & .messages-bubble__content {
+        background: var(--surface-elevated);
+        border-radius: 1.125rem 1.125rem 1.125rem 0.25rem;
+      }
+    }
+
+    &.messages-bubble--deleted {
+      opacity: 0.6;
+
+      & .messages-bubble__content { font-style: italic; }
+    }
   }
 
-  .messages-send-form button {
-    justify-self: end;
+  .messages-bubble__content {
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--text-sm);
+    line-height: 1.4;
+    word-break: break-word;
+  }
+
+  .messages-bubble__meta {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    padding: 0.125rem var(--space-sm);
+  }
+
+  .messages-bubble__actions {
+    display: inline-flex;
+    gap: var(--space-2xs);
+    margin-left: var(--space-xs);
+
+    & button {
+      background: none;
+      border: none;
+      color: var(--text-tertiary);
+      cursor: pointer;
+      font-size: var(--text-xs);
+      padding: 0;
+
+      &:hover { color: var(--text-primary); }
+    }
+  }
+
+  .messages-compose {
+    display: flex;
+    gap: var(--space-xs);
+    padding: var(--space-sm);
+    border-top: 1px solid var(--border);
+    align-items: flex-end;
+  }
+
+  .messages-compose__input {
+    flex: 1;
+    background: var(--surface-elevated);
+    border: none;
+    border-radius: 1.25rem;
+    padding: var(--space-xs) var(--space-sm);
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+    resize: none;
+    max-height: 7.5rem;
+    font-family: inherit;
+
+    &::placeholder { color: var(--text-tertiary); }
+    &:focus { outline: 2px solid var(--accent); outline-offset: -2px; }
+  }
+
+  .messages-compose__send {
+    background: var(--accent);
+    border: none;
+    color: white;
+    border-radius: 50%;
+    width: 2.25rem;
+    height: 2.25rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+
+    &:hover { opacity: 0.9; }
+  }
+
+  .messages-typing {
+    padding: var(--space-2xs) var(--space-sm);
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    font-style: italic;
+  }
+
+  .messages-typing__dots {
+    animation: typing-dots 1.4s infinite;
+  }
+
+  @keyframes typing-dots {
+    0%, 20% { opacity: 0.2; }
+    50% { opacity: 1; }
+    80%, 100% { opacity: 0.2; }
   }
 
   .messages-empty-note {
-    color: var(--text-secondary);
+    color: var(--text-tertiary);
+    text-align: center;
+    padding: var(--space-lg);
   }
 
-  @media (max-width: 56rem) {
+  /* Header popover */
+  .messages-popover {
+    position: relative;
+  }
+
+  .messages-popover__trigger {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    position: relative;
+    padding: var(--space-2xs);
+
+    &:hover { color: var(--text-primary); }
+  }
+
+  .messages-badge {
+    position: absolute;
+    top: -0.25rem;
+    right: -0.25rem;
+    background: var(--error, #ef4444);
+    color: white;
+    font-size: 0.625rem;
+    font-weight: 700;
+    min-width: 1rem;
+    height: 1rem;
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.25rem;
+  }
+
+  .messages-popover__dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    width: 20rem;
+    background: var(--surface-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg, 0 10px 25px rgba(0,0,0,0.2));
+    z-index: 100;
+    overflow: hidden;
+    margin-top: var(--space-2xs);
+  }
+
+  .messages-popover__item {
+    display: block;
+    padding: var(--space-xs) var(--space-sm);
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid var(--border);
+
+    &:hover { background: var(--surface-elevated); }
+    &.messages-popover__item--unread { background: rgba(91,141,239,0.08); }
+  }
+
+  .messages-popover__title {
+    display: block;
+    font-weight: 600;
+    font-size: var(--text-sm);
+  }
+
+  .messages-popover__preview {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .messages-popover__link {
+    display: block;
+    text-align: center;
+    padding: var(--space-xs);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+
+    &:hover { background: var(--surface-elevated); }
+  }
+
+  .messages-popover__empty {
+    padding: var(--space-md);
+    text-align: center;
+    color: var(--text-tertiary);
+    font-size: var(--text-sm);
+  }
+
+  /* Mobile responsive */
+  @media (max-width: 48rem) {
     .messages-layout {
       grid-template-columns: 1fr;
+    }
+
+    .messages-sidebar {
+      border-right: none;
+    }
+
+    .messages-main {
+      display: none;
+    }
+
+    .messages-layout.messages-layout--thread-open .messages-sidebar {
+      display: none;
+    }
+
+    .messages-layout.messages-layout--thread-open .messages-main {
+      display: flex;
     }
   }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,7 +17,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=41">
+  <link rel="stylesheet" href="/css/minoo.css?v=42">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   <script defer src="https://analytics.minoo.live/script.js" data-website-id="b357d196-9464-42e1-a93b-5f85743f20c9"></script>
@@ -43,6 +43,15 @@
           </form>
         </div>
         <div class="site-header__right">
+          {% if account is defined and account.isAuthenticated() %}
+          <div class="messages-popover" id="messages-popover">
+            <button class="messages-popover__trigger" id="messages-popover-trigger" data-user-id="{{ account.id() }}" data-hub-url="/hub" aria-expanded="false" aria-controls="messages-popover-dropdown" aria-label="Messages">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+              <span class="messages-badge" id="messages-badge" hidden>0</span>
+            </button>
+            <div class="messages-popover__dropdown" id="messages-popover-dropdown" hidden></div>
+          </div>
+          {% endif %}
           {% include "components/user-menu.html.twig" %}
         </div>
       </div>
@@ -364,6 +373,9 @@
     document.querySelectorAll('.related-section').forEach(el => { el.style.opacity = '0'; el.style.transition = 'opacity 0.4s ease'; observer.observe(el); });
   }
   </script>
+  {% if account is defined and account.isAuthenticated() %}
+    <script type="module" src="/js/messaging/popover.js"></script>
+  {% endif %}
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/components/user-menu.html.twig
+++ b/templates/components/user-menu.html.twig
@@ -13,6 +13,7 @@
       </div>
     </div>
     <div class="user-menu__section">
+      <a href="/messages" class="user-menu__item">Messages</a>
       <a href="/account" class="user-menu__item">{{ trans('usermenu.profile') }}</a>
       {% if 'elder_coordinator' in account.getRoles() %}
         <a href="/dashboard/coordinator" class="user-menu__item">{{ trans('usermenu.dashboard') }}</a>

--- a/templates/messages.html.twig
+++ b/templates/messages.html.twig
@@ -4,26 +4,26 @@
 
 {% block content %}
   <section class="messages-page">
-    <header class="messages-page__header">
-      <h1>{{ trans('messages.heading') }}</h1>
-      <p>{{ trans('messages.subheading') }}</p>
-    </header>
-
     {% if account is not defined or not account.isAuthenticated() %}
       <div class="messages-empty">
         <h2>{{ trans('messages.auth_required_title') }}</h2>
         <p>{{ trans('messages.auth_required_body') }}</p>
       </div>
     {% else %}
-      <div class="messages-layout" id="messages-app">
+      <div class="messages-layout" id="messages-app" data-user-id="{{ account.id() }}" data-hub-url="/hub">
         <aside class="messages-sidebar">
-          <h2>{{ trans('messages.inbox') }}</h2>
+          <div class="messages-sidebar__header">
+            <h2>Chats</h2>
+            <button class="messages-compose-btn" id="messages-new-thread" aria-label="New message">✎</button>
+          </div>
           <div id="messages-thread-list" class="messages-thread-list"></div>
         </aside>
         <main class="messages-main">
           <div id="messages-thread-view" class="messages-thread-view">
             <p class="messages-thread-view__placeholder">{{ trans('messages.select_thread') }}</p>
           </div>
+          <div id="messages-typing-area"></div>
+          <div id="messages-compose-area"></div>
         </main>
       </div>
     {% endif %}
@@ -33,125 +33,6 @@
 {% block scripts %}
   {{ parent() }}
   {% if account is defined and account.isAuthenticated() %}
-  <script>
-    (function () {
-      const listEl = document.getElementById('messages-thread-list');
-      const viewEl = document.getElementById('messages-thread-view');
-      if (!listEl || !viewEl) return;
-
-      let currentThreadId = null;
-
-      function escapeHtml(text) {
-        return String(text)
-          .replaceAll('&', '&amp;')
-          .replaceAll('<', '&lt;')
-          .replaceAll('>', '&gt;')
-          .replaceAll('"', '&quot;')
-          .replaceAll("'", '&#39;');
-      }
-
-      async function loadThreads() {
-        const response = await fetch('/api/messaging/threads');
-        if (!response.ok) throw new Error('Failed to load threads');
-        const json = await response.json();
-        return Array.isArray(json.threads) ? json.threads : [];
-      }
-
-      function renderThreads(threads) {
-        if (threads.length === 0) {
-          listEl.innerHTML = '<p class="messages-empty-note">{{ trans('messages.empty_inbox')|e('js') }}</p>';
-          return;
-        }
-
-        listEl.innerHTML = threads.map((thread) => {
-          const title = thread.title && thread.title.trim() !== '' ? thread.title : '{{ trans('messages.untitled_thread')|e('js') }} #' + thread.id;
-          const preview = thread.last_message && thread.last_message.body
-            ? thread.last_message.body
-            : '{{ trans('messages.no_messages_yet')|e('js') }}';
-          const activeClass = currentThreadId === thread.id ? 'messages-thread-list__item--active' : '';
-          return '<button class="messages-thread-list__item ' + activeClass + '" data-thread-id="' + thread.id + '">' +
-            '<span class="messages-thread-list__title">' + escapeHtml(title) + '</span>' +
-            '<span class="messages-thread-list__preview">' + escapeHtml(preview) + '</span>' +
-          '</button>';
-        }).join('');
-      }
-
-      async function loadThreadMessages(threadId) {
-        const response = await fetch('/api/messaging/threads/' + threadId + '/messages?limit=100');
-        if (!response.ok) throw new Error('Failed to load messages');
-        const json = await response.json();
-        return Array.isArray(json.messages) ? json.messages : [];
-      }
-
-      function renderMessages(messages) {
-        if (messages.length === 0) {
-          viewEl.innerHTML = '<p class="messages-empty-note">{{ trans('messages.no_messages_yet')|e('js') }}</p>';
-          return;
-        }
-
-        viewEl.innerHTML =
-          '<div class="messages-message-list">' +
-          messages.map((message) => {
-            return '<article class="messages-message">' +
-              '<header class="messages-message__meta">#' + message.id + ' · ' + new Date(message.created_at * 1000).toLocaleString() + '</header>' +
-              '<p class="messages-message__body">' + escapeHtml(message.body || '') + '</p>' +
-            '</article>';
-          }).join('') +
-          '</div>' +
-          '<form id="messages-send-form" class="messages-send-form">' +
-            '<label for="messages-body" class="visually-hidden">{{ trans('messages.compose_label')|e('js') }}</label>' +
-            '<textarea id="messages-body" rows="3" maxlength="2000" placeholder="{{ trans('messages.compose_placeholder')|e('js') }}" required></textarea>' +
-            '<button type="submit">{{ trans('messages.send')|e('js') }}</button>' +
-          '</form>';
-
-        const form = document.getElementById('messages-send-form');
-        const bodyInput = document.getElementById('messages-body');
-        if (form && bodyInput) {
-          form.addEventListener('submit', async (event) => {
-            event.preventDefault();
-            const body = bodyInput.value.trim();
-            if (!body || !currentThreadId) return;
-
-            const response = await fetch('/api/messaging/threads/' + currentThreadId + '/messages', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ body }),
-            });
-
-            if (!response.ok) return;
-            bodyInput.value = '';
-            await openThread(currentThreadId);
-            await refresh();
-          });
-        }
-      }
-
-      async function openThread(threadId) {
-        currentThreadId = Number(threadId);
-        const messages = await loadThreadMessages(currentThreadId);
-        renderMessages(messages);
-
-        const items = listEl.querySelectorAll('[data-thread-id]');
-        items.forEach((item) => {
-          item.classList.toggle('messages-thread-list__item--active', Number(item.dataset.threadId) === currentThreadId);
-        });
-      }
-
-      async function refresh() {
-        const threads = await loadThreads();
-        renderThreads(threads);
-      }
-
-      listEl.addEventListener('click', async (event) => {
-        const button = event.target.closest('[data-thread-id]');
-        if (!button) return;
-        await openThread(button.dataset.threadId);
-      });
-
-      refresh().catch(() => {
-        listEl.innerHTML = '<p class="messages-empty-note">{{ trans('messages.load_error')|e('js') }}</p>';
-      });
-    })();
-  </script>
+    <script type="module" src="/js/messaging/index.js"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace `messages.html.twig` inline JS (120+ lines) with ES module import, add `data-user-id`/`data-hub-url` attributes, sidebar header with compose button, and separate typing/compose container elements
- Add message popover with SVG chat icon and unread badge to `base.html.twig` header (authenticated users only), load `popover.js` module, bump CSS to `?v=42`
- Add "Messages" link to user-menu dropdown
- Replace all `.messages-*` CSS with comprehensive Messenger-style components: chat bubbles (outgoing blue/incoming gray with directional corners), thread list with avatars and unread states, pill-shaped compose textarea, typing indicator with animated dots, header popover dropdown, and responsive mobile layout (`@media max-width: 48rem`)

Closes #575

## Test plan
- [ ] Verify PHPUnit passes on main repo (worktree has no vendor/)
- [ ] Verify messages page renders correctly for authenticated users
- [ ] Verify header popover appears with chat icon for authenticated users
- [ ] Verify "Messages" link appears in user menu dropdown
- [ ] Verify mobile responsive layout shows single-panel with toggle
- [ ] Verify CSS version bumped to ?v=42

🤖 Generated with [Claude Code](https://claude.com/claude-code)