### PR TITLE
feat(#600): add language switcher UI to site header

### DIFF
--- a/public/css/minoo.css
+++ b/public/css/minoo.css
@@ -5604,6 +5604,35 @@
   }
 }
 
+/* Language switcher */
+@layer components {
+  .language-switcher {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    font-size: var(--step--1);
+  }
+
+  .language-switcher__item {
+    padding: var(--space-3xs) var(--space-2xs);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
+  }
+
+  a.language-switcher__item:hover {
+    color: var(--text-primary);
+    background-color: var(--surface-hover);
+  }
+
+  .language-switcher__item--active {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+}
+
 @layer utilities {
   .flow > * + * {
     margin-block-start: var(--space-sm);

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,7 +17,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=42">
+  <link rel="stylesheet" href="/css/minoo.css?v=43">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   <script defer src="https://analytics.minoo.live/script.js" data-website-id="b357d196-9464-42e1-a93b-5f85743f20c9"></script>
@@ -43,6 +43,7 @@
           </form>
         </div>
         <div class="site-header__right">
+          {% include "components/language-switcher.html.twig" %}
           {% if account is defined and account.isAuthenticated() %}
           <div class="messages-popover" id="messages-popover">
             <button class="messages-popover__trigger" id="messages-popover-trigger" data-user-id="{{ account.id() }}" data-hub-url="/.well-known/mercure" aria-expanded="false" aria-controls="messages-popover-dropdown" aria-label="Messages">

--- a/templates/components/language-switcher.html.twig
+++ b/templates/components/language-switcher.html.twig
@@ -1,0 +1,11 @@
+{# Language switcher - toggles between available languages #}
+<nav class="language-switcher" aria-label="{{ trans('language_switcher.label') }}">
+  {% set current = current_language() %}
+  {% for lang in available_languages() %}
+    {% if lang.id == current.id %}
+      <span class="language-switcher__item language-switcher__item--active" aria-current="true" lang="{{ lang.id }}">{{ lang.label }}</span>
+    {% else %}
+      <a href="{{ lang_switch_url(lang.id, request_path|default('/')) }}" class="language-switcher__item" lang="{{ lang.id }}" hreflang="{{ lang.id }}">{{ lang.label }}</a>
+    {% endif %}
+  {% endfor %}
+</nav>


### PR DESCRIPTION
## Summary
- Adds `templates/components/language-switcher.html.twig` using framework i18n Twig functions (`available_languages()`, `lang_switch_url()`, `current_language()`)
- Includes switcher in `base.html.twig` header right area, before user menu/login
- Adds minimal CSS styles in `@layer components` using existing design tokens
- Bumps CSS cache version to v=43

Closes #600

## Test plan
- [x] All 819 PHPUnit tests pass (4 skipped)
- [ ] Visual check: language switcher appears in header between search and user menu
- [ ] Click Anishinaabemowin link switches to /oj/ prefix
- [ ] Active language shown as non-link text with `aria-current="true"`
- [ ] Accessible: `aria-label` on nav, `lang`/`hreflang` attributes on links

🤖 Generated with [Claude Code](https://claude.com/claude-code)