### PR TITLE
refactor(#631): migrate controllers from SsrResponse to Symfony Response

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2802,16 +2802,16 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
-                "reference": "89e0f09553b6feaa791b9416b7f4360fc9b8654a"
+                "reference": "058806755f61dca5170fc7a5b9f5ba87c3a19b91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/access/zipball/89e0f09553b6feaa791b9416b7f4360fc9b8654a",
-                "reference": "89e0f09553b6feaa791b9416b7f4360fc9b8654a",
+                "url": "https://api.github.com/repos/waaseyaa/access/zipball/058806755f61dca5170fc7a5b9f5ba87c3a19b91",
+                "reference": "058806755f61dca5170fc7a5b9f5ba87c3a19b91",
                 "shasum": ""
             },
             "require": {
@@ -2844,13 +2844,13 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
@@ -2897,13 +2897,13 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.106"
             },
             "time": "2026-04-02T15:57:27+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-agent.git",
@@ -2942,13 +2942,13 @@
             "description": "AI agent orchestration and tool execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-agent/issues",
-                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-23T06:24:45+00:00"
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-schema.git",
@@ -2986,22 +2986,22 @@
             "description": "AI-friendly schema definitions and entity metadata for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-schema/issues",
-                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-23T06:34:58+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
-                "reference": "b960262ef767980381fe9c95f63b603e0b5ca83c"
+                "reference": "bcd4a78798435feaabdbb3dc6023588a5d2f9482"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ai-vector/zipball/b960262ef767980381fe9c95f63b603e0b5ca83c",
-                "reference": "b960262ef767980381fe9c95f63b603e0b5ca83c",
+                "url": "https://api.github.com/repos/waaseyaa/ai-vector/zipball/bcd4a78798435feaabdbb3dc6023588a5d2f9482",
+                "reference": "bcd4a78798435feaabdbb3dc6023588a5d2f9482",
                 "shasum": ""
             },
             "require": {
@@ -3034,22 +3034,22 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-23T19:48:14+00:00"
+            "time": "2026-04-03T14:58:04+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
-                "reference": "aeaec471e380182cdf504c9ab291a0dd725c87e3"
+                "reference": "d8f2f2ee44da40943d1fad733aeae804848a3cc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/api/zipball/aeaec471e380182cdf504c9ab291a0dd725c87e3",
-                "reference": "aeaec471e380182cdf504c9ab291a0dd725c87e3",
+                "url": "https://api.github.com/repos/waaseyaa/api/zipball/d8f2f2ee44da40943d1fad733aeae804848a3cc2",
+                "reference": "d8f2f2ee44da40943d1fad733aeae804848a3cc2",
                 "shasum": ""
             },
             "require": {
@@ -3057,8 +3057,7 @@
                 "waaseyaa/access": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/foundation": "^0.1",
-                "waaseyaa/routing": "^0.1",
-                "waaseyaa/ssr": "^0.1"
+                "waaseyaa/routing": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -3087,22 +3086,22 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-01T17:53:50+00:00"
+            "time": "2026-04-05T01:21:35+00:00"
         },
         {
             "name": "waaseyaa/auth",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/auth.git",
-                "reference": "f47d14718e4c8f580444b60b13d64cffc9dcffb9"
+                "reference": "740cafbcbc66db1d3f64adc011b64450c59aed01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/auth/zipball/f47d14718e4c8f580444b60b13d64cffc9dcffb9",
-                "reference": "f47d14718e4c8f580444b60b13d64cffc9dcffb9",
+                "url": "https://api.github.com/repos/waaseyaa/auth/zipball/740cafbcbc66db1d3f64adc011b64450c59aed01",
+                "reference": "740cafbcbc66db1d3f64adc011b64450c59aed01",
                 "shasum": ""
             },
             "require": {
@@ -3138,13 +3137,13 @@
             "description": "Headless authentication for Waaseyaa — login, registration, 2FA, password reset",
             "support": {
                 "issues": "https://github.com/waaseyaa/auth/issues",
-                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-30T15:05:30+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
@@ -3187,22 +3186,22 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-23T00:58:08+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
-                "reference": "2bd6aa8b38bacd01ed35f5c0b294d9afc0638370"
+                "reference": "414a783ba0872ac12a55aab398e06f6030b653c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/cli/zipball/2bd6aa8b38bacd01ed35f5c0b294d9afc0638370",
-                "reference": "2bd6aa8b38bacd01ed35f5c0b294d9afc0638370",
+                "url": "https://api.github.com/repos/waaseyaa/cli/zipball/414a783ba0872ac12a55aab398e06f6030b653c3",
+                "reference": "414a783ba0872ac12a55aab398e06f6030b653c3",
                 "shasum": ""
             },
             "require": {
@@ -3241,13 +3240,13 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-02T16:14:37+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
@@ -3286,13 +3285,13 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.106"
             },
             "time": "2026-04-02T16:14:37+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
@@ -3330,7 +3329,7 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-19T22:48:53+00:00"
         },
@@ -3386,7 +3385,7 @@
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
@@ -3432,13 +3431,13 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.106"
             },
             "time": "2026-04-04T17:16:03+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
@@ -3480,22 +3479,22 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.106"
             },
             "time": "2026-04-04T17:16:03+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
-                "reference": "5ebf640ccbd2cfb2c2649fab1602bda3a0b97a36"
+                "reference": "628d19b0bddd68d24a0d49e70f6525cc24d6dbbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/field/zipball/5ebf640ccbd2cfb2c2649fab1602bda3a0b97a36",
-                "reference": "5ebf640ccbd2cfb2c2649fab1602bda3a0b97a36",
+                "url": "https://api.github.com/repos/waaseyaa/field/zipball/628d19b0bddd68d24a0d49e70f6525cc24d6dbbb",
+                "reference": "628d19b0bddd68d24a0d49e70f6525cc24d6dbbb",
                 "shasum": ""
             },
             "require": {
@@ -3526,22 +3525,22 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "f9f6933233b1971193642537a0981d94217d7500"
+                "reference": "da132219ab5d3d1d9d1f9064b6a014e9c2f1d193"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/f9f6933233b1971193642537a0981d94217d7500",
-                "reference": "f9f6933233b1971193642537a0981d94217d7500",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/da132219ab5d3d1d9d1f9064b6a014e9c2f1d193",
+                "reference": "da132219ab5d3d1d9d1f9064b6a014e9c2f1d193",
                 "shasum": ""
             },
             "require": {
@@ -3581,9 +3580,9 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-04T17:16:03+00:00"
+            "time": "2026-04-06T03:56:58+00:00"
         },
         {
             "name": "waaseyaa/geo",
@@ -3635,16 +3634,16 @@
         },
         {
             "name": "waaseyaa/graphql",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/graphql.git",
-                "reference": "887365ba278bbb5141444bea343b680213531f11"
+                "reference": "5515718594e7187da0a6f3f26c5a82f18248a1f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/887365ba278bbb5141444bea343b680213531f11",
-                "reference": "887365ba278bbb5141444bea343b680213531f11",
+                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/5515718594e7187da0a6f3f26c5a82f18248a1f8",
+                "reference": "5515718594e7187da0a6f3f26c5a82f18248a1f8",
                 "shasum": ""
             },
             "require": {
@@ -3683,13 +3682,13 @@
             "description": "GraphQL endpoint for Waaseyaa — auto-generated schema from entity types",
             "support": {
                 "issues": "https://github.com/waaseyaa/graphql/issues",
-                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-01T17:53:50+00:00"
+            "time": "2026-04-04T00:58:32+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
@@ -3727,22 +3726,22 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/mail",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mail.git",
-                "reference": "577d0f19b3aaedb934ed8dfccf4df5a92d595e19"
+                "reference": "05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/577d0f19b3aaedb934ed8dfccf4df5a92d595e19",
-                "reference": "577d0f19b3aaedb934ed8dfccf4df5a92d595e19",
+                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9",
+                "reference": "05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9",
                 "shasum": ""
             },
             "require": {
@@ -3781,22 +3780,22 @@
             "description": "Transport-agnostic mail API for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mail/issues",
-                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-31T01:44:53+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/mcp",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mcp.git",
-                "reference": "fb557980cff31f9fc1e315915aa89722f58d993f"
+                "reference": "cfe8839c8c96bc701bae67966b99fb935b43d7e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/mcp/zipball/fb557980cff31f9fc1e315915aa89722f58d993f",
-                "reference": "fb557980cff31f9fc1e315915aa89722f58d993f",
+                "url": "https://api.github.com/repos/waaseyaa/mcp/zipball/cfe8839c8c96bc701bae67966b99fb935b43d7e3",
+                "reference": "cfe8839c8c96bc701bae67966b99fb935b43d7e3",
                 "shasum": ""
             },
             "require": {
@@ -3838,13 +3837,13 @@
             "description": "Remote MCP server endpoint for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mcp/issues",
-                "source": "https://github.com/waaseyaa/mcp/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/mcp/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-01T18:00:30+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/media",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/media.git",
@@ -3887,13 +3886,13 @@
             "description": "Media entity type and file management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/media/issues",
-                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-30T16:26:08+00:00"
         },
         {
             "name": "waaseyaa/menu",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/menu.git",
@@ -3936,7 +3935,7 @@
             "description": "Menu and navigation link management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/menu/issues",
-                "source": "https://github.com/waaseyaa/menu/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/menu/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-29T16:26:20+00:00"
         },
@@ -4038,7 +4037,7 @@
         },
         {
             "name": "waaseyaa/node",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/node.git",
@@ -4082,13 +4081,13 @@
             "description": "Content node entity type for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/node/issues",
-                "source": "https://github.com/waaseyaa/node/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/node/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-29T16:26:20+00:00"
         },
         {
             "name": "waaseyaa/path",
-            "version": "v0.1.0-alpha.101",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/path.git",
@@ -4131,22 +4130,22 @@
             "description": "URL path aliases and routing integration for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/path/issues",
-                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.101"
+                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-29T16:26:20+00:00"
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
-                "reference": "9b7530ac5ef1012460c9c9c16a8ee5abb3bdad44"
+                "reference": "cdcf6140eaba74e2be53b0c58927542099a1e936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/9b7530ac5ef1012460c9c9c16a8ee5abb3bdad44",
-                "reference": "9b7530ac5ef1012460c9c9c16a8ee5abb3bdad44",
+                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/cdcf6140eaba74e2be53b0c58927542099a1e936",
+                "reference": "cdcf6140eaba74e2be53b0c58927542099a1e936",
                 "shasum": ""
             },
             "require": {
@@ -4175,22 +4174,22 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-16T21:50:01+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
-                "reference": "c36ef5b50fc6165bbf7724e104da19e7a5b338cd"
+                "reference": "0bd4b8e560fcba724dfb359f7bcb50c7e87141bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/c36ef5b50fc6165bbf7724e104da19e7a5b338cd",
-                "reference": "c36ef5b50fc6165bbf7724e104da19e7a5b338cd",
+                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/0bd4b8e560fcba724dfb359f7bcb50c7e87141bc",
+                "reference": "0bd4b8e560fcba724dfb359f7bcb50c7e87141bc",
                 "shasum": ""
             },
             "require": {
@@ -4226,13 +4225,13 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-28T20:10:03+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/relationship",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/relationship.git",
@@ -4274,13 +4273,13 @@
             "description": "Reusable relationship primitives for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/relationship/issues",
-                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-30T16:26:08+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
@@ -4321,13 +4320,13 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-23T17:30:12+00:00"
         },
         {
             "name": "waaseyaa/search",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/search.git",
@@ -4374,22 +4373,22 @@
             "description": "Search provider interface and DTOs for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/search/issues",
-                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-23T17:41:28+00:00"
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ssr.git",
-                "reference": "3815a8d7366c5b28ac3f848de1d9944b4af382c3"
+                "reference": "65eda65211ca7cd48270c9d001d37888878a14d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/3815a8d7366c5b28ac3f848de1d9944b4af382c3",
-                "reference": "3815a8d7366c5b28ac3f848de1d9944b4af382c3",
+                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/65eda65211ca7cd48270c9d001d37888878a14d6",
+                "reference": "65eda65211ca7cd48270c9d001d37888878a14d6",
                 "shasum": ""
             },
             "require": {
@@ -4400,6 +4399,7 @@
                 "waaseyaa/config": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/field": "^0.1",
+                "waaseyaa/foundation": "^0.1",
                 "waaseyaa/routing": "^0.1"
             },
             "require-dev": {
@@ -4430,22 +4430,22 @@
             "description": "Server-side rendering with Twig templates for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ssr/issues",
-                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-05T01:21:35+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
-                "reference": "58d4940a62f1eaa9cb0d99cbfb90a63299a1f32c"
+                "reference": "c569028bc730805482bd79dde075c5bdd2d472f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/state/zipball/58d4940a62f1eaa9cb0d99cbfb90a63299a1f32c",
-                "reference": "58d4940a62f1eaa9cb0d99cbfb90a63299a1f32c",
+                "url": "https://api.github.com/repos/waaseyaa/state/zipball/c569028bc730805482bd79dde075c5bdd2d472f2",
+                "reference": "c569028bc730805482bd79dde075c5bdd2d472f2",
                 "shasum": ""
             },
             "require": {
@@ -4474,13 +4474,13 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-03-18T23:44:26+00:00"
+            "time": "2026-04-04T00:46:26+00:00"
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/taxonomy.git",
@@ -4524,13 +4524,13 @@
             "description": "Taxonomy vocabulary and term entity types for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/taxonomy/issues",
-                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-30T16:26:08+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
@@ -4568,22 +4568,22 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
-                "reference": "b70f0868f2424308670b6940f5e6979593541931"
+                "reference": "e83130b4eb19c2feb3a533132a172d2123ae5a6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/user/zipball/b70f0868f2424308670b6940f5e6979593541931",
-                "reference": "b70f0868f2424308670b6940f5e6979593541931",
+                "url": "https://api.github.com/repos/waaseyaa/user/zipball/e83130b4eb19c2feb3a533132a172d2123ae5a6b",
+                "reference": "e83130b4eb19c2feb3a533132a172d2123ae5a6b",
                 "shasum": ""
             },
             "require": {
@@ -4622,13 +4622,13 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-01T17:10:23+00:00"
+            "time": "2026-04-03T20:07:25+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
@@ -4667,13 +4667,13 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-27T19:12:28+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
@@ -4718,7 +4718,7 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.106"
             },
             "time": "2026-03-29T16:26:20+00:00"
         },
