### PR TITLE
fix(#717): remove always-false ternary in IcsBuilder::foldLine

### DIFF
--- a/src/Support/IcsBuilder.php
+++ b/src/Support/IcsBuilder.php
@@ -139,9 +139,10 @@ final class IcsBuilder
             $line  = substr($line, $cut);
             $first = false;
         }
-        // Remainder.
+        // Remainder. Loop ran at least once (only reached when line > 75 octets),
+        // so $first is always false here — always emit as a continuation.
         if ($line !== '') {
-            $out .= $first ? $line : (self::CRLF . ' ' . $line);
+            $out .= self::CRLF . ' ' . $line;
         }
         return $out;
     }


### PR DESCRIPTION
Fixes the single PHPStan `ternary.alwaysFalse` error introduced by #718.

The remainder-emission branch in `foldLine()` is only reachable after the while loop has iterated at least once (the loop is entered only when `strlen($line) > 75`), so `$first` is always false by that point. Simplified to always emit as a continuation with CRLF + space.

## Test plan
- [x] `./vendor/bin/phpunit --filter IcsBuilderTest` → 7/7 pass
- [ ] CI PHPStan clean (new error gone; pre-existing baseline drift is separate)