### PR TITLE
chore: align mail commands with MailerInterface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ minoo/
 | `templates/*`, `public/css/*` | `minoo:frontend-ssr` | `docs/specs/frontend-ssr.md` |
 | `src/Domain/Geo/*`, `src/Support/GeoDistance.php`, `src/Support/CommunityLookup.php` | — | `docs/specs/geo-domain.md` |
 | `src/Support/NorthCloudClient.php`, `src/Support/NorthCloudCache.php` | — | `docs/specs/geo-domain.md` (NC client section) |
-| `src/Support/*` (other) | — | Cross-cutting: SlugGenerator, MailService, Flash, FixtureResolver, ElderIdentity |
+| `src/Support/*` (other) | — | Cross-cutting: SlugGenerator, Flash, FixtureResolver, ElderIdentity; auth mail is framework `AuthMailer` |
 | `config/*`, `composer.json` | — | See `../waaseyaa/CLAUDE.md` for framework conventions |
 | `src/Entity/*`, `src/Provider/*`, `src/Access/*` | `waaseyaa-app-development` | `docs/specs/entity-model.md` |
 | `src/Controller/*`, `src/Routing/*` | `waaseyaa-app-development` | — |
@@ -183,7 +183,7 @@ All user-facing copy follows `docs/content-tone-guide.md`:
 - **Reaction field rename**: `emoji` was renamed to `reaction_type` with migration `20260322_120000`. Allowed values: `like`, `interested`, `recommend`, `miigwech`, `connect`. All API endpoints, JS, and tests use `reaction_type`.
 - **Game sessions must set `game_type`**: Both `ShkodaController` and `CrosswordController` must include `'game_type' => 'shkoda'`/`'crossword'` when creating game sessions. `GameStatsCalculator::build()` filters by `game_type` — missing it causes stats to silently return zero for authenticated users.
 - **Game controllers must inject `GateInterface`**: All game API endpoints that mutate session state (`check`, `complete`, `hint`, `abandon`, `guess`) must call `$this->gate->denies('update', $session, $account)` for session ownership validation.
-- **AuthMailer requires `isConfigured()` guard**: All `AuthMailer` methods check `MailService::isConfigured()` before sending. Without a valid `SENDGRID_API_KEY`, SendGrid returns HTTP 401 and throws — crashing registration and password reset flows. CI and local dev typically have no API key.
+- **AuthMailer requires `isConfigured()` guard**: Framework `AuthMailer` skips sends when `authEmailConfigured` is false (no SendGrid key + from address). Without valid credentials, forcing a send would hit SendGrid 401 and throw — crashing registration and password reset flows. CI and local dev typically have no API key.
 - **PHPStan baseline drift**: After adding new files that call `EntityInterface::get()`, regenerate the baseline with `./vendor/bin/phpstan analyse --generate-baseline phpstan-baseline.neon`. The baseline won't auto-update when new files are added.
 - **Controller DI**: `SsrPageHandler::resolveControllerInstance()` auto-injects constructor params. It checks a hardcoded `$serviceMap` (EntityTypeManager, Twig, HttpRequest, AccountInterface), then falls back to `serviceResolver` for any type registered as a singleton in a service provider. Register new services in providers and they'll be injected automatically.
 - **Production deploy path**: `/home/deployer/minoo/current` (symlink to `releases/N`). DB at `storage/waaseyaa.sqlite`. User table is `user` (not `users`), fields stored in `_data` JSON blob. Query by field: `WHERE _data LIKE '%field_value%'`.

--- a/config/waaseyaa.php
+++ b/config/waaseyaa.php
@@ -116,6 +116,9 @@ return [
         'base_url' => getenv('MINOO_BASE_URL') ?: 'https://minoo.live',
     ],
 