@@ -6575,23 +6575,22 @@
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.103",
+            "version": "v0.1.0-alpha.106",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
-                "reference": "154bb4866dd5fb4deb1454fb92c20e46d4b80177"
+                "reference": "28937148e6faec2d358b05f6100542b9d95fee4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/testing/zipball/154bb4866dd5fb4deb1454fb92c20e46d4b80177",
-                "reference": "154bb4866dd5fb4deb1454fb92c20e46d4b80177",
+                "url": "https://api.github.com/repos/waaseyaa/testing/zipball/28937148e6faec2d358b05f6100542b9d95fee4f",
+                "reference": "28937148e6faec2d358b05f6100542b9d95fee4f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
                 "phpunit/phpunit": "^10.5",
-                "symfony/event-dispatcher": "^7.0",
-                "waaseyaa/graphql": "@dev"
+                "symfony/event-dispatcher": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -6609,12 +6608,12 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Testing utilities for Waaseyaa — base test case, entity factories, GraphQL schema contract base, and helper traits.",
+            "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.103"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.106"
             },
-            "time": "2026-04-02T23:57:27+00:00"
+            "time": "2026-04-04T00:58:32+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Method Minoo\\Controller\\AgimController\:\:getEntityTypeManager\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: src/Controller/AgimController.php
+
+		-
 			message: '#^Parameter \#1 \$community of method Minoo\\Controller\\CommunityController\:\:findNearbyCommunities\(\) expects Waaseyaa\\Entity\\ContentEntityBase, Waaseyaa\\Entity\\EntityInterface given\.$#'
 			identifier: argument.type
 			count: 1
@@ -137,3 +143,9 @@ parameters:
 			identifier: nullCoalesce.variable
 			count: 1
 			path: src/Support/GeocodingService.php
+
+		-
+			message: '#^Parameter \#1 \$array \(list\<array\{id\: mixed, key\: mixed, label_en\: mixed, label_oj\: mixed\}\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: src/Support/JourneyEngine.php

--- a/src/Controller/AccountHomeController.php
+++ b/src/Controller/AccountHomeController.php
@@ -11,7 +11,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\User\User;
 
 final class AccountHomeController
