### PR TITLE
test(#533): add part-of-speech mapper validation tests

### DIFF
--- a/tests/Minoo/Unit/Ingest/DictionaryEntryMapperPartOfSpeechTest.php
+++ b/tests/Minoo/Unit/Ingest/DictionaryEntryMapperPartOfSpeechTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Tests\Unit\Ingest;
+
+use Minoo\Ingestion\EntityMapper\DictionaryEntryMapper;
+use Minoo\Ingestion\ValueObject\DictionaryEntryFields;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DictionaryEntryMapper::class)]
+#[CoversClass(DictionaryEntryFields::class)]
+final class DictionaryEntryMapperPartOfSpeechTest extends TestCase
+{
+    private DictionaryEntryMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new DictionaryEntryMapper();
+    }
+
+    #[Test]
+    public function it_maps_word_class_normalized_as_part_of_speech(): void
+    {
+        $data = [
+            'lemma' => 'makwa',
+            'definition' => 'bear',
+            'word_class_normalized' => 'na',
+            'word_class' => 'noun animate',
+            'part_of_speech' => 'noun',
+        ];
+
+        $result = $this->mapper->map($data);
+
+        $this->assertSame('na', $result->partOfSpeech);
+    }
+
+    #[Test]
+    public function it_falls_back_to_word_class_when_normalized_missing(): void
+    {
+        $data = [
+            'lemma' => 'jiimaan',
+            'definition' => 'canoe, boat',
+            'word_class' => 'ni',
+            'part_of_speech' => 'noun',
+        ];
+
+        $result = $this->mapper->map($data);
+
+        $this->assertSame('ni', $result->partOfSpeech);
+    }
+
+    #[Test]
+    public function it_falls_back_to_part_of_speech_field(): void
+    {
+        $data = [
+            'lemma' => 'giizis',
+            'definition' => 'sun, moon, month',
+            'part_of_speech' => 'na',
+        ];
+
+        $result = $this->mapper->map($data);
+
+        $this->assertSame('na', $result->partOfSpeech);
+    }
+
+    #[Test]
+    public function it_returns_empty_string_when_no_pos_fields_present(): void
+    {
+        $data = [
+            'lemma' => 'makwa',
+            'definition' => 'bear',
+        ];
+
+        $result = $this->mapper->map($data);
+
+        $this->assertSame('', $result->partOfSpeech);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 4 focused unit tests validating the `DictionaryEntryMapper` part-of-speech fallback chain: `word_class_normalized` -> `word_class` -> `part_of_speech` -> empty string
- Uses realistic Ojibwe test data (makwa=bear, jiimaan=canoe, giizis=sun)
- Closes #533

## Test plan
- [x] `./vendor/bin/phpunit tests/Minoo/Unit/Ingest/DictionaryEntryMapperPartOfSpeechTest.php` — all 4 tests pass
- [x] Full suite: 823 tests, 1 pre-existing worktree-specific failure (IngestionDashboardControllerTest path resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)