### PR TITLE
feat(#667): align Minoo bootstrap with Waaseyaa skeleton

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+node_modules
+vendor
+storage/*.sqlite
+tests
+phpunit.xml.dist
+*.md
+.claude
+.cursor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM php:8.4-fpm-alpine AS base
+
+RUN apk add --no-cache \
+    sqlite-libs \
+    icu-libs \
+    && docker-php-ext-install \
+    intl \
+    opcache \
+    pdo_sqlite
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+FROM base AS deps
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-scripts --prefer-dist --optimize-autoloader
+
+FROM base AS production
+
+COPY --from=deps /app/vendor /app/vendor
+COPY . /app
+
+RUN composer dump-autoload --optimize --no-dev \
+    && mkdir -p /app/storage \
+    && chown -R www-data:www-data /app/storage
+
+ENV APP_ENV=production
+ENV APP_DEBUG=false
+ENV WAASEYAA_DB=/app/storage/waaseyaa.sqlite
+
+EXPOSE 9000
+
+USER www-data

--- a/bin/deploy-artifact-smoke
+++ b/bin/deploy-artifact-smoke
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Optional pre-release HTTP check against a directory that already matches CI deploy output.
+#
+# 1. Build the tree the same way your deploy job does (e.g. composer install --no-dev + rsync).
+# 2. export ARTIFACT_DIR=/absolute/path/to/that/tree
+# 3. Optionally add scripts/deploy-smoke-routes.txt (one URL path per line; lines starting with # ignored).
+#
+# Usage: ARTIFACT_DIR=/path/to/build ./bin/deploy-artifact-smoke [port]
+# Suggested: run from workflow_dispatch or a scheduled workflow, not every PR.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${1:-9875}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-}"
+
+if [[ -z "$ARTIFACT_DIR" ]]; then
+    echo "deploy-artifact-smoke: set ARTIFACT_DIR to the built artifact root" >&2
+    exit 1
+fi
+
+if [[ ! -f "$ARTIFACT_DIR/public/index.php" ]]; then
+    echo "deploy-artifact-smoke: expected public/index.php under ARTIFACT_DIR" >&2
+    exit 1
+fi
+
+ROUTES_FILE="$REPO_ROOT/scripts/deploy-smoke-routes.txt"
+paths=("/")
+if [[ -f "$ROUTES_FILE" ]]; then
+    mapfile -t paths < <(grep -v '^[[:space:]]*#' "$ROUTES_FILE" | grep -v '^[[:space:]]*$' || true)
+    if [[ ${#paths[@]} -eq 0 ]]; then
+        paths=("/")
+    fi
+fi
+
+cd "$ARTIFACT_DIR"
+php -S "127.0.0.1:$PORT" public/index.php >/tmp/waaseyaa-deploy-smoke-php.log 2>&1 &
+PID=$!
+trap 'kill "$PID" 2>/dev/null || true' EXIT
+sleep 2
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "deploy-artifact-smoke: curl is required" >&2
+    exit 1
+fi
+
+fail=0
+for p in "${paths[@]}"; do
+    code=$(curl -sS -o /tmp/waaseyaa-deploy-smoke-body -w "%{http_code}" "http://127.0.0.1:$PORT${p}" || echo "000")
+    if [[ "$code" != "200" ]]; then
+        echo "deploy-artifact-smoke: FAIL ${p} -> HTTP ${code}" >&2
+        fail=1
+    fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "deploy-artifact-smoke: OK"

--- a/bin/golden-public-index.php
+++ b/bin/golden-public-index.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$kernel = new \Waaseyaa\Foundation\Kernel\HttpKernel(dirname(__DIR__));
+$kernel->handle();

--- a/bin/post-create-setup.php
+++ b/bin/post-create-setup.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$envExample = $root . '/.env.example';
+$envFile = $root . '/.env';
+
+if (!file_exists($envFile) && file_exists($envExample)) {
+    $content = file_get_contents($envExample);
+    $secret = bin2hex(random_bytes(32));
+    $appName = ucwords(str_replace(['-', '_'], ' ', basename($root)));
+    if (str_contains($appName, ' ')) {
+        $appName = '"' . $appName . '"';
+    }
+    $content = str_replace('WAASEYAA_JWT_SECRET=', "WAASEYAA_JWT_SECRET={$secret}", $content);
+    if (str_contains($content, 'APP_NAME=Waaseyaa')) {
+        $content = str_replace('APP_NAME=Waaseyaa', "APP_NAME={$appName}", $content);
+    } else {
+        fwrite(STDERR, "Warning: Could not set APP_NAME — placeholder not found in .env.example.\n");
+    }
+    file_put_contents($envFile, $content);
+}
+
+echo "\n";
+echo "  \033[32mWaaseyaa project ready.\033[0m\n";
+echo "\n";
+echo "  \033[33mbin/waaseyaa serve\033[0m    Start the dev server\n";
+echo "  \033[33mbin/waaseyaa\033[0m          See all commands\n";
+echo "\n";

--- a/bin/waaseyaa-version
+++ b/bin/waaseyaa-version
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * Standalone framework provenance (no full Waaseyaa kernel boot).
  * Same logic as: php bin/waaseyaa waaseyaa:version
  *
- * Options: --json, --report-only
+ * Options: --json, --strict (explicit default: fail on drift), --report-only (always exit 0)
  */
 $root = dirname(__DIR__);
 require $root . '/vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,8 @@
             "PHP_CLI_SERVER_WORKERS=4 bin/waaseyaa serve & npm --prefix ../waaseyaa/packages/admin run dev -- --host && kill $!"
         ],
         "post-create-project-cmd": [
-            "chmod +x bin/waaseyaa bin/waaseyaa-version bin/verify-deploy-rsync bin/waaseyaa-audit-site"
+            "chmod +x bin/waaseyaa bin/waaseyaa-version bin/verify-deploy-rsync bin/waaseyaa-audit-site",
+            "php bin/post-create-setup.php"
         ]
     },
     "minimum-stability": "dev",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
Aligns Minoo with the official `waaseyaa/framework` project skeleton: Symfony Dotenv at HTTP and CLI entry points (framework #1132), `post-create-setup` in Composer, official optional bin scripts, and Docker assets from the skeleton. Refreshes `composer.lock` for `symfony/dotenv`. Includes `chore(mcp): refresh package-lock after npm audit fix` on this branch.

## Related issue
- Closes #667

## What changed
- **`symfony/dotenv`**: `public/index.php` and `bin/waaseyaa` load `.env` with the same error handling as the skeleton.
- **`.env.example`**: Skeleton-style base (APP_*, WAASEYAA_DB, JWT placeholder, CORS comments) plus existing Minoo-specific vars (Mercure, SendGrid, NorthCloud). `APP_NAME=Waaseyaa` placeholder preserves `post-create-setup.php` behavior for new checkouts.
- **New / synced bin files (upstream)**: `post-create-setup.php`, `deploy-artifact-smoke`, `golden-public-index.php`; `waaseyaa-version` docblock aligned with skeleton.
- **Docker**: `Dockerfile` and `.dockerignore` copied from skeleton (optional FPM image).
- **MCP**: `mcp/package-lock.json` from `npm audit fix` (no vulnerabilities).

## Verification
- `./vendor/bin/phpunit -c phpunit.xml.dist` — OK (871 tests locally; 3 skipped unchanged).
- Pre-push hook: unit + integration suites passed.

## Checklist
- [x] No secrets in committed files
- [x] PHPUnit passing
- [ ] Assign #667 to appropriate milestone if required by repo process

Made with [Cursor](https://cursor.com)