@@ -21,7 +22,7 @@ final class AccountHomeController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('account/home.html.twig', LayoutTwigContext::withAccount($account, [
             'roles' => $account->getRoles(),
@@ -29,16 +30,16 @@ final class AccountHomeController
             'path' => '/account',
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function toggleElder(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function toggleElder(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('user');
         $user = $storage->load($account->id());
 
         if (!$user instanceof User) {
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/account']);
+            return new RedirectResponse('/account');
         }
 
         $isElder = ElderIdentity::isElder($user);
@@ -47,6 +48,6 @@ final class AccountHomeController
 
         Flash::success($isElder ? 'Elder status removed.' : 'You have identified as an Elder. Miigwech.');
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/account']);
+        return new RedirectResponse('/account');
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Minoo\Controller;
 
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class AdminController
 {
@@ -15,12 +15,12 @@ final class AdminController
         $this->projectRoot = dirname(__DIR__, 2);
     }
 
-    public function spa(): SsrResponse
+    public function spa(): Response
     {
         $spaIndex = $this->projectRoot . '/public/admin/index.html';
 
         if (file_exists($spaIndex)) {
-            return new SsrResponse(content: file_get_contents($spaIndex), statusCode: 200);
+            return new Response(file_get_contents($spaIndex));
         }
 
         $html = <<<'HTML'
@@ -60,6 +60,6 @@ final class AdminController
         </html>
         HTML;
 
-        return new SsrResponse(content: $html, statusCode: 200);
+        return new Response($html);
     }
 }

--- a/src/Controller/AgimController.php
+++ b/src/Controller/AgimController.php
@@ -12,7 +12,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class AgimController
 {
@@ -76,19 +76,19 @@ final class AgimController
     }
 
     /** Render the Agim game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('agim.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/agim',
         ]));
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /**
      * GET /api/games/agim/start?level={1-4}
      * Creates a new game session for the requested level.
      */
-    public function start(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function start(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $raw = (int) ($query['level'] ?? 1);
         $level = isset(self::TIERS[$raw]) ? $raw : 1;
@@ -120,7 +120,7 @@ final class AgimController
      * GET /api/games/agim/prompt?session_token=X
      * Returns the next numeral to answer.
      */
-    public function prompt(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function prompt(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = $query['session_token'] ?? '';
         if ($token === '') {
@@ -150,7 +150,7 @@ final class AgimController
      * Body: {session_token, numeral, answer}
      * Validates the answer, updates session state.
      */
-    public function answer(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function answer(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -211,7 +211,7 @@ final class AgimController
      * Body: {session_token}
      * Returns teaching data for all numbers in the level.
      */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -268,7 +268,7 @@ final class AgimController
     }
 
     /** GET /api/games/agim/stats — auth required (enforced at route level). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(
             GameStatsCalculator::build($this->entityTypeManager, $account, 'agim', ['abandoned'], ['completed']),

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -14,7 +14,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Minoo\Middleware\RateLimitMiddleware;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\User\User;
 
 final class AuthController
@@ -27,7 +28,7 @@ final class AuthController
         private readonly AuthConfig $authConfig,
     ) {}
 
-    public function loginForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function loginForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('auth/login.html.twig', LayoutTwigContext::withAccount($account, [
             'errors' => [],
@@ -35,10 +36,10 @@ final class AuthController
             'redirect' => (string) $request->query->get('redirect', ''),
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function submitLogin(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitLogin(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $limiter = new RateLimitMiddleware(
             getenv('WAASEYAA_DB') ?: dirname(__DIR__, 2) . '/storage/waaseyaa.sqlite'
@@ -50,7 +51,7 @@ final class AuthController
                 'errors' => ['email' => 'Too many attempts. Please try again in 5 minutes.'],
                 'values' => [],
             ]));
-            return new SsrResponse(content: $html, statusCode: 429);
+            return new Response($html, 429);
         }
         $limiter->record($ip, '/login');
 
@@ -70,7 +71,7 @@ final class AuthController
                 'errors' => $errors,
                 'values' => compact('email'),
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $storage = $this->entityTypeManager->getStorage('user');
@@ -83,7 +84,7 @@ final class AuthController
                 'errors' => ['email' => 'Invalid email or password.'],
                 'values' => compact('email'),
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         /** @var User|null $user */
@@ -94,7 +95,7 @@ final class AuthController
                 'errors' => ['email' => 'Invalid email or password.'],
                 'values' => compact('email'),
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         if (!$user->isActive()) {
@@ -102,7 +103,7 @@ final class AuthController
                 'errors' => ['email' => 'This account has been deactivated.'],
                 'values' => compact('email'),
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $_SESSION['waaseyaa_uid'] = $user->id();
@@ -114,20 +115,20 @@ final class AuthController
             '/',
         );
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $redirect]);
+        return new RedirectResponse($redirect);
     }
 
-    public function registerForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function registerForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('auth/register.html.twig', LayoutTwigContext::withAccount($account, [
             'errors' => [],
             'values' => [],
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function submitRegister(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitRegister(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $name = trim((string) $request->request->get('name', ''));
         $email = trim((string) $request->request->get('email', ''));
@@ -152,7 +153,7 @@ final class AuthController
                 'errors' => $errors,
                 'values' => compact('name', 'email', 'phone'),
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $storage = $this->entityTypeManager->getStorage('user');
@@ -169,12 +170,12 @@ final class AuthController
                 $token = $this->tokenRepo->createToken($existingUser->id(), 'email_verification', $this->authConfig->tokenTtl('email_verification'));
                 $this->authMailer->sendEmailVerification($existingUser, $token);
                 $html = $this->twig->render('auth/check-email.html.twig', LayoutTwigContext::withAccount($account, []));
-                return new SsrResponse(content: $html);
+                return new Response($html);
             }
 
             // Active account — show generic check-email page to prevent enumeration
             $html = $this->twig->render('auth/check-email.html.twig', LayoutTwigContext::withAccount($account, []));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         /** @var User $user */
@@ -203,19 +204,19 @@ final class AuthController
 
         Flash::success('Welcome to Minoo, ' . $name . '.');
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/']);
+        return new RedirectResponse('/');
     }
 
-    public function forgotPasswordForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function forgotPasswordForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('auth/forgot-password.html.twig', LayoutTwigContext::withAccount($account, [
             'values' => [],
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function submitForgotPassword(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitForgotPassword(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $limiter = new RateLimitMiddleware(
             getenv('WAASEYAA_DB') ?: dirname(__DIR__, 2) . '/storage/waaseyaa.sqlite'
@@ -228,7 +229,7 @@ final class AuthController
                 'submitted' => true,
                 'values' => [],
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
         $limiter->record($ip, '/forgot-password');
 
@@ -256,10 +257,10 @@ final class AuthController
             'values' => compact('email'),
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function resetPasswordForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function resetPasswordForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = (string) $request->query->get('token', '');
         $tokenError = null;
@@ -279,10 +280,10 @@ final class AuthController
             'errors' => [],
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function submitResetPassword(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitResetPassword(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = (string) $request->request->get('token', '');
         $password = (string) $request->request->get('password', '');
@@ -296,7 +297,7 @@ final class AuthController
                 'token_error' => 'This reset link is invalid or has expired.',
                 'errors' => [],
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $userId = $result['user_id'];
@@ -317,7 +318,7 @@ final class AuthController
                 'token_error' => null,
                 'errors' => $errors,
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $storage = $this->entityTypeManager->getStorage('user');
@@ -330,7 +331,7 @@ final class AuthController
                 'token_error' => 'User account not found.',
                 'errors' => [],
             ]));
-            return new SsrResponse(content: $html);
+            return new Response($html);
         }
 
         $user->setRawPassword($password);
@@ -339,10 +340,10 @@ final class AuthController
 
         Flash::success('Your password has been reset. Please sign in.');
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/login']);
+        return new RedirectResponse('/login');
     }
 
-    public function verifyEmail(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function verifyEmail(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = (string) $request->query->get('token', '');
 
@@ -351,7 +352,7 @@ final class AuthController
                 'verified' => false,
                 'error' => 'This verification link is invalid or has expired.',
             ]));
-            return new SsrResponse(content: $html, statusCode: 400);
+            return new Response($html, 400);
         }
 
         $result = $this->tokenRepo->validateToken($token, 'email_verification');
@@ -361,7 +362,7 @@ final class AuthController
                 'verified' => false,
                 'error' => 'This verification link is invalid or has expired.',
             ]));
-            return new SsrResponse(content: $html, statusCode: 400);
+            return new Response($html, 400);
         }
 
         $userId = $result['user_id'];
@@ -374,7 +375,7 @@ final class AuthController
                 'verified' => false,
                 'error' => 'User account not found.',
             ]));
-            return new SsrResponse(content: $html, statusCode: 404);
+            return new Response($html, 404);
         }
 
         $user->set('status', true);
@@ -390,16 +391,16 @@ final class AuthController
         $html = $this->twig->render('auth/verify-email.html.twig', LayoutTwigContext::withAccount($account, [
             'verified' => true,
         ]));
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function logout(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function logout(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (session_status() === \PHP_SESSION_ACTIVE) {
             session_destroy();
         }
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/']);
+        return new RedirectResponse('/');
     }
 
     private function safeRedirect(string $target, string $fallback): string

--- a/src/Controller/BlockController.php
+++ b/src/Controller/BlockController.php
@@ -9,7 +9,7 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Api\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class BlockController
 {
@@ -18,7 +18,7 @@ final class BlockController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->blockStorage();
         $ids = $storage->getQuery()
@@ -38,7 +38,7 @@ final class BlockController
         return $this->json(['blocks' => $payload]);
     }
 
-    public function store(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function store(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $blockedId = (int) ($data['blocked_id'] ?? 0);
@@ -79,7 +79,7 @@ final class BlockController
         return $this->json(['id' => (int) $block->id()], 201);
     }
 
-    public function delete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function delete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $blockedUserId = (int) ($params['user_id'] ?? 0);
         $blockerId = (int) $account->id();

--- a/src/Controller/BusinessController.php
+++ b/src/Controller/BusinessController.php
@@ -11,7 +11,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class BusinessController
 {
@@ -22,7 +22,7 @@ final class BusinessController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('group');
         $ids = $storage->getQuery()
@@ -50,12 +50,12 @@ final class BusinessController
             'communities' => $communities,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('group');
@@ -139,10 +139,7 @@ final class BusinessController
             'image_credit' => $imageCredit,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $business !== null ? 200 : 404,
-        );
+        return new Response($html, $business !== null ? 200 : 404);
     }
 
     /**

--- a/src/Controller/CommunityController.php
+++ b/src/Controller/CommunityController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Geo\GeoDistance;
 
 final class CommunityController
@@ -25,7 +25,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('community');
         $location = $this->resolveLocation($request);
@@ -112,7 +112,7 @@ final class CommunityController
             'businesses_json' => json_encode($businessesJson, JSON_HEX_TAG | JSON_HEX_AMP | JSON_THROW_ON_ERROR),
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     private const NEARBY_LIMIT = 6;
@@ -120,7 +120,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('community');
@@ -138,7 +138,7 @@ final class CommunityController
                 'location_json' => 'null',
             ]));
 
-            return new SsrResponse(content: $html, statusCode: 404);
+            return new Response($html, 404);
         }
 
         $nearby = [];
@@ -221,7 +221,7 @@ final class CommunityController
             'local_people' => $localPeople,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /**

--- a/src/Controller/ContributorController.php
+++ b/src/Controller/ContributorController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ContributorController
 {
@@ -20,7 +20,7 @@ final class ContributorController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('contributor');
         $ids = $storage->getQuery()
@@ -35,12 +35,12 @@ final class ContributorController
             'contributors' => $contributors,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('contributor');
@@ -56,9 +56,6 @@ final class ContributorController
             'contributor' => $contributor,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $contributor !== null ? 200 : 404,
-        );
+        return new Response($html, $contributor !== null ? 200 : 404);
     }
 }

--- a/src/Controller/CoordinatorDashboardController.php
+++ b/src/Controller/CoordinatorDashboardController.php
@@ -12,7 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class CoordinatorDashboardController
 {
@@ -21,7 +22,7 @@ final class CoordinatorDashboardController
         private readonly Environment $twig,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $requestStorage = $this->entityTypeManager->getStorage('elder_support_request');
 
@@ -84,11 +85,11 @@ final class CoordinatorDashboardController
             'pending_application_count' => $pendingApplicationCount,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
-    public function applications(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function applications(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('volunteer');
         $ids = $storage->getQuery()
@@ -102,17 +103,17 @@ final class CoordinatorDashboardController
             'applications' => $applications,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
-    public function approveApplication(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function approveApplication(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $volunteer = $this->loadVolunteerByUuid($params['uuid'] ?? '');
 
         if ($volunteer === null || $volunteer->get('status') !== 'pending') {
             Flash::error('Application not found or already processed.');
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator/applications']);
+            return new RedirectResponse('/dashboard/coordinator/applications');
         }
 
         $volunteer->set('status', 'active');
@@ -132,17 +133,17 @@ final class CoordinatorDashboardController
         }
 
         Flash::success('Volunteer application approved.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator/applications']);
+        return new RedirectResponse('/dashboard/coordinator/applications');
     }
 
     /** @param array<string, mixed> $params */
-    public function denyApplication(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function denyApplication(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $volunteer = $this->loadVolunteerByUuid($params['uuid'] ?? '');
 
         if ($volunteer === null || $volunteer->get('status') !== 'pending') {
             Flash::error('Application not found or already processed.');
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator/applications']);
+            return new RedirectResponse('/dashboard/coordinator/applications');
         }
 
         $volunteer->set('status', 'denied');
@@ -150,7 +151,7 @@ final class CoordinatorDashboardController
         $this->entityTypeManager->getStorage('volunteer')->save($volunteer);
 
         Flash::info('Volunteer application denied.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator/applications']);
+        return new RedirectResponse('/dashboard/coordinator/applications');
     }
 
     private function loadVolunteerByUuid(string $uuid): ?EntityInterface

--- a/src/Controller/CrosswordController.php
+++ b/src/Controller/CrosswordController.php
@@ -12,7 +12,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class CrosswordController
 {
@@ -30,16 +30,16 @@ final class CrosswordController
     }
 
     /** Render the crossword game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('crossword.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/crossword',
         ]));
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** GET /api/games/crossword/daily — today's puzzle. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $puzzleId = "daily-{$today}";
@@ -72,7 +72,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/random — random practice puzzle. */
-    public function random(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function random(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $tier = $query['tier'] ?? 'easy';
         if (!in_array($tier, ['easy', 'medium', 'hard'], true)) {
@@ -119,7 +119,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/themes — list theme packs with progress. */
-    public function themes(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function themes(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
         $allIds = $puzzleStorage->getQuery()->execute();
@@ -172,7 +172,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/theme/{slug} — next unsolved puzzle in theme. */
-    public function theme(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function theme(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         if ($slug === '') {
@@ -244,7 +244,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/check — validate a word. */
-    public function check(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function check(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -326,7 +326,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/complete — submit finished puzzle. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -415,13 +415,13 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/stats — player stats (auth required). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'crossword', ['abandoned'], ['completed']));
     }
 
     /** POST /api/games/crossword/hint — reveal a letter (tracked server-side). */
-    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -477,7 +477,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/abandon — give up on current puzzle. */
-    public function abandon(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function abandon(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';

--- a/src/Controller/ElderSupportController.php
+++ b/src/Controller/ElderSupportController.php
@@ -10,7 +10,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ElderSupportController
 {
@@ -21,7 +22,7 @@ final class ElderSupportController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function requestForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function requestForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $location = $this->resolveLocation($request);
 
@@ -31,12 +32,12 @@ final class ElderSupportController
             'location' => $location,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function submitRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $name = trim((string) $request->request->get('name', ''));
         $phone = trim((string) $request->request->get('phone', ''));
@@ -73,7 +74,7 @@ final class ElderSupportController
                 'values' => compact('name', 'phone', 'community', 'type', 'notes', 'isRepresentative', 'elderName', 'consent'),
             ]));
 
-            return new SsrResponse(content: $html, statusCode: 422);
+            return new Response($html, 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
@@ -94,16 +95,12 @@ final class ElderSupportController
 
         Flash::success('Your request has been submitted. A coordinator will be in touch.');
 
-        return new SsrResponse(
-            content: '',
-            statusCode: 302,
-            headers: ['Location' => '/elders/request/' . $entity->uuid()],
-        );
+        return new RedirectResponse('/elders/request/' . $entity->uuid());
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function requestDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function requestDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $uuid = $params['uuid'] ?? '';
         $entity = null;
@@ -120,10 +117,7 @@ final class ElderSupportController
             'entity' => $entity,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $entity !== null ? 200 : 404,
-        );
+        return new Response($html, $entity !== null ? 200 : 404);
     }
 
     private function resolveLocation(HttpRequest $request): \Minoo\Domain\Geo\ValueObject\LocationContext

--- a/src/Controller/ElderSupportWorkflowController.php
+++ b/src/Controller/ElderSupportWorkflowController.php
@@ -8,7 +8,8 @@ use Waaseyaa\SSR\Flash\Flash;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ElderSupportWorkflowController
 {
@@ -16,10 +17,10 @@ final class ElderSupportWorkflowController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function assignVolunteer(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function assignVolunteer(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (!in_array('elder_coordinator', $account->getRoles(), true) && !$account->hasPermission('administer content')) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         $esrid = (int) ($params['esrid'] ?? 0);
@@ -29,14 +30,14 @@ final class ElderSupportWorkflowController
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $volunteerStorage = $this->entityTypeManager->getStorage('volunteer');
         $volunteer = $volunteerId > 0 ? $volunteerStorage->load($volunteerId) : null;
 
         if ($volunteer === null) {
-            return new SsrResponse(content: 'Volunteer not found', statusCode: 404);
+            return new Response('Volunteer not found', 404);
         }
 
         $entity->set('assigned_volunteer', $volunteerId);
@@ -46,10 +47,10 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Volunteer assigned successfully.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator']);
+        return new RedirectResponse('/dashboard/coordinator');
     }
 
-    public function startRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function startRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->volunteerTransition(
             $params,
@@ -60,22 +61,22 @@ final class ElderSupportWorkflowController
         );
     }
 
-    public function completeRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function completeRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $esrid = (int) ($params['esrid'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         if ($entity->get('assigned_volunteer') !== $account->id()) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         if ($entity->get('status') !== 'in_progress') {
-            return new SsrResponse(content: 'Invalid status transition', statusCode: 422);
+            return new Response('Invalid status transition', 422);
         }
 
         $notes = trim((string) $request->request->get('completion_notes', ''));
@@ -88,13 +89,13 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Request marked as complete. The coordinator will follow up.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+        return new RedirectResponse('/dashboard/volunteer');
     }
 
-    public function confirmRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function confirmRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (!in_array('elder_coordinator', $account->getRoles(), true) && !$account->hasPermission('administer content')) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         $esrid = (int) ($params['esrid'] ?? 0);
@@ -102,11 +103,11 @@ final class ElderSupportWorkflowController
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         if ($entity->get('status') !== 'completed') {
-            return new SsrResponse(content: 'Invalid status transition', statusCode: 422);
+            return new Response('Invalid status transition', 422);
         }
 
         $entity->set('status', 'confirmed');
@@ -114,13 +115,13 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Request marked as confirmed. Thank you for following up.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator']);
+        return new RedirectResponse('/dashboard/coordinator');
     }
 
-    public function cancelRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function cancelRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (!in_array('elder_coordinator', $account->getRoles(), true) && !$account->hasPermission('administer content')) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         $esrid = (int) ($params['esrid'] ?? 0);
@@ -128,12 +129,12 @@ final class ElderSupportWorkflowController
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $status = $entity->get('status');
         if (!in_array($status, ['open', 'assigned'], true)) {
-            return new SsrResponse(content: 'Invalid status transition', statusCode: 422);
+            return new Response('Invalid status transition', 422);
         }
 
         $reason = trim((string) $request->request->get('reason', ''));
@@ -144,25 +145,25 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Request cancelled.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator']);
+        return new RedirectResponse('/dashboard/coordinator');
     }
 
-    public function declineRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function declineRequest(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $esrid = (int) ($params['esrid'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         if ($entity->get('assigned_volunteer') !== $account->id()) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         if ($entity->get('status') !== 'assigned') {
-            return new SsrResponse(content: 'Invalid status transition', statusCode: 422);
+            return new Response('Invalid status transition', 422);
         }
 
         $entity->set('status', 'open');
@@ -172,13 +173,13 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Request declined. The coordinator has been notified.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+        return new RedirectResponse('/dashboard/volunteer');
     }
 
-    public function reassignVolunteer(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function reassignVolunteer(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (!in_array('elder_coordinator', $account->getRoles(), true) && !$account->hasPermission('administer content')) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         $esrid = (int) ($params['esrid'] ?? 0);
@@ -188,14 +189,14 @@ final class ElderSupportWorkflowController
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $volunteerStorage = $this->entityTypeManager->getStorage('volunteer');
         $volunteer = $volunteerId > 0 ? $volunteerStorage->load($volunteerId) : null;
 
         if ($volunteer === null) {
-            return new SsrResponse(content: 'Volunteer not found', statusCode: 404);
+            return new Response('Volunteer not found', 404);
         }
 
         $entity->set('assigned_volunteer', $volunteerId);
@@ -205,7 +206,7 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success('Request reassigned.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/coordinator']);
+        return new RedirectResponse('/dashboard/coordinator');
     }
 
     private function volunteerTransition(
@@ -214,22 +215,22 @@ final class ElderSupportWorkflowController
         string $fromStatus,
         string $toStatus,
         string $message,
-    ): SsrResponse
+    ): Response
     {
         $esrid = (int) ($params['esrid'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
         $entity = $esrid > 0 ? $storage->load($esrid) : null;
 
         if ($entity === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         if ($entity->get('assigned_volunteer') !== $account->id()) {
-            return new SsrResponse(content: 'Forbidden', statusCode: 403);
+            return new Response('Forbidden', 403);
         }
 
         if ($entity->get('status') !== $fromStatus) {
-            return new SsrResponse(content: 'Invalid status transition', statusCode: 422);
+            return new Response('Invalid status transition', 422);
         }
 
         $entity->set('status', $toStatus);
@@ -237,6 +238,6 @@ final class ElderSupportWorkflowController
         $storage->save($entity);
 
         Flash::success($message);
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+        return new RedirectResponse('/dashboard/volunteer');
     }
 }

--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -10,7 +10,7 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Api\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Media\UploadHandler;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class EngagementController
 {
@@ -27,7 +27,7 @@ final class EngagementController
         private readonly UploadHandler $uploadHandler,
     ) {}
 
-    public function react(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function react(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -58,7 +58,7 @@ final class EngagementController
         return $this->json(['id' => $entity->id(), 'reaction_type' => $entity->get('reaction_type')], 201);
     }
 
-    public function deleteReaction(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function deleteReaction(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('reaction');
@@ -77,7 +77,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function comment(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function comment(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -115,7 +115,7 @@ final class EngagementController
         ], 201);
     }
 
-    public function deleteComment(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function deleteComment(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('comment');
@@ -134,7 +134,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function getComments(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function getComments(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $targetType = $params['target_type'] ?? '';
         if (!$this->isValidTargetType($targetType)) {
@@ -166,7 +166,7 @@ final class EngagementController
         return $this->json(['comments' => $items]);
     }
 
-    public function follow(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function follow(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -194,7 +194,7 @@ final class EngagementController
         return $this->json(['id' => $entity->id()], 201);
     }
 
-    public function deleteFollow(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function deleteFollow(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('follow');
@@ -213,7 +213,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function createPost(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function createPost(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         // Support both JSON and multipart form data
         // Try JSON first (existing API), fall back to form data (multipart with images)
@@ -342,7 +342,7 @@ final class EngagementController
         return is_string($mimeType) ? $mimeType : '';
     }
 
-    public function deletePost(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function deletePost(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('post');

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -11,7 +11,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class EventController
 {
@@ -22,7 +22,7 @@ final class EventController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('event');
         $ids = $storage->getQuery()
@@ -49,12 +49,12 @@ final class EventController
             'communities' => $communities,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('event');
@@ -129,10 +129,7 @@ final class EventController
             'image_credit' => $imageCredit,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $event !== null ? 200 : 404,
-        );
+        return new Response($html, $event !== null ? 200 : 404);
     }
 
     /**

--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -13,7 +13,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class FeedController
 {
@@ -23,7 +24,7 @@ final class FeedController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $resolved = self::resolveFilter($query['filter'] ?? 'all');
         $ctx = $this->buildContext($request, $query, $account, $resolved['filter']);
@@ -55,10 +56,10 @@ final class FeedController
             $headers['Set-Cookie'] = "minoo_fv=1; Path=/; Expires={$expires}; SameSite=Lax";
         }
 
-        return new SsrResponse(content: $html, headers: $headers);
+        return new Response($html, 200, $headers);
     }
 
-    public function api(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function api(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $ctx = $this->buildContext($request, $query, $account);
         $response = $this->assembler->assemble($ctx);
@@ -75,14 +76,10 @@ final class FeedController
             'activeFilter' => $response->activeFilter,
         ], JSON_THROW_ON_ERROR);
 
-        return new SsrResponse(
-            content: $json,
-            statusCode: 200,
-            headers: ['Content-Type' => 'application/json'],
-        );
+        return new Response($json, 200, ['Content-Type' => 'application/json']);
     }
 
-    public function explore(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function explore(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $type = $query['type'] ?? 'all';
         $q = trim($query['q'] ?? '');
@@ -100,7 +97,7 @@ final class FeedController
             $target .= '?' . http_build_query(['q' => $q]);
         }
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $target]);
+        return new RedirectResponse($target);
     }
 
     /**

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class GroupController
 {
@@ -21,7 +21,7 @@ final class GroupController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('group');
         $ids = $storage->getQuery()
@@ -49,12 +49,12 @@ final class GroupController
             'communities' => $communities,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('group');
@@ -114,9 +114,6 @@ final class GroupController
             'related_teachings' => $relatedTeachings,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $group !== null ? 200 : 404,
-        );
+        return new Response($html, $group !== null ? 200 : 404);
     }
 }

--- a/src/Controller/IngestionApiController.php
+++ b/src/Controller/IngestionApiController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Api\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class IngestionApiController
 {
@@ -21,7 +21,7 @@ final class IngestionApiController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function status(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function status(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $status = $this->readNcStatusFile();
         if ($status === null) {
@@ -31,7 +31,7 @@ final class IngestionApiController
         return $this->json(['status' => $status]);
     }
 
-    public function ingestEnvelope(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function ingestEnvelope(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $payload = $this->jsonBody($request);
         if ($payload === []) {
@@ -53,17 +53,17 @@ final class IngestionApiController
         ], 201);
     }
 
-    public function approve(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function approve(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->updateStatus((int) ($params['id'] ?? 0), IngestStatus::Approved->value, (int) $account->id());
     }
 
-    public function reject(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function reject(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->updateStatus((int) ($params['id'] ?? 0), 'rejected', (int) $account->id());
     }
 
-    public function materialize(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function materialize(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -104,7 +104,7 @@ final class IngestionApiController
         ]);
     }
 
-    private function updateStatus(int $id, string $status, int $reviewedBy): SsrResponse
+    private function updateStatus(int $id, string $status, int $reviewedBy): Response
     {
         if ($id <= 0) {
             return $this->json(['error' => 'Invalid id.'], 422);

--- a/src/Controller/IngestionDashboardController.php
+++ b/src/Controller/IngestionDashboardController.php
@@ -10,7 +10,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class IngestionDashboardController
 {
@@ -22,7 +22,7 @@ final class IngestionDashboardController
     ) {}
 
     /** @param array<string, string> $params */
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('ingest_log');
 
@@ -40,7 +40,7 @@ final class IngestionDashboardController
             'hide_sidebar' => true,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     private function resolveStatusFilter(array $query): ?string

--- a/src/Controller/JourneyController.php
+++ b/src/Controller/JourneyController.php
@@ -13,7 +13,7 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Api\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * JourneyController — Routes for Minoo's Journey hidden-object game.
@@ -45,18 +45,18 @@ class JourneyController
     // ── Page ──────────────────────────────────────────────────────────────
 
     /** GET /games/journey */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('journey.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/journey',
         ]));
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     // ── Scene listing and loading ─────────────────────────────────────────
 
     /** GET /api/games/journey/scenes — list all scenes (no hotspot coords). */
-    public function scenes(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function scenes(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(['scenes' => JourneyEngine::listScenes()]);
     }
@@ -67,7 +67,7 @@ class JourneyController
      * Returns scene data safe for the client (no hotspot coordinates) plus
      * a session token used for all subsequent tap/hint/complete calls.
      */
-    public function scene(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function scene(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         if ($slug === '') {
@@ -99,7 +99,7 @@ class JourneyController
      * The client never receives hotspot coordinates. It sends where the
      * player tapped; the server decides if it hit anything.
      */
-    public function tap(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function tap(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -170,7 +170,7 @@ class JourneyController
      * hint ("top-left", "bottom-right", etc.) — enough for the player to
      * narrow the search without revealing the exact location.
      */
-    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -232,7 +232,7 @@ class JourneyController
      * Called when the client detects scene_complete in a tap response.
      * Returns star rating, narrative card, and homestead unlock (if any).
      */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -279,7 +279,7 @@ class JourneyController
     // ── Stats ─────────────────────────────────────────────────────────────
 
     /** GET /api/games/journey/stats */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'journey', ['abandoned'], ['completed']));
     }

--- a/src/Controller/LanguageController.php
+++ b/src/Controller/LanguageController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class LanguageController
 {
@@ -25,7 +25,7 @@ final class LanguageController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $page = max(1, (int) ($query['page'] ?? 1));
         $offset = ($page - 1) * self::PAGE_SIZE;
@@ -51,12 +51,12 @@ final class LanguageController
             'total_entries' => $total,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('dictionary_entry');
@@ -76,15 +76,12 @@ final class LanguageController
             'inflected_forms' => $entry !== null ? $this->parseInflectedForms((string) $entry->get('inflected_forms')) : [],
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $entry !== null ? 200 : 404,
-        );
+        return new Response($html, $entry !== null ? 200 : 404);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function search(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function search(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $q = trim((string) ($query['q'] ?? ''));
 
@@ -106,7 +103,7 @@ final class LanguageController
             'search_total' => $searchTotal,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /**

--- a/src/Controller/MatcherController.php
+++ b/src/Controller/MatcherController.php
@@ -12,7 +12,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class MatcherController
 {
@@ -30,17 +30,17 @@ final class MatcherController
     }
 
     /** Render the game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('matcher.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/matcher',
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** GET /api/games/matcher/daily — today's matching pairs. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $difficulty = 'easy';
@@ -71,7 +71,7 @@ final class MatcherController
     }
 
     /** GET /api/games/matcher/practice — random pairs by difficulty. */
-    public function practice(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function practice(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $difficulty = $query['difficulty'] ?? 'easy';
         if (!in_array($difficulty, ['easy', 'medium', 'hard'], true)) {
@@ -107,7 +107,7 @@ final class MatcherController
     }
 
     /** POST /api/games/matcher/match — validate a single match attempt. */
-    public function match(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function match(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -152,7 +152,7 @@ final class MatcherController
     }
 
     /** POST /api/games/matcher/complete — finish game, record stats. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -201,7 +201,7 @@ final class MatcherController
     }
 
     /** GET /api/games/matcher/stats — player stats. */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build(
             $this->entityTypeManager,

--- a/src/Controller/MessagingController.php
+++ b/src/Controller/MessagingController.php
@@ -11,7 +11,7 @@ use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Mercure\MercurePublisher;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class MessagingController
 {
@@ -21,7 +21,7 @@ final class MessagingController
         private readonly ?MercurePublisher $mercurePublisher = null,
     ) {}
 
-    public function editMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function editMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $messageId = (int) ($params['message_id'] ?? 0);
@@ -70,7 +70,7 @@ final class MessagingController
         ]);
     }
 
-    public function deleteMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function deleteMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $messageId = (int) ($params['message_id'] ?? 0);
@@ -102,7 +102,7 @@ final class MessagingController
         return $this->json(['deleted' => true]);
     }
 
-    public function markRead(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function markRead(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -140,7 +140,7 @@ final class MessagingController
         return $this->json(['last_read_at' => $now]);
     }
 
-    public function typing(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function typing(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -158,7 +158,7 @@ final class MessagingController
         return $this->json(['typing' => true]);
     }
 
-    public function unreadCount(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function unreadCount(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $userId = (int) $account->id();
         $participantStorage = $this->participantStorage();
@@ -179,7 +179,7 @@ final class MessagingController
         return $this->json(['unread_count' => $totalUnread]);
     }
 
-    public function indexThreads(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function indexThreads(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $participantStorage = $this->participantStorage();
         $threadStorage = $this->threadStorage();
@@ -233,7 +233,7 @@ final class MessagingController
         return $this->json(['threads' => $payload]);
     }
 
-    public function createThread(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function createThread(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $participantIds = $this->normalizeParticipantIds($data['participant_ids'] ?? []);
@@ -322,7 +322,7 @@ final class MessagingController
         return $this->json(['id' => (int) $thread->id()], 201);
     }
 
-    public function showThread(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function showThread(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isParticipant($threadId, (int) $account->id())) {
@@ -354,7 +354,7 @@ final class MessagingController
         ]);
     }
 
-    public function indexMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function indexMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isParticipant($threadId, (int) $account->id())) {
@@ -415,7 +415,7 @@ final class MessagingController
         return $this->json(['messages' => $payload]);
     }
 
-    public function createMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function createMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -473,7 +473,7 @@ final class MessagingController
         ], 201);
     }
 
-    public function addParticipants(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function addParticipants(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isThreadOwner($threadId, (int) $account->id(), $account)) {
@@ -522,7 +522,7 @@ final class MessagingController
         return $this->json(['added_participant_ids' => $added], 201);
     }
 
-    public function removeParticipant(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function removeParticipant(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $targetUserId = (int) ($params['user_id'] ?? 0);
@@ -557,7 +557,7 @@ final class MessagingController
         return $this->json(['removed' => true]);
     }
 
-    public function searchUsers(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function searchUsers(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $term = mb_strtolower(trim((string) ($query['q'] ?? '')));
         if ($term === '') {
@@ -595,7 +595,7 @@ final class MessagingController
         return $this->json(['users' => $matches]);
     }
 
-    public function searchMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function searchMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $term = trim((string) ($query['q'] ?? ''));
         if ($term === '' || mb_strlen($term) < 2) {

--- a/src/Controller/OralHistoryController.php
+++ b/src/Controller/OralHistoryController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class OralHistoryController
 {
@@ -20,7 +20,7 @@ final class OralHistoryController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $collectionStorage = $this->entityTypeManager->getStorage('oral_history_collection');
         $collectionIds = $collectionStorage->getQuery()
@@ -43,12 +43,12 @@ final class OralHistoryController
             'stories' => $stories,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function collection(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function collection(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $collectionStorage = $this->entityTypeManager->getStorage('oral_history_collection');
@@ -85,15 +85,12 @@ final class OralHistoryController
             'curator' => $curator,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $collection !== null ? 200 : 404,
-        );
+        return new Response($html, $collection !== null ? 200 : 404);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storyStorage = $this->entityTypeManager->getStorage('oral_history');
@@ -155,9 +152,6 @@ final class OralHistoryController
             'next_story' => $nextStory,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $story !== null ? 200 : 404,
-        );
+        return new Response($html, $story !== null ? 200 : 404);
     }
 }

--- a/src/Controller/PeopleController.php
+++ b/src/Controller/PeopleController.php
@@ -10,7 +10,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class PeopleController
 {
@@ -21,7 +21,7 @@ final class PeopleController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('resource_person');
         $queryBuilder = $storage->getQuery()
@@ -78,12 +78,12 @@ final class PeopleController
             'location' => $location,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('resource_person');
@@ -156,10 +156,7 @@ final class PeopleController
             'related_events' => $relatedEvents,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $person !== null ? 200 : 404,
-        );
+        return new Response($html, $person !== null ? 200 : 404);
     }
 
     private function resolveLocation(HttpRequest $request): \Minoo\Domain\Geo\ValueObject\LocationContext

--- a/src/Controller/RoleManagementController.php
+++ b/src/Controller/RoleManagementController.php
@@ -11,7 +11,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\User\User;
 
 final class RoleManagementController
@@ -24,7 +25,7 @@ final class RoleManagementController
         private readonly Environment $twig,
     ) {}
 
-    public function changeRole(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function changeRole(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $targetUid = (int) $params['uid'];
         $action = $request->request->get('action', '');
@@ -35,13 +36,13 @@ final class RoleManagementController
             || !in_array($role, self::ALLOWED_ROLES, true)) {
             Flash::error('Invalid request.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         if ($targetUid === $account->id()) {
             Flash::error('You cannot modify your own roles.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         $actorRoles = $account->getRoles();
@@ -51,13 +52,13 @@ final class RoleManagementController
         if (!$isCoordinator && !$isAdmin) {
             Flash::error('You do not have permission to manage roles.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/account']);
+            return new RedirectResponse('/account');
         }
 
         if ($role === 'elder_coordinator' && !$isAdmin) {
             Flash::error('Only admins can manage coordinator roles.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         $storage = $this->entityTypeManager->getStorage('user');
@@ -66,13 +67,13 @@ final class RoleManagementController
         if (!$user instanceof User) {
             Flash::error('User not found.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         if (in_array('admin', $user->getRoles(), true)) {
             Flash::error('Admin accounts cannot be modified.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         try {
@@ -90,17 +91,17 @@ final class RoleManagementController
             error_log(sprintf('[RoleManagementController::changeRole] Error: %s', $e->getMessage()));
             Flash::error('Unable to update role. Please try again.');
 
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+            return new RedirectResponse($referrer);
         }
 
         $label = $role === 'elder_coordinator' ? 'Coordinator' : ucfirst($role);
         $verb = $action === 'grant' ? 'granted to' : 'revoked from';
         Flash::success("{$label} role {$verb} " . $user->getName() . '.');
 
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $referrer]);
+        return new RedirectResponse($referrer);
     }
 
-    public function coordinatorList(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function coordinatorList(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $users = $this->loadUserRows($account);
 
@@ -110,10 +111,10 @@ final class RoleManagementController
             'path' => '/dashboard/coordinator/users',
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function adminList(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function adminList(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $users = $this->loadUserRows($account);
 
@@ -123,7 +124,7 @@ final class RoleManagementController
             'path' => '/admin/users',
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /**

--- a/src/Controller/ShkodaController.php
+++ b/src/Controller/ShkodaController.php
@@ -12,7 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ShkodaController
 {
@@ -30,23 +31,23 @@ final class ShkodaController
     }
 
     /** Redirect legacy /games/ishkode URL to /games/shkoda. */
-    public function redirectLegacy(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function redirectLegacy(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        return new SsrResponse(content: '', statusCode: 301, headers: ['Location' => '/games/shkoda']);
+        return new RedirectResponse('/games/shkoda', 301);
     }
 
     /** Render the game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('shkoda.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/shkoda',
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** GET /api/games/shkoda/daily — today's challenge metadata. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $dayOfWeek = (int) date('w');
@@ -114,7 +115,7 @@ final class ShkodaController
     }
 
     /** GET /api/games/shkoda/word — random word for practice/streak. */
-    public function word(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function word(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $mode = ($query['mode'] ?? 'practice') === 'streak' ? 'streak' : 'practice';
         $tier = $query['tier'] ?? 'easy';
@@ -173,7 +174,7 @@ final class ShkodaController
     }
 
     /** POST /api/games/shkoda/guess — validate a letter (daily mode only). */
-    public function guess(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function guess(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -253,7 +254,7 @@ final class ShkodaController
     }
 
     /** POST /api/games/shkoda/complete — submit completed game, get teaching data + stats. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -321,7 +322,7 @@ final class ShkodaController
     }
 
     /** GET /api/games/shkoda/stats — player stats (auth required). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'shkoda'));
     }

--- a/src/Controller/TeachingController.php
+++ b/src/Controller/TeachingController.php
@@ -11,7 +11,7 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class TeachingController
 {
@@ -22,7 +22,7 @@ final class TeachingController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('teaching');
         $ids = $storage->getQuery()
@@ -50,12 +50,12 @@ final class TeachingController
             'communities' => $communities,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('teaching');
@@ -123,10 +123,7 @@ final class TeachingController
             'image_credit' => $imageCredit,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $teaching !== null ? 200 : 404,
-        );
+        return new Response($html, $teaching !== null ? 200 : 404);
     }
 
     /**

--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -9,7 +9,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\SSR\Flash\Flash;
 
 final class VolunteerController
@@ -24,11 +25,11 @@ final class VolunteerController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function signupForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function signupForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if ($account->isAuthenticated() && $this->hasExistingVolunteer($account)) {
             Flash::info("You're already registered as a volunteer.");
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+            return new RedirectResponse('/dashboard/volunteer');
         }
 
         $location = $this->resolveLocation($request);
@@ -39,12 +40,12 @@ final class VolunteerController
             'location' => $location,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function submitSignup(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitSignup(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $name = trim((string) $request->request->get('name', ''));
         $phone = trim((string) $request->request->get('phone', ''));
@@ -58,7 +59,7 @@ final class VolunteerController
 
         if ($account->isAuthenticated() && $this->hasExistingVolunteer($account)) {
             Flash::info("You're already registered as a volunteer.");
-            return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+            return new RedirectResponse('/dashboard/volunteer');
         }
 
         $errors = [];
@@ -82,7 +83,7 @@ final class VolunteerController
                 'values' => compact('name', 'phone', 'community', 'availability', 'skills', 'notes', 'maxTravelKm'),
             ]));
 
-            return new SsrResponse(content: $html, statusCode: 422);
+            return new Response($html, 422);
         }
 
         $storage = $this->entityTypeManager->getStorage('volunteer');
@@ -106,16 +107,12 @@ final class VolunteerController
         $entity = $storage->create($values);
         $storage->save($entity);
 
-        return new SsrResponse(
-            content: '',
-            statusCode: 302,
-            headers: ['Location' => '/elders/volunteer/' . $entity->uuid()],
-        );
+        return new RedirectResponse('/elders/volunteer/' . $entity->uuid());
     }
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function signupDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function signupDetail(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $uuid = $params['uuid'] ?? '';
         $entity = null;
@@ -132,10 +129,7 @@ final class VolunteerController
             'entity' => $entity,
         ]));
 
-        return new SsrResponse(
-            content: $html,
-            statusCode: $entity !== null ? 200 : 404,
-        );
+        return new Response($html, $entity !== null ? 200 : 404);
     }
 
     private function hasExistingVolunteer(AccountInterface $account): bool

--- a/src/Controller/VolunteerDashboardController.php
+++ b/src/Controller/VolunteerDashboardController.php
@@ -10,7 +10,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\SSR\SsrResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class VolunteerDashboardController
 {
@@ -19,7 +20,7 @@ final class VolunteerDashboardController
         private readonly Environment $twig,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('elder_support_request');
 
@@ -47,14 +48,14 @@ final class VolunteerDashboardController
             'volunteer' => $volunteer,
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function editForm(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function editForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $volunteer = $this->findVolunteerByAccount($account);
         if ($volunteer === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $html = $this->twig->render('dashboard/volunteer-edit.html.twig', LayoutTwigContext::withAccount($account, [
@@ -63,14 +64,14 @@ final class VolunteerDashboardController
             'values' => [],
         ]));
 
-        return new SsrResponse(content: $html);
+        return new Response($html);
     }
 
-    public function submitEdit(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function submitEdit(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $volunteer = $this->findVolunteerByAccount($account);
         if ($volunteer === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $phone = trim((string) $request->request->get('phone', ''));
@@ -92,7 +93,7 @@ final class VolunteerDashboardController
                     'notes' => trim((string) $request->request->get('notes', '')),
                 ],
             ]));
-            return new SsrResponse(content: $html, statusCode: 422);
+            return new Response($html, 422);
         }
 
         $volunteer->set('phone', $phone);
@@ -116,14 +117,14 @@ final class VolunteerDashboardController
         $storage->save($volunteer);
 
         Flash::success('Your profile has been updated.');
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+        return new RedirectResponse('/dashboard/volunteer');
     }
 
-    public function toggleAvailability(array $params, array $query, AccountInterface $account, HttpRequest $request): SsrResponse
+    public function toggleAvailability(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $volunteer = $this->findVolunteerByAccount($account);
         if ($volunteer === null) {
-            return new SsrResponse(content: 'Not found', statusCode: 404);
+            return new Response('Not found', 404);
         }
 
         $newStatus = $volunteer->get('status') === 'active' ? 'unavailable' : 'active';
@@ -135,7 +136,7 @@ final class VolunteerDashboardController
 
         $message = $newStatus === 'active' ? 'You are now active.' : 'You are now unavailable.';
         Flash::success($message);
-        return new SsrResponse(content: '', statusCode: 302, headers: ['Location' => '/dashboard/volunteer']);
+        return new RedirectResponse('/dashboard/volunteer');
     }
 
     private function findVolunteerByAccount(AccountInterface $account): ?\Waaseyaa\Entity\ContentEntityBase

--- a/tests/Minoo/Unit/Controller/AccountHomeControllerTest.php
+++ b/tests/Minoo/Unit/Controller/AccountHomeControllerTest.php
@@ -48,7 +48,7 @@ final class AccountHomeControllerTest extends TestCase
         $controller = $this->createController($twig);
         $response = $controller->index([], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -70,7 +70,7 @@ final class AccountHomeControllerTest extends TestCase
         $controller = $this->createController($twig);
         $response = $controller->index([], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -139,8 +139,8 @@ final class AccountHomeControllerTest extends TestCase
         $_SESSION = [];
         $response = $controller->toggleElder([], [], $account, HttpRequest::create('/account/elder-toggle', 'POST'));
 
-        $this->assertSame(302, $response->statusCode);
-        $this->assertSame('/account', $response->headers['Location']);
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/account', $response->headers->get('Location'));
         $this->assertTrue(ElderIdentity::isElder($user));
     }
 
@@ -163,7 +163,7 @@ final class AccountHomeControllerTest extends TestCase
         $_SESSION = [];
         $response = $controller->toggleElder([], [], $account, HttpRequest::create('/account/elder-toggle', 'POST'));
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertFalse(ElderIdentity::isElder($user));
     }
 }

--- a/tests/Minoo/Unit/Controller/AgimControllerTest.php
+++ b/tests/Minoo/Unit/Controller/AgimControllerTest.php
@@ -71,8 +71,8 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->start([], ['level' => '1'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $body = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
         $this->assertSame('abc-123', $body['session_token']);
         $this->assertSame(1, $body['level']);
         $this->assertSame(5, $body['total']);
@@ -89,7 +89,7 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->start([], ['level' => '99'], $this->account, $this->request);
 
-        $body = json_decode($response->content, true);
+        $body = json_decode($response->getContent(), true);
         $this->assertSame(1, $body['level']);
         $this->assertSame(5, $body['total']);
     }
@@ -129,7 +129,7 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->start([], ['level' => '4'], $this->account, $this->request);
 
-        $body = json_decode($response->content, true);
+        $body = json_decode($response->getContent(), true);
         $this->assertSame(19, $body['total']);
         $this->assertSame(4, $body['level']);
         $this->assertSame('streak', $createdValues['difficulty_tier']);
@@ -146,8 +146,8 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->prompt([], ['session_token' => 'tok-1'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $body = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
         $this->assertSame(3, $body['numeral']);
         $this->assertSame(3, $body['remaining']);
     }
@@ -160,7 +160,7 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->prompt([], ['session_token' => 'bad-token'], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -175,8 +175,8 @@ final class AgimControllerTest extends TestCase
         $request = $this->jsonPost(['session_token' => 'tok-1', 'numeral' => 1, 'answer' => 'bezhig']);
         $response = $controller->answer([], [], $this->account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $body = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
         $this->assertTrue($body['correct']);
         $this->assertSame('bezhig', $body['expected_word']);
         $this->assertSame(2, $body['remaining']);
@@ -194,7 +194,7 @@ final class AgimControllerTest extends TestCase
         $request = $this->jsonPost(['session_token' => 'tok-1', 'numeral' => 1, 'answer' => 'wrong']);
         $response = $controller->answer([], [], $this->account, $request);
 
-        $body = json_decode($response->content, true);
+        $body = json_decode($response->getContent(), true);
         $this->assertFalse($body['correct']);
         $this->assertSame(3, $body['remaining']); // still 3 — numeral re-queued
         $this->assertSame('bezhig', $body['expected_word']);
@@ -212,7 +212,7 @@ final class AgimControllerTest extends TestCase
         $request = $this->jsonPost(['session_token' => 'tok-1', 'numeral' => 2, 'answer' => 'NIIZH']);
         $response = $controller->answer([], [], $this->account, $request);
 
-        $body = json_decode($response->content, true);
+        $body = json_decode($response->getContent(), true);
         $this->assertTrue($body['correct']);
     }
 
@@ -238,7 +238,7 @@ final class AgimControllerTest extends TestCase
         $request = $this->jsonPost(['session_token' => 'tok-1', 'numeral' => 5, 'answer' => 'naanan']);
         $response = $controller->answer([], [], $this->account, $request);
 
-        $body = json_decode($response->content, true);
+        $body = json_decode($response->getContent(), true);
         $this->assertTrue($body['correct']);
         $this->assertSame(0, $body['remaining']);
         $this->assertSame('completed', $setValues['status']);
@@ -265,8 +265,8 @@ final class AgimControllerTest extends TestCase
         $controller = new AgimController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->stats([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $body = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
         $this->assertSame(0, $body['current_streak']);
     }
 

--- a/tests/Minoo/Unit/Controller/AuthControllerTest.php
+++ b/tests/Minoo/Unit/Controller/AuthControllerTest.php
@@ -103,8 +103,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitLogin([], [], $this->account, $this->request);
 
-        self::assertSame(302, $response->statusCode);
-        self::assertSame('/elders/request/42', $response->headers['Location']);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/elders/request/42', $response->headers->get('Location'));
     }
 
     #[Test]
@@ -119,8 +119,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitLogin([], [], $this->account, $this->request);
 
-        self::assertSame(302, $response->statusCode);
-        self::assertSame('/', $response->headers['Location']);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/', $response->headers->get('Location'));
     }
 
     #[Test]
@@ -136,8 +136,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitLogin([], [], $this->account, $this->request);
 
-        self::assertSame(302, $response->statusCode);
-        self::assertSame('/', $response->headers['Location']);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/', $response->headers->get('Location'));
     }
 
     #[Test]
@@ -153,8 +153,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitLogin([], [], $this->account, $this->request);
 
-        self::assertSame(302, $response->statusCode);
-        self::assertSame('/', $response->headers['Location']);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/', $response->headers->get('Location'));
     }
 
     #[Test]
@@ -185,8 +185,8 @@ final class AuthControllerTest extends TestCase
         $response = $this->createController()->submitRegister([], [], $this->account, $this->request);
 
         // Should auto-login and redirect to home
-        self::assertSame(302, $response->statusCode);
-        self::assertSame('/', $response->headers['Location']);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/', $response->headers->get('Location'));
         // Session should be set (auto-login)
         self::assertSame(42, $_SESSION['waaseyaa_uid']);
     }
@@ -211,8 +211,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitForgotPassword([], [], $this->account, $this->request);
 
-        self::assertSame(200, $response->statusCode);
-        self::assertStringContainsString('submitted', $response->content);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('submitted', $response->getContent());
     }
 
     #[Test]
@@ -227,8 +227,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitForgotPassword([], [], $this->account, $this->request);
 
-        self::assertSame(200, $response->statusCode);
-        self::assertStringContainsString('submitted', $response->content);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('submitted', $response->getContent());
     }
 
     #[Test]
@@ -238,8 +238,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->verifyEmail([], [], $this->account, $this->request);
 
-        self::assertSame(400, $response->statusCode);
-        self::assertStringContainsString('invalid or has expired', $response->content);
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('invalid or has expired', $response->getContent());
     }
 
     #[Test]
@@ -271,8 +271,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->verifyEmail([], [], $this->account, $this->request);
 
-        self::assertSame(200, $response->statusCode);
-        self::assertStringContainsString('verified', $response->content);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('verified', $response->getContent());
         self::assertSame(99, $_SESSION['waaseyaa_uid']);
     }
 
@@ -305,8 +305,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitRegister([], [], $this->account, $this->request);
 
-        self::assertSame(200, $response->statusCode);
-        self::assertStringContainsString('check-email', $response->content);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('check-email', $response->getContent());
     }
 
     #[Test]
@@ -333,8 +333,8 @@ final class AuthControllerTest extends TestCase
 
         $response = $this->createController()->submitRegister([], [], $this->account, $this->request);
 
-        self::assertSame(200, $response->statusCode);
-        self::assertStringContainsString('check-email', $response->content);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('check-email', $response->getContent());
     }
 
     private function createSuccessfulUser(): User

--- a/tests/Minoo/Unit/Controller/BlockControllerTest.php
+++ b/tests/Minoo/Unit/Controller/BlockControllerTest.php
@@ -72,8 +72,8 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->store([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Cannot block yourself', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Cannot block yourself', $response->getContent());
     }
 
     #[Test]
@@ -84,8 +84,8 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->store([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('blocked_id is required', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('blocked_id is required', $response->getContent());
     }
 
     #[Test]
@@ -99,8 +99,8 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->store([], [], $account, $request);
 
-        $this->assertSame(409, $response->statusCode);
-        $this->assertStringContainsString('already blocked', $response->content);
+        $this->assertSame(409, $response->getStatusCode());
+        $this->assertStringContainsString('already blocked', $response->getContent());
     }
 
     #[Test]
@@ -119,8 +119,8 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->store([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $this->assertStringContainsString('"id":10', $response->content);
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertStringContainsString('"id":10', $response->getContent());
     }
 
     #[Test]
@@ -134,7 +134,7 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->delete(['user_id' => '2'], [], $account, $request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -152,8 +152,8 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->delete(['user_id' => '2'], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"removed":true', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"removed":true', $response->getContent());
     }
 
     #[Test]
@@ -168,7 +168,7 @@ final class BlockControllerTest extends TestCase
 
         $response = $this->controller->index([], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"blocks":', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"blocks":', $response->getContent());
     }
 }

--- a/tests/Minoo/Unit/Controller/BusinessControllerTest.php
+++ b/tests/Minoo/Unit/Controller/BusinessControllerTest.php
@@ -62,9 +62,9 @@ final class BusinessControllerTest extends TestCase
         $controller = new BusinessController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Nginaajiiw Salon &amp; Spa', $response->content);
-        $this->assertStringContainsString('Cedar &amp; Stone', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Nginaajiiw Salon &amp; Spa', $response->getContent());
+        $this->assertStringContainsString('Cedar &amp; Stone', $response->getContent());
     }
 
     #[Test]
@@ -75,8 +75,8 @@ final class BusinessControllerTest extends TestCase
         $controller = new BusinessController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('/businesses', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('/businesses', $response->getContent());
     }
 
     #[Test]
@@ -92,8 +92,8 @@ final class BusinessControllerTest extends TestCase
         $controller = new BusinessController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'nginaajiiw-salon-spa'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Nginaajiiw Salon &amp; Spa', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Nginaajiiw Salon &amp; Spa', $response->getContent());
     }
 
     #[Test]
@@ -104,7 +104,7 @@ final class BusinessControllerTest extends TestCase
         $controller = new BusinessController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'nonexistent'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -120,6 +120,6 @@ final class BusinessControllerTest extends TestCase
         $controller = new BusinessController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'some-group'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/CommunityControllerTest.php
+++ b/tests/Minoo/Unit/Controller/CommunityControllerTest.php
@@ -65,9 +65,9 @@ final class CommunityControllerTest extends TestCase
         $controller = new CommunityController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Sagamok Anishnawbek', $response->content);
-        $this->assertStringContainsString('Blind River', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Sagamok Anishnawbek', $response->getContent());
+        $this->assertStringContainsString('Blind River', $response->getContent());
     }
 
     #[Test]
@@ -78,8 +78,8 @@ final class CommunityControllerTest extends TestCase
         $controller = new CommunityController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('[]', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('[]', $response->getContent());
     }
 
     #[Test]
@@ -95,8 +95,8 @@ final class CommunityControllerTest extends TestCase
         $controller = new CommunityController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'sagamok-anishnawbek'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Sagamok Anishnawbek', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Sagamok Anishnawbek', $response->getContent());
     }
 
     #[Test]
@@ -107,7 +107,7 @@ final class CommunityControllerTest extends TestCase
         $controller = new CommunityController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'nonexistent'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -131,8 +131,8 @@ final class CommunityControllerTest extends TestCase
         $controller = new CommunityController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'sagamok-anishnawbek'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Sagamok Anishnawbek', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Sagamok Anishnawbek', $response->getContent());
     }
 
     #[Test]
@@ -159,10 +159,10 @@ final class CommunityControllerTest extends TestCase
 
         $response = $controller->show(['slug' => 'sagamok-anishnawbek'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Sagamok Anishnawbek', $response->content);
-        $this->assertStringNotContainsString('people:', $response->content);
-        $this->assertStringNotContainsString('office:', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Sagamok Anishnawbek', $response->getContent());
+        $this->assertStringNotContainsString('people:', $response->getContent());
+        $this->assertStringNotContainsString('office:', $response->getContent());
     }
 
     #[Test]

--- a/tests/Minoo/Unit/Controller/CoordinatorApplicationsTest.php
+++ b/tests/Minoo/Unit/Controller/CoordinatorApplicationsTest.php
@@ -57,7 +57,7 @@ final class CoordinatorApplicationsTest extends TestCase
         $request = HttpRequest::create('/dashboard/coordinator/applications');
         $response = $controller->applications([], [], $this->account, $request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -109,7 +109,7 @@ final class CoordinatorApplicationsTest extends TestCase
         $request = HttpRequest::create('/dashboard/coordinator/applications/test-uuid/approve', 'POST');
         $response = $controller->approveApplication(['uuid' => 'test-uuid'], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertContains('volunteer', $user->getRoles());
     }
 
@@ -147,7 +147,7 @@ final class CoordinatorApplicationsTest extends TestCase
         $request = HttpRequest::create('/dashboard/coordinator/applications/test-uuid/deny', 'POST');
         $response = $controller->denyApplication(['uuid' => 'test-uuid'], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -174,7 +174,7 @@ final class CoordinatorApplicationsTest extends TestCase
         $request = HttpRequest::create('/dashboard/coordinator/applications/test-uuid/approve', 'POST');
         $response = $controller->approveApplication(['uuid' => 'test-uuid'], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -209,6 +209,6 @@ final class CoordinatorApplicationsTest extends TestCase
         $request = HttpRequest::create('/dashboard/coordinator/applications/test-uuid/approve', 'POST');
         $response = $controller->approveApplication(['uuid' => 'test-uuid'], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/CoordinatorDashboardControllerTest.php
+++ b/tests/Minoo/Unit/Controller/CoordinatorDashboardControllerTest.php
@@ -96,11 +96,11 @@ final class CoordinatorDashboardControllerTest extends TestCase
         $controller = new CoordinatorDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->index([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Elder Mary', $response->content);
-        $this->assertStringContainsString('John Helper', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Elder Mary', $response->getContent());
+        $this->assertStringContainsString('John Helper', $response->getContent());
         // pending_application_count should be an integer, not empty
-        $this->assertMatchesRegularExpression('/pending:\d+/', $response->content);
+        $this->assertMatchesRegularExpression('/pending:\d+/', $response->getContent());
     }
 
     #[Test]
@@ -162,18 +162,18 @@ final class CoordinatorDashboardControllerTest extends TestCase
         $controller = new CoordinatorDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->index([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
         // Same community first (< 1 km), then near volunteer (~68 km)
-        $this->assertStringContainsString('Same Vol:< 1 km;', $response->content);
-        $this->assertStringContainsString('Near Vol:68 km;', $response->content);
+        $this->assertStringContainsString('Same Vol:< 1 km;', $response->getContent());
+        $this->assertStringContainsString('Near Vol:68 km;', $response->getContent());
 
         // Same Vol should appear before Near Vol
-        $samePos = strpos($response->content, 'Same Vol');
-        $nearPos = strpos($response->content, 'Near Vol');
+        $samePos = strpos($response->getContent(), 'Same Vol');
+        $nearPos = strpos($response->getContent(), 'Near Vol');
         $this->assertLessThan($nearPos, $samePos);
 
         // Community names are resolved from IDs
-        $this->assertStringContainsString('[1=Sagamok]', $response->content);
-        $this->assertStringContainsString('[2=Sudbury]', $response->content);
+        $this->assertStringContainsString('[1=Sagamok]', $response->getContent());
+        $this->assertStringContainsString('[2=Sudbury]', $response->getContent());
     }
 }

--- a/tests/Minoo/Unit/Controller/CrosswordControllerTest.php
+++ b/tests/Minoo/Unit/Controller/CrosswordControllerTest.php
@@ -62,8 +62,8 @@ final class CrosswordControllerTest extends TestCase
         $controller = new CrosswordController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->random([], ['tier' => 'medium'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $content = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
         $this->assertSame('no_puzzles', $content['error']);
         $this->assertSame('medium', $content['tier']);
     }
@@ -76,8 +76,8 @@ final class CrosswordControllerTest extends TestCase
         $controller = new CrosswordController($this->entityTypeManager, $this->twig, $this->gate);
         $response = $controller->random([], ['tier' => 'extreme'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $content = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
         $this->assertSame('easy', $content['tier']);
     }
 }

--- a/tests/Minoo/Unit/Controller/ElderSupportControllerTest.php
+++ b/tests/Minoo/Unit/Controller/ElderSupportControllerTest.php
@@ -42,7 +42,7 @@ final class ElderSupportControllerTest extends TestCase
         $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
         $response = $controller->requestForm([], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -53,7 +53,7 @@ final class ElderSupportControllerTest extends TestCase
 
         $response = $controller->submitRequest([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     #[Test]
@@ -67,8 +67,8 @@ final class ElderSupportControllerTest extends TestCase
 
         $response = $controller->submitRequest([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('name', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('name', $response->getContent());
     }
 
     #[Test]
@@ -83,8 +83,8 @@ final class ElderSupportControllerTest extends TestCase
 
         $response = $controller->submitRequest([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('type', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('type', $response->getContent());
     }
 
     #[Test]
@@ -109,7 +109,7 @@ final class ElderSupportControllerTest extends TestCase
         $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
         $response = $controller->requestDetail(['uuid' => $uuid], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -129,7 +129,7 @@ final class ElderSupportControllerTest extends TestCase
         $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
         $response = $controller->requestDetail(['uuid' => 'nonexistent'], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -138,7 +138,7 @@ final class ElderSupportControllerTest extends TestCase
         $controller = new ElderSupportController($this->entityTypeManager, $this->twig);
         $response = $controller->requestDetail([], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -156,8 +156,8 @@ final class ElderSupportControllerTest extends TestCase
 
         $response = $controller->submitRequest([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('consent', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('consent', $response->getContent());
     }
 
     #[Test]
@@ -175,7 +175,7 @@ final class ElderSupportControllerTest extends TestCase
 
         $response = $controller->submitRequest([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('elder_name', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('elder_name', $response->getContent());
     }
 }

--- a/tests/Minoo/Unit/Controller/ElderSupportWorkflowControllerTest.php
+++ b/tests/Minoo/Unit/Controller/ElderSupportWorkflowControllerTest.php
@@ -63,7 +63,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->assignVolunteer(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('assigned', $entity->get('status'));
         $this->assertSame(5, $entity->get('assigned_volunteer'));
     }
@@ -80,7 +80,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->startRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('in_progress', $entity->get('status'));
     }
 
@@ -96,7 +96,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->completeRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('completed', $entity->get('status'));
     }
 
@@ -112,7 +112,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->confirmRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('confirmed', $entity->get('status'));
     }
 
@@ -128,7 +128,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->assignVolunteer(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -142,7 +142,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->startRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -158,7 +158,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->cancelRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('cancelled', $entity->get('status'));
         $this->assertSame('Elder no longer needs help', $entity->get('cancelled_reason'));
     }
@@ -176,7 +176,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->cancelRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('cancelled', $entity->get('status'));
     }
 
@@ -192,7 +192,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->cancelRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     #[Test]
@@ -204,7 +204,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->cancelRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -219,7 +219,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->declineRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('open', $entity->get('status'));
         $this->assertNull($entity->get('assigned_volunteer'));
         $this->assertNull($entity->get('assigned_at'));
@@ -236,7 +236,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->declineRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -250,7 +250,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->declineRequest(['esrid' => '1'], [], $account, $this->request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     #[Test]
@@ -263,7 +263,7 @@ final class ElderSupportWorkflowControllerTest extends TestCase
         $controller = new ElderSupportWorkflowController($this->entityTypeManager);
         $response = $controller->declineRequest(['esrid' => '99'], [], $account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     private function createCoordinatorAccount(): AccountInterface

--- a/tests/Minoo/Unit/Controller/EngagementControllerTest.php
+++ b/tests/Minoo/Unit/Controller/EngagementControllerTest.php
@@ -80,8 +80,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid target_type', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
     }
 
     #[Test]
@@ -95,8 +95,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->comment([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid target_type', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
     }
 
     #[Test]
@@ -109,8 +109,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->follow([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid target_type', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
     }
 
     #[Test]
@@ -125,8 +125,8 @@ final class EngagementControllerTest extends TestCase
             $request,
         );
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Invalid target_type', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
     }
 
     // --- Reaction type validation ---
@@ -147,7 +147,7 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     // --- Missing fields ---
@@ -159,8 +159,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Missing required fields', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Missing required fields', $response->getContent());
     }
 
     #[Test]
@@ -170,8 +170,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->comment([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Missing required fields', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Missing required fields', $response->getContent());
     }
 
     // --- Body length validation ---
@@ -183,8 +183,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Body must be', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
     }
 
     #[Test]
@@ -194,8 +194,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Body must be', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
     }
 
     #[Test]
@@ -209,8 +209,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->comment([], [], $this->mockAccount(), $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('Body must be', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
     }
 
     // --- Happy-path creation tests ---
@@ -229,8 +229,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(1, $json['id']);
     }
 
@@ -248,8 +248,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(7, $json['id']);
     }
 
@@ -267,8 +267,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->comment([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(5, $json['id']);
         $this->assertSame('Great event!', $json['body']);
     }
@@ -287,8 +287,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->follow([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(7, $json['id']);
     }
 
@@ -304,8 +304,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(3, $json['id']);
     }
 
@@ -336,8 +336,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(3, $json['id']);
     }
 
@@ -376,8 +376,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame(3, $json['id']);
     }
 
@@ -394,8 +394,8 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
         $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertTrue($json['deleted']);
     }
 
@@ -410,8 +410,8 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
         $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
 
-        $this->assertSame(403, $response->statusCode);
-        $this->assertStringContainsString('Forbidden', $response->content);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('Forbidden', $response->getContent());
     }
 
     #[Test]
@@ -425,8 +425,8 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
         $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertTrue($json['deleted']);
     }
 
@@ -440,7 +440,7 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/react/999', 'DELETE');
         $response = $this->controller->deleteReaction(['id' => '999'], [], $account, $request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -454,7 +454,7 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/comment/1', 'DELETE');
         $response = $this->controller->deleteComment(['id' => '1'], [], $account, $request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -468,7 +468,7 @@ final class EngagementControllerTest extends TestCase
         $request = HttpRequest::create('/api/engagement/post/1', 'DELETE');
         $response = $this->controller->deletePost(['id' => '1'], [], $account, $request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     // --- Constructor exception safety net (#453) ---
@@ -486,8 +486,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->react([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame('Invalid entity data', $json['error']);
     }
 
@@ -504,8 +504,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->comment([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame('Invalid entity data', $json['error']);
     }
 
@@ -522,8 +522,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->follow([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame('Invalid entity data', $json['error']);
     }
 
@@ -540,8 +540,8 @@ final class EngagementControllerTest extends TestCase
 
         $response = $this->controller->createPost([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertSame('Invalid entity data', $json['error']);
     }
 }

--- a/tests/Minoo/Unit/Controller/FeedControllerTest.php
+++ b/tests/Minoo/Unit/Controller/FeedControllerTest.php
@@ -48,7 +48,7 @@ final class FeedControllerTest extends TestCase
 
         $response = $controller->index([], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -132,8 +132,8 @@ final class FeedControllerTest extends TestCase
 
         $response = $controller->api([], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $json = json_decode($response->content, true);
+        $this->assertSame(200, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
         $this->assertArrayHasKey('items', $json);
         $this->assertArrayHasKey('nextCursor', $json);
         $this->assertArrayHasKey('activeFilter', $json);
@@ -153,6 +153,6 @@ final class FeedControllerTest extends TestCase
 
         $response = $controller->explore([], ['type' => 'events', 'q' => 'pow wow'], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/IngestionApiControllerTest.php
+++ b/tests/Minoo/Unit/Controller/IngestionApiControllerTest.php
@@ -25,8 +25,8 @@ final class IngestionApiControllerTest extends TestCase
         $account = $this->createMock(AccountInterface::class);
         $response = $controller->status([], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
-        $decoded = json_decode($response->content, true, 16, JSON_THROW_ON_ERROR);
+        $this->assertSame(200, $response->getStatusCode());
+        $decoded = json_decode($response->getContent(), true, 16, JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('status', $decoded);
     }
 
@@ -40,7 +40,7 @@ final class IngestionApiControllerTest extends TestCase
 
         $response = $controller->ingestEnvelope([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     #[Test]
@@ -67,7 +67,7 @@ final class IngestionApiControllerTest extends TestCase
         $controller = new IngestionApiController($etm);
         $response = $controller->approve(['id' => '10'], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('approved', $log->get('status'));
         $this->assertSame(99, $log->get('reviewed_by'));
     }

--- a/tests/Minoo/Unit/Controller/IngestionDashboardControllerTest.php
+++ b/tests/Minoo/Unit/Controller/IngestionDashboardControllerTest.php
@@ -76,7 +76,7 @@ final class IngestionDashboardControllerTest extends TestCase
             $account = $this->createMock(AccountInterface::class);
             $request = new HttpRequest();
             $response = $controller->index([], [], $account, $request);
-            $this->assertSame(200, $response->statusCode);
+            $this->assertSame(200, $response->getStatusCode());
         } finally {
             if (is_file($statusPath)) {
                 unlink($statusPath);
@@ -142,7 +142,7 @@ final class IngestionDashboardControllerTest extends TestCase
 
         $response = $controller->index([], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -194,7 +194,7 @@ final class IngestionDashboardControllerTest extends TestCase
 
         $response = $controller->index([], ['status' => 'failed'], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -239,7 +239,7 @@ final class IngestionDashboardControllerTest extends TestCase
 
         $response = $controller->index([], ['status' => 'evil_injection'], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     private function queryMockReturning(array $executeResult, bool $count = false, bool $allowCondition = false): EntityQueryInterface

--- a/tests/Minoo/Unit/Controller/LanguageControllerSearchTest.php
+++ b/tests/Minoo/Unit/Controller/LanguageControllerSearchTest.php
@@ -45,9 +45,9 @@ final class LanguageControllerSearchTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->search([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('/language/search', $response->content);
-        $this->assertStringContainsString('|0', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('/language/search', $response->getContent());
+        $this->assertStringContainsString('|0', $response->getContent());
     }
 
     #[Test]
@@ -67,9 +67,9 @@ final class LanguageControllerSearchTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->search([], ['q' => 'makwa'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('makwa', $response->content);
-        $this->assertStringContainsString('|1', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('makwa', $response->getContent());
+        $this->assertStringContainsString('|1', $response->getContent());
     }
 
     #[Test]
@@ -80,7 +80,7 @@ final class LanguageControllerSearchTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->search([], ['q' => '   '], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -94,7 +94,7 @@ final class LanguageControllerSearchTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->search([], ['q' => 'zzz'], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('|0', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('|0', $response->getContent());
     }
 }

--- a/tests/Minoo/Unit/Controller/LanguageControllerTest.php
+++ b/tests/Minoo/Unit/Controller/LanguageControllerTest.php
@@ -66,9 +66,9 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('makwa', $response->content);
-        $this->assertStringContainsString('miigwech', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('makwa', $response->getContent());
+        $this->assertStringContainsString('miigwech', $response->getContent());
     }
 
     #[Test]
@@ -79,8 +79,8 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('/language', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('/language', $response->getContent());
     }
 
     #[Test]
@@ -99,8 +99,8 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('aniin', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('aniin', $response->getContent());
     }
 
     #[Test]
@@ -125,10 +125,10 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->show(['slug' => 'makwa'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('makwa', $response->content);
-        $this->assertStringContainsString('plural: makwag', $response->content);
-        $this->assertStringContainsString('diminutive: makoons', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('makwa', $response->getContent());
+        $this->assertStringContainsString('plural: makwag', $response->getContent());
+        $this->assertStringContainsString('diminutive: makoons', $response->getContent());
     }
 
     #[Test]
@@ -139,7 +139,7 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->show(['slug' => 'nonexistent'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -161,8 +161,8 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->show(['slug' => 'makwa'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('makwag pl; makoons dim', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('makwag pl; makoons dim', $response->getContent());
     }
 
     #[Test]
@@ -175,6 +175,6 @@ final class LanguageControllerTest extends TestCase
         $controller = new LanguageController($this->entityTypeManager, $this->twig, $this->northCloudClient);
         $response = $controller->show(['slug' => 'secret-word'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/MessagingControllerTest.php
+++ b/tests/Minoo/Unit/Controller/MessagingControllerTest.php
@@ -63,7 +63,7 @@ final class MessagingControllerTest extends TestCase
 
         $response = $this->controller->createMessage(['id' => '10'], [], $account, $request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -106,8 +106,8 @@ final class MessagingControllerTest extends TestCase
 
         $response = $this->controller->createMessage(['id' => (string) $threadId], [], $account, $request);
 
-        $this->assertSame(201, $response->statusCode);
-        $this->assertStringContainsString('"id":99', $response->content);
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertStringContainsString('"id":99', $response->getContent());
     }
 
     #[Test]
@@ -123,8 +123,8 @@ final class MessagingControllerTest extends TestCase
 
         $response = $this->controller->createThread([], [], $account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('At least 2 participants', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('At least 2 participants', $response->getContent());
     }
 
     #[Test]
@@ -161,7 +161,7 @@ final class MessagingControllerTest extends TestCase
         $request = $this->jsonRequest(['body' => 'Edited']);
         $response = $this->controller->editMessage(['id' => (string) $threadId, 'message_id' => (string) $messageId], [], $account, $request);
 
-        $this->assertSame(403, $response->statusCode);
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     #[Test]
@@ -198,9 +198,9 @@ final class MessagingControllerTest extends TestCase
         $request = $this->jsonRequest(['body' => 'Edited body']);
         $response = $this->controller->editMessage(['id' => (string) $threadId, 'message_id' => (string) $messageId], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"body":"Edited body"', $response->content);
-        $this->assertStringContainsString('"edited_at":', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"body":"Edited body"', $response->getContent());
+        $this->assertStringContainsString('"edited_at":', $response->getContent());
     }
 
     #[Test]
@@ -236,8 +236,8 @@ final class MessagingControllerTest extends TestCase
         $request = HttpRequest::create('/', 'DELETE');
         $response = $this->controller->deleteMessage(['id' => (string) $threadId, 'message_id' => (string) $messageId], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"deleted":true', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"deleted":true', $response->getContent());
     }
 
     #[Test]
@@ -274,8 +274,8 @@ final class MessagingControllerTest extends TestCase
         $request = HttpRequest::create('/', 'POST');
         $response = $this->controller->markRead(['id' => (string) $threadId], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"last_read_at":', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"last_read_at":', $response->getContent());
     }
 
     #[Test]
@@ -324,8 +324,8 @@ final class MessagingControllerTest extends TestCase
         $request = HttpRequest::create('/', 'GET');
         $response = $this->controller->unreadCount([], [], $account, $request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('"unread_count":1', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('"unread_count":1', $response->getContent());
     }
 }
 

--- a/tests/Minoo/Unit/Controller/PeopleControllerTest.php
+++ b/tests/Minoo/Unit/Controller/PeopleControllerTest.php
@@ -63,9 +63,9 @@ final class PeopleControllerTest extends TestCase
         $controller = new PeopleController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Mary Trudeau', $response->content);
-        $this->assertStringContainsString('John Beaucage', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Mary Trudeau', $response->getContent());
+        $this->assertStringContainsString('John Beaucage', $response->getContent());
     }
 
     #[Test]
@@ -76,8 +76,8 @@ final class PeopleControllerTest extends TestCase
         $controller = new PeopleController($this->entityTypeManager, $this->twig);
         $response = $controller->list([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('/people', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('/people', $response->getContent());
     }
 
     #[Test]
@@ -93,8 +93,8 @@ final class PeopleControllerTest extends TestCase
         $controller = new PeopleController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'mary-trudeau'], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Mary Trudeau', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Mary Trudeau', $response->getContent());
     }
 
     #[Test]
@@ -105,6 +105,6 @@ final class PeopleControllerTest extends TestCase
         $controller = new PeopleController($this->entityTypeManager, $this->twig);
         $response = $controller->show(['slug' => 'nonexistent'], [], $this->account, $this->request);
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/RoleManagementControllerTest.php
+++ b/tests/Minoo/Unit/Controller/RoleManagementControllerTest.php
@@ -69,7 +69,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertContains('volunteer', $targetUser->getRoles());
     }
 
@@ -86,7 +86,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('revoke', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertNotContains('volunteer', $targetUser->getRoles());
     }
 
@@ -103,7 +103,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'elder');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertTrue(ElderIdentity::isElder($targetUser));
     }
 
@@ -120,7 +120,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('revoke', 'elder');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertFalse(ElderIdentity::isElder($targetUser));
     }
 
@@ -134,7 +134,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '5'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -147,7 +147,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'elder_coordinator');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -163,7 +163,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'elder_coordinator');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertContains('elder_coordinator', $targetUser->getRoles());
     }
 
@@ -180,7 +180,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -191,7 +191,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('destroy', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -202,7 +202,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -213,7 +213,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'superuser');
         $response = $this->controller->changeRole(['uid' => '2'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -227,7 +227,7 @@ final class RoleManagementControllerTest extends TestCase
         $request = $this->changeRoleRequest('grant', 'volunteer');
         $response = $this->controller->changeRole(['uid' => '999'], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -266,7 +266,7 @@ final class RoleManagementControllerTest extends TestCase
 
         $response = $this->controller->coordinatorList([], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -295,6 +295,6 @@ final class RoleManagementControllerTest extends TestCase
 
         $response = $this->controller->adminList([], [], $account, new HttpRequest());
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
+++ b/tests/Minoo/Unit/Controller/VolunteerControllerTest.php
@@ -42,7 +42,7 @@ final class VolunteerControllerTest extends TestCase
         $controller = new VolunteerController($this->entityTypeManager, $this->twig);
         $response = $controller->signupForm([], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -53,7 +53,7 @@ final class VolunteerControllerTest extends TestCase
 
         $response = $controller->submitSignup([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
+        $this->assertSame(422, $response->getStatusCode());
     }
 
     #[Test]
@@ -66,8 +66,8 @@ final class VolunteerControllerTest extends TestCase
 
         $response = $controller->submitSignup([], [], $this->account, $request);
 
-        $this->assertSame(422, $response->statusCode);
-        $this->assertStringContainsString('phone', $response->content);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('phone', $response->getContent());
     }
 
     #[Test]
@@ -98,7 +98,7 @@ final class VolunteerControllerTest extends TestCase
 
         $response = $controller->submitSignup([], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -129,7 +129,7 @@ final class VolunteerControllerTest extends TestCase
 
         $response = $controller->submitSignup([], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -159,7 +159,7 @@ final class VolunteerControllerTest extends TestCase
         $controller = new VolunteerController($this->entityTypeManager, $this->twig);
         $response = $controller->submitSignup([], [], $this->account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     #[Test]
@@ -184,7 +184,7 @@ final class VolunteerControllerTest extends TestCase
         $controller = new VolunteerController($this->entityTypeManager, $this->twig);
         $response = $controller->signupDetail(['uuid' => $uuid], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -204,7 +204,7 @@ final class VolunteerControllerTest extends TestCase
         $controller = new VolunteerController($this->entityTypeManager, $this->twig);
         $response = $controller->signupDetail(['uuid' => 'nonexistent'], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -213,6 +213,6 @@ final class VolunteerControllerTest extends TestCase
         $controller = new VolunteerController($this->entityTypeManager, $this->twig);
         $response = $controller->signupDetail([], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Minoo/Unit/Controller/VolunteerDashboardControllerTest.php
+++ b/tests/Minoo/Unit/Controller/VolunteerDashboardControllerTest.php
@@ -79,8 +79,8 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->index([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('Mary', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Mary', $response->getContent());
     }
 
     #[Test]
@@ -91,7 +91,7 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->index([], [], $this->account, $this->request);
 
-        $this->assertSame(200, $response->statusCode);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     #[Test]
@@ -127,8 +127,8 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->editForm([], [], $account, HttpRequest::create('/'));
 
-        $this->assertSame(200, $response->statusCode);
-        $this->assertStringContainsString('edit:John', $response->content);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('edit:John', $response->getContent());
     }
 
     #[Test]
@@ -153,7 +153,7 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->editForm([], [], $this->account, HttpRequest::create('/'));
 
-        $this->assertSame(404, $response->statusCode);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     #[Test]
@@ -192,7 +192,7 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->submitEdit([], [], $account, $request);
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('555-9999', $volunteer->get('phone'));
         $this->assertSame('Evenings', $volunteer->get('availability'));
     }
@@ -226,7 +226,7 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->toggleAvailability([], [], $account, HttpRequest::create('/', 'POST'));
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('unavailable', $volunteer->get('status'));
     }
 
@@ -259,7 +259,7 @@ final class VolunteerDashboardControllerTest extends TestCase
         $controller = new VolunteerDashboardController($this->entityTypeManager, $this->twig);
         $response = $controller->toggleAvailability([], [], $account, HttpRequest::create('/', 'POST'));
 
-        $this->assertSame(302, $response->statusCode);
+        $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('active', $volunteer->get('status'));
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `waaseyaa/*` from **alpha.104 → alpha.106** and migrates 29 controllers from the removed `Waaseyaa\SSR\SsrResponse` (deleted by waaseyaa/framework#1066) to `Symfony\Component\HttpFoundation\Response` / `RedirectResponse`.
- Unblocks alpha.106 which contains `AppControllerRouter` (waaseyaa/framework#1120) — required for `Class::method` app-controller dispatch. Verified locally: `AppControllerRouter::handle → SsrPageHandler::dispatchAppController → <AppController>::<method>`.
- Updates 23 test files to use Symfony's `getStatusCode()` / `getContent()` / `headers->get()` API instead of the former `SsrResponse` readonly public properties.

## Migration details

Three patterns handled, including multi-line constructors with ternary `statusCode` values (e.g. `ElderSupportController::requestDetail()` returning `200 or 404`). Rewrote using a balanced-paren Python parser rather than regex, to safely handle nested expressions inside named arguments.

- `new SsrResponse(content: $html)` → `new Response($html)`
- `new SsrResponse(content: $html, statusCode: N)` → `new Response($html, N)`
- `new SsrResponse(content: '', statusCode: 302, headers: ['Location' => $url])` → `new RedirectResponse($url)`

`phpstan-baseline.neon` regenerated (26 entries, normal drift across 5 alpha versions; verified baseline entries are framework-type-signature shifts unrelated to this migration).

## Test plan

- [x] `vendor/bin/phpunit` — **871 passing, 3 skipped** (matches pre-migration baseline on alpha.104)
- [x] `vendor/bin/phpstan analyse` — **no errors**
- [x] All public routes return `HTTP 200` locally: `/`, `/elders`, `/elders/request`, `/elders/volunteer`, `/safety`, `/games`, `/language`, `/communities`
- [x] `POST /elders/request` — `302` → confirmation page renders with real UUID
- [x] `POST /elders/volunteer` — `302` → confirmation page with real UUID
- [x] Full dispatch chain verified in server logs: `AppControllerRouter::handle → SsrPageHandler::dispatchAppController → VolunteerController::submitSignup`
- [ ] CI green on this PR
- [ ] Playwright suite green on this PR

## Notes

- **Production is still on alpha.75** (last 3 deploy runs failed pre-migration). This PR lets CI validate the full alpha.75 → alpha.106 jump in isolation before we touch `main`.
- Pre-existing bug observed, **not fixed in this PR**: `VolunteerController::submitSignup` at line 54 crashes with `ParameterBag::all()` when the `skills` field is POSTed as a scalar instead of an array. Worth a follow-up issue — separate from this migration's scope.
- The CSS `@layer` workarounds for #630 are untouched. Still safe to leave in place.

Closes #631
Related: waaseyaa/framework#1066, waaseyaa/framework#1120, waaseyaa/framework#1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)