+    // Messaging (digests, Mercure, etc.) — see config/messaging.php.
+    'messaging' => require __DIR__ . '/messaging.php',
+
     // AI embedding pipeline configuration.
     'ai' => [
         // 'ollama' or 'openai'. Empty disables embedding generation.

--- a/src/Provider/MailServiceProvider.php
+++ b/src/Provider/MailServiceProvider.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Minoo\Provider;
 
 use Minoo\Support\Command\MailTestCommand;
+use Minoo\Support\Command\MessagingDigestCommand;
+use Minoo\Support\MessageDigestCommand;
 use Symfony\Component\Console\Command\Command;
 use Waaseyaa\Foundation\Kernel\ConsoleKernel;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Mail\MailerInterface;
 
 /**
- * Contributes `mail:test`. {@see ServiceProvider::commands()} is not on
+ * Contributes `mail:test` and `messaging:digest`. {@see ServiceProvider::commands()} is not on
  * {@see \Waaseyaa\Foundation\ServiceProvider\ServiceProviderInterface} by design; the base
  * {@see ServiceProvider} declares it, and {@see ConsoleKernel} registers returned commands after boot.
  */
@@ -32,12 +34,26 @@ final class MailServiceProvider extends ServiceProvider
         $configured = trim((string) ($config['sendgrid_api_key'] ?? '')) !== ''
             && $fromAddress !== '';
 
+        $messagingConfig = [];
+        if (isset($this->config['messaging']) && is_array($this->config['messaging'])) {
+            $messagingConfig = $this->config['messaging'];
+        }
+
+        $digest = new MessageDigestCommand(
+            $entityTypeManager,
+            $this->resolve(MailerInterface::class),
+            $configured,
+            $messagingConfig,
+            $fromAddress,
+        );
+
         return [
             new MailTestCommand(
                 $this->resolve(MailerInterface::class),
                 $configured,
                 $fromAddress,
             ),
+            new MessagingDigestCommand($digest),
         ];
     }
 }

--- a/src/Provider/MailServiceProvider.php
+++ b/src/Provider/MailServiceProvider.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 namespace Minoo\Provider;
 
 use Minoo\Support\Command\MailTestCommand;
+use Symfony\Component\Console\Command\Command;
+use Waaseyaa\Foundation\Kernel\ConsoleKernel;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Mail\MailerInterface;
 
