### PR TITLE
fix(config): Mercure messaging env via explicit getenv() fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 # Overlay jobs clone waaseyaa/framework to rsync admin-surface/cli into vendor so CI matches
 # monorepo main when split packages lag Packagist. Use `main` (not Minoo branch names): the
-# framework repo does not mirror Minoo feature branch names.
+# framework repo does not mirror Minoo feature branch names. Do not pin PR/topic branches here —
+# they are deleted after merge and will break checkout.
 env:
   WAASEYAA_FRAMEWORK_REF: main
 

--- a/config/messaging.php
+++ b/config/messaging.php
@@ -2,13 +2,25 @@
 
 declare(strict_types=1);
 
+// getenv() returns false when unset; ?? does not fall back on false (only null).
+// Be explicit so hub URL and secrets match Laravel env()-style semantics.
+$mercureHubUrl = getenv('MERCURE_HUB_URL');
+if ($mercureHubUrl === false || $mercureHubUrl === '') {
+    $mercureHubUrl = 'http://localhost:3000/.well-known/mercure';
+}
+
+$mercureJwtSecret = getenv('MERCURE_JWT_SECRET');
+if ($mercureJwtSecret === false) {
+    $mercureJwtSecret = '';
+}
+
 return [
     'max_message_length' => 2000,
     'typing_indicator_ttl' => 5,
     'digest_interval' => '4h',
     'digest_debounce' => 15,
     'digest_active_skip' => 30,
-    'mercure_hub_url' => env('MERCURE_HUB_URL', 'http://localhost:3000/.well-known/mercure'),
-    'mercure_jwt_secret' => env('MERCURE_JWT_SECRET', ''),
+    'mercure_hub_url' => $mercureHubUrl,
+    'mercure_jwt_secret' => $mercureJwtSecret,
     'polling_fallback_interval' => 10,
 ];


### PR DESCRIPTION
## Summary

`config/messaging.php` on `main` referenced Laravel-style `env()`, which is not defined when this file is loaded. This replaces that with explicit `getenv()` handling:

- **Unset** (`false`) or **empty** hub URL → default `http://localhost:3000/.well-known/mercure`
- **Unset** JWT secret → `''` (explicit empty env value is preserved)

## Checklist

- [ ] Link an issue if one exists (none provided)
- [ ] Issue in a milestone (N/A until issue exists)


Made with [Cursor](https://cursor.com)