### PR TITLE
test(#603): Playwright E2E tests for dictionary browse and search

### DIFF
--- a/tests/playwright/language-search.spec.ts
+++ b/tests/playwright/language-search.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dictionary browse and search', () => {
+  test('language page shows dictionary entries', async ({ page }) => {
+    await page.goto('/language');
+    const heading = page.locator('h1');
+    await expect(heading).toBeVisible();
+    const cards = page.locator('.card--language');
+    await expect(cards.first()).toBeVisible();
+  });
+
+  test('language page has pagination', async ({ page }) => {
+    await page.goto('/language');
+    const pagination = page.locator('.pagination');
+    await expect(pagination).toBeVisible();
+  });
+
+  test('search form is present on language page', async ({ page }) => {
+    await page.goto('/language');
+    const searchInput = page.locator('#dict-search');
+    await expect(searchInput).toBeVisible();
+  });
+
+  test('search returns results for "makwa"', async ({ page }) => {
+    await page.goto('/language/search?q=makwa');
+    const cards = page.locator('.card--language');
+    await expect(cards.first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('search with no results shows message', async ({ page }) => {
+    await page.goto('/language/search?q=xyznotaword123');
+    const content = page.locator('main');
+    await expect(content).toContainText('No results');
+  });
+
+  test('dictionary entry detail page works', async ({ page }) => {
+    await page.goto('/language');
+    const firstLink = page.locator('.card--language .card__title a').first();
+    await firstLink.click();
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('attribution is visible on entries', async ({ page }) => {
+    await page.goto('/language');
+    const attribution = page.locator('.card__meta').first();
+    await expect(attribution).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 7 Playwright E2E tests for the language/dictionary page covering browse, search, pagination, detail navigation, and attribution
- Tests depend on dictionary search feature (#331) being merged -- search-related tests will pass after that lands
- Covers: dictionary entry cards, pagination, search form presence, search results, no-results message, detail page navigation, attribution visibility

## Test plan
- [ ] Run `npx playwright test tests/playwright/language-search.spec.ts` after #331 merges
- [ ] Verify browse tests pass with seeded dictionary data
- [ ] Confirm search tests pass once search route is live

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)