+/**
+ * Contributes `mail:test`. {@see ServiceProvider::commands()} is not on
+ * {@see \Waaseyaa\Foundation\ServiceProvider\ServiceProviderInterface} by design; the base
+ * {@see ServiceProvider} declares it, and {@see ConsoleKernel} registers returned commands after boot.
+ */
 final class MailServiceProvider extends ServiceProvider
 {
     public function register(): void {}
 
     /**
-     * @return list<object>
+     * @return list<Command>
      */
     public function commands(
         \Waaseyaa\Entity\EntityTypeManager $entityTypeManager,

--- a/src/Provider/MailServiceProvider.php
+++ b/src/Provider/MailServiceProvider.php
@@ -6,29 +6,29 @@ namespace Minoo\Provider;
 
 use Minoo\Support\Command\MailTestCommand;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
-use Waaseyaa\Mail\Driver\SendGridDriver;
-use Waaseyaa\Mail\MailDriverInterface;
+use Waaseyaa\Mail\MailerInterface;
 
 final class MailServiceProvider extends ServiceProvider
 {
-    public function register(): void
-    {
-        $config = $this->config['mail'] ?? [];
+    public function register(): void {}
 
-        $this->singleton(MailDriverInterface::class, fn () => new SendGridDriver(
-            apiKey: $config['sendgrid_api_key'] ?? '',
-            fromAddress: $config['from_address'] ?? '',
-            fromName: $config['from_name'] ?? '',
-        ));
-    }
-
+    /**
+     * @return list<object>
+     */
     public function commands(
         \Waaseyaa\Entity\EntityTypeManager $entityTypeManager,
         \Waaseyaa\Database\DatabaseInterface $database,
         \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $dispatcher,
     ): array {
+        $config = $this->config['mail'] ?? [];
+        $configured = trim((string) ($config['sendgrid_api_key'] ?? '')) !== ''
+            && trim((string) ($config['from_address'] ?? '')) !== '';
+
         return [
-            new MailTestCommand($this->resolve(MailDriverInterface::class)),
+            new MailTestCommand(
+                $this->resolve(MailerInterface::class),
+                $configured,
+            ),
         ];
     }
 }

--- a/src/Provider/MailServiceProvider.php
+++ b/src/Provider/MailServiceProvider.php
@@ -28,13 +28,15 @@ final class MailServiceProvider extends ServiceProvider
         \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $dispatcher,
     ): array {
         $config = $this->config['mail'] ?? [];
+        $fromAddress = trim((string) ($config['from_address'] ?? ''));
         $configured = trim((string) ($config['sendgrid_api_key'] ?? '')) !== ''
-            && trim((string) ($config['from_address'] ?? '')) !== '';
+            && $fromAddress !== '';
 
         return [
             new MailTestCommand(
                 $this->resolve(MailerInterface::class),
                 $configured,
+                $fromAddress,
             ),
         ];
     }

--- a/src/Support/Command/MailTestCommand.php
+++ b/src/Support/Command/MailTestCommand.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Minoo\Support\Command;
 
-use Waaseyaa\Mail\MailDriverInterface;
-use Waaseyaa\Mail\MailMessage;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Mail\Envelope;
+use Waaseyaa\Mail\MailerInterface;
 
 #[AsCommand(name: 'mail:test', description: 'Send a test email to verify SendGrid configuration')]
 final class MailTestCommand extends Command
 {
-    public function __construct(private readonly MailDriverInterface $mailService)
-    {
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        private readonly bool $mailConfigured,
+    ) {
         parent::__construct();
     }
 
@@ -27,22 +29,22 @@ final class MailTestCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $email = $input->getArgument('email');
+        $email = (string) $input->getArgument('email');
 
-        if (!$this->mailService->isConfigured()) {
+        if (!$this->mailConfigured) {
             $output->writeln('<error>Mail is not configured. Set SENDGRID_API_KEY in your environment.</error>');
             return self::FAILURE;
         }
 
         try {
-            $statusCode = $this->mailService->send(new MailMessage(
+            $this->mailer->send(new Envelope(
+                to: [$email],
                 from: '',
-                to: $email,
                 subject: '[Minoo] Mail test',
-                body: 'This is a test email from Minoo. If you received this, SendGrid is working.',
+                textBody: 'This is a test email from Minoo. If you received this, SendGrid is working.',
             ));
 
-            $output->writeln("<info>Test email sent to {$email} (HTTP {$statusCode}). Check your inbox (and spam).</info>");
+            $output->writeln("<info>Test email sent to {$email}. Check your inbox (and spam).</info>");
             return self::SUCCESS;
         } catch (\Throwable $e) {
             $output->writeln('<error>Failed to send test email: ' . $e->getMessage() . '</error>');

--- a/src/Support/Command/MailTestCommand.php
+++ b/src/Support/Command/MailTestCommand.php
@@ -18,6 +18,7 @@ final class MailTestCommand extends Command
     public function __construct(
         private readonly MailerInterface $mailer,
         private readonly bool $mailConfigured,
+        private readonly string $mailFromAddress,
     ) {
         parent::__construct();
     }
@@ -39,7 +40,7 @@ final class MailTestCommand extends Command
         try {
             $this->mailer->send(new Envelope(
                 to: [$email],
-                from: '',
+                from: $this->mailFromAddress,
                 subject: '[Minoo] Mail test',
                 textBody: 'This is a test email from Minoo. If you received this, SendGrid is working.',
             ));

--- a/src/Support/Command/MessagingDigestCommand.php
+++ b/src/Support/Command/MessagingDigestCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minoo\Support\Command;
+
+use Minoo\Support\MessageDigestCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'messaging:digest', description: 'Send email digests for unread thread messages (cron)')]
+final class MessagingDigestCommand extends Command
+{
+    public function __construct(
+        private readonly MessageDigestCommand $digest,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->digest->execute();
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Support/MessageDigestCommand.php
+++ b/src/Support/MessageDigestCommand.php
@@ -15,6 +15,7 @@ final class MessageDigestCommand
         private readonly MailerInterface $mailer,
         private readonly bool $mailConfigured,
         private readonly array $config,
+        private readonly string $mailFromAddress,
     ) {}
 
     public function execute(): void
@@ -126,7 +127,7 @@ final class MessageDigestCommand
 
         $this->mailer->send(new Envelope(
             to: [$email],
-            from: '',
+            from: $this->mailFromAddress,
             subject: $subject,
             textBody: $body,
         ));

--- a/src/Support/MessageDigestCommand.php
+++ b/src/Support/MessageDigestCommand.php
@@ -5,20 +5,21 @@ declare(strict_types=1);
 namespace Minoo\Support;
 
 use Waaseyaa\Entity\EntityTypeManager;
-use Waaseyaa\Mail\MailDriverInterface;
-use Waaseyaa\Mail\MailMessage;
+use Waaseyaa\Mail\Envelope;
+use Waaseyaa\Mail\MailerInterface;
 
 final class MessageDigestCommand
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly MailDriverInterface $mailService,
+        private readonly MailerInterface $mailer,
+        private readonly bool $mailConfigured,
         private readonly array $config,
     ) {}
 
     public function execute(): void
     {
-        if (!$this->mailService->isConfigured()) {
+        if (!$this->mailConfigured) {
             return;
         }
 
@@ -123,11 +124,11 @@ final class MessageDigestCommand
         $body .= "\nOpen Messages: https://minoo.sagamok.ca/messages\n";
         $body .= "\n--\nMinoo - Sagamok Anishnawbek Community Platform\n";
 
-        $this->mailService->send(new MailMessage(
+        $this->mailer->send(new Envelope(
+            to: [$email],
             from: '',
-            to: $email,
             subject: $subject,
-            body: $body,
+            textBody: $body,
         ));
     }
 }

--- a/tests/Minoo/Unit/Support/MessageDigestCommandTest.php
+++ b/tests/Minoo/Unit/Support/MessageDigestCommandTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Minoo\Tests\Unit\Support;
 
-use Waaseyaa\Mail\MailDriverInterface;
 use Minoo\Support\MessageDigestCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -12,34 +11,34 @@ use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityQueryInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Mail\MailerInterface;
 
 #[CoversClass(MessageDigestCommand::class)]
 final class MessageDigestCommandTest extends TestCase
 {
     private EntityTypeManager $etm;
-    private MailDriverInterface $mailService;
+
+    private MailerInterface $mailer;
 
     protected function setUp(): void
     {
         $this->etm = $this->createMock(EntityTypeManager::class);
-        $this->mailService = $this->createMock(MailDriverInterface::class);
+        $this->mailer = $this->createMock(MailerInterface::class);
     }
 
     #[Test]
     public function it_skips_when_mail_not_configured(): void
     {
-        $this->mailService->method('isConfigured')->willReturn(false);
-        $this->mailService->expects($this->never())->method('send');
+        $this->mailer->expects($this->never())->method('send');
 
-        $command = new MessageDigestCommand($this->etm, $this->mailService, []);
+        $command = new MessageDigestCommand($this->etm, $this->mailer, false, []);
         $command->execute();
     }
 
     #[Test]
     public function it_skips_users_with_no_unread(): void
     {
-        $this->mailService->method('isConfigured')->willReturn(true);
-        $this->mailService->expects($this->never())->method('send');
+        $this->mailer->expects($this->never())->method('send');
 
         $participantStorage = $this->createMock(EntityStorageInterface::class);
         $query = $this->createMock(EntityQueryInterface::class);
@@ -56,7 +55,7 @@ final class MessageDigestCommandTest extends TestCase
             ['user', $userStorage],
         ]);
 
-        $command = new MessageDigestCommand($this->etm, $this->mailService, []);
+        $command = new MessageDigestCommand($this->etm, $this->mailer, true, []);
         $command->execute();
     }
 }

--- a/tests/Minoo/Unit/Support/MessageDigestCommandTest.php
+++ b/tests/Minoo/Unit/Support/MessageDigestCommandTest.php
@@ -31,7 +31,7 @@ final class MessageDigestCommandTest extends TestCase
     {
         $this->mailer->expects($this->never())->method('send');
 
-        $command = new MessageDigestCommand($this->etm, $this->mailer, false, []);
+        $command = new MessageDigestCommand($this->etm, $this->mailer, false, [], 'noreply@minoo.test');
         $command->execute();
     }
 
@@ -55,7 +55,7 @@ final class MessageDigestCommandTest extends TestCase
             ['user', $userStorage],
         ]);
 
-        $command = new MessageDigestCommand($this->etm, $this->mailer, true, []);
+        $command = new MessageDigestCommand($this->etm, $this->mailer, true, [], 'noreply@minoo.test');
         $command->execute();
     }
 }


### PR DESCRIPTION
## Summary

Consumes the framework mail consolidation ([waaseyaa/framework#1166](https://github.com/waaseyaa/framework/pull/1166)): `MailDriverInterface` / `MailMessage` are removed upstream.

- `MailServiceProvider`: stop registering a duplicate SendGrid driver; `MailTestCommand` resolves `MailerInterface`.
- `MailTestCommand` / `MessageDigestCommand`: use `Envelope` + `MailerInterface`; digest command takes `mailConfigured` flag.
- `CLAUDE.md`: auth-mail gotcha updated.

## Merge order

1. Land and **tag** [framework #1166](https://github.com/waaseyaa/framework/pull/1166) (or merge together if using path repos).
2. Run `composer update 'waaseyaa/*'` on Minoo if needed, then merge this PR.

Related: [waaseyaa/framework#1157](https://github.com/waaseyaa/framework/issues/1157)

Made with [Cursor](https://cursor.com)