### PR TITLE
feat(og): dynamic Open Graph PNGs for public detail pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,25 @@ FROM php:8.4-fpm-alpine AS base
 RUN apk add --no-cache \
     sqlite-libs \
     icu-libs \
-    && docker-php-ext-install \
+    freetype \
+    libpng \
+    libjpeg-turbo \
+    ttf-dejavu \
+    freetype-dev \
+    libpng-dev \
+    libjpeg-turbo-dev \
+    $PHPIZE_DEPS \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+    gd \
     intl \
     opcache \
-    pdo_sqlite
+    pdo_sqlite \
+    && apk del --no-cache \
+    freetype-dev \
+    libpng-dev \
+    libjpeg-turbo-dev \
+    $PHPIZE_DEPS
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
         "phpunit/phpunit": "^10.5",
         "waaseyaa/testing": "^0.1"
     },
+    "suggest": {
+        "ext-gd": "Required for dynamic Open Graph PNG images (GD + FreeType)."
+    },
     "autoload": {
         "psr-4": {
             "App\\": "src/"

--- a/src/Controller/OpenGraphController.php
+++ b/src/Controller/OpenGraphController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Support\OgImageRenderer;
+use App\Support\PublicOgEntityLoader;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+final class OpenGraphController
+{
+    private const CACHE_MAX_AGE = 86400;
+
+    /** @var array{0: int, 1: int, 2: int} */
+    private const ACCENT_BUSINESS = [216, 86, 64];
+
+    /** @var array{0: int, 1: int, 2: int} */
+    private const ACCENT_EVENT = [230, 57, 70];
+
+    /** @var array{0: int, 1: int, 2: int} */
+    private const ACCENT_TEACHING = [244, 162, 97];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly OgImageRenderer $ogImageRenderer,
+    ) {}
+
+    /** @param array<string, mixed> $params */
+    /** @param array<string, mixed> $query */
+    public function businessPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $slug = (string) ($params['slug'] ?? '');
+        $entity = PublicOgEntityLoader::loadBusiness($this->entityTypeManager, $slug);
+
+        return $this->pngForEntity($request, $entity, 'Business', self::ACCENT_BUSINESS, static function (EntityInterface $e): string {
+            return (string) $e->get('name');
+        });
+    }
+
+    /** @param array<string, mixed> $params */
+    /** @param array<string, mixed> $query */
+    public function eventPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $slug = (string) ($params['slug'] ?? '');
+        $entity = PublicOgEntityLoader::loadEvent($this->entityTypeManager, $slug);
+
+        return $this->pngForEntity($request, $entity, 'Event', self::ACCENT_EVENT, static function (EntityInterface $e): string {
+            return (string) $e->get('title');
+        });
+    }
+
+    /** @param array<string, mixed> $params */
+    /** @param array<string, mixed> $query */
+    public function teachingPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $slug = (string) ($params['slug'] ?? '');
+        $entity = PublicOgEntityLoader::loadTeaching($this->entityTypeManager, $slug);
+
+        return $this->pngForEntity($request, $entity, 'Teaching', self::ACCENT_TEACHING, static function (EntityInterface $e): string {
+            return (string) $e->get('title');
+        });
+    }
+
+    /**
+     * @param array{0: int, 1: int, 2: int} $accentRgb
+     * @param callable(EntityInterface): string $titleResolver
+     */
+    private function pngForEntity(
+        HttpRequest $request,
+        ?EntityInterface $entity,
+        string $subtitle,
+        array $accentRgb,
+        callable $titleResolver,
+    ): Response {
+        if ($entity === null) {
+            return new Response('', 404);
+        }
+
+        $title = $titleResolver($entity);
+        $etag = '"' . hash('sha256', $entity->uuid() . '|' . $subtitle . '|' . $title) . '"';
+
+        $response = new Response();
+        $response->headers->set('Content-Type', 'image/png');
+        $response->setPublic();
+        $response->setMaxAge(self::CACHE_MAX_AGE);
+        $response->setEtag($etag);
+
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        $binary = $this->ogImageRenderer->renderPng($title, $subtitle, $accentRgb);
+        $response->setContent($binary);
+
+        return $response;
+    }
+}

--- a/src/Provider/AppServiceProvider.php
+++ b/src/Provider/AppServiceProvider.php
@@ -61,6 +61,7 @@ use App\Twig\AccountDisplayTwigExtension;
 use App\Twig\DateTwigExtension;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 use Waaseyaa\AdminSurface\AdminSurfaceServiceProvider;
 use Waaseyaa\AdminSurface\Host\GenericAdminSurfaceHost;
 use Waaseyaa\Api\Schema\SchemaPresenter;
@@ -121,6 +122,10 @@ final class AppServiceProvider extends ServiceProvider
         });
 
         $this->singleton(UrlPrefixNegotiator::class, fn() => new UrlPrefixNegotiator());
+
+        $this->singleton(\App\Support\OgImageRenderer::class, function (): \App\Support\OgImageRenderer {
+            return new \App\Support\OgImageRenderer(dirname(__DIR__, 2));
+        });
 
         // =====================================================================
         // --- Rate limiting ---
@@ -1662,6 +1667,16 @@ final class AppServiceProvider extends ServiceProvider
                 ->build(),
         );
 
+        $router->addRoute(
+            'og.event.png',
+            RouteBuilder::create('/og/event/{slug}.png')
+                ->controller('App\\Controller\\OpenGraphController::eventPng')
+                ->allowAll()
+                ->methods('GET')
+                ->requirement('slug', '[a-z0-9][a-z0-9-]*[a-z0-9]')
+                ->build(),
+        );
+
         // =====================================================================
         // --- Groups ---
         // =====================================================================
@@ -1708,6 +1723,16 @@ final class AppServiceProvider extends ServiceProvider
                 ->build(),
         );
 
+        $router->addRoute(
+            'og.business.png',
+            RouteBuilder::create('/og/business/{slug}.png')
+                ->controller('App\\Controller\\OpenGraphController::businessPng')
+                ->allowAll()
+                ->methods('GET')
+                ->requirement('slug', '[a-z0-9][a-z0-9-]*[a-z0-9]')
+                ->build(),
+        );
+
         // =====================================================================
         // --- Teachings ---
         // =====================================================================
@@ -1728,6 +1753,16 @@ final class AppServiceProvider extends ServiceProvider
                 ->controller('App\\Controller\\TeachingController::show')
                 ->allowAll()
                 ->render()
+                ->methods('GET')
+                ->requirement('slug', '[a-z0-9][a-z0-9-]*[a-z0-9]')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'og.teaching.png',
+            RouteBuilder::create('/og/teaching/{slug}.png')
+                ->controller('App\\Controller\\OpenGraphController::teachingPng')
+                ->allowAll()
                 ->methods('GET')
                 ->requirement('slug', '[a-z0-9][a-z0-9-]*[a-z0-9]')
                 ->build(),
@@ -3765,6 +3800,22 @@ final class AppServiceProvider extends ServiceProvider
                 $event->entity->set('updated_at', time());
             }
         });
+
+        // =====================================================================
+        // --- Twig: site_base_url for og:image / og:url absolute URLs ---
+        // =====================================================================
+
+        $siteBase = rtrim((string) ($this->config['mail']['base_url'] ?? 'https://minoo.live'), '/');
+        /** @var array<int, Environment> $twigTargets */
+        $twigTargets = [];
+        foreach ([SsrServiceProvider::getTwigEnvironment(), ThemeServiceProvider::getTwigEnvironment()] as $env) {
+            if ($env instanceof Environment) {
+                $twigTargets[spl_object_id($env)] = $env;
+            }
+        }
+        foreach ($twigTargets as $env) {
+            $env->addGlobal('site_base_url', $siteBase);
+        }
     }
 
     /**

--- a/src/Support/OgImageRenderer.php
+++ b/src/Support/OgImageRenderer.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use RuntimeException;
+
+/**
+ * Renders 1200×630 Open Graph card PNGs (GD + FreeType).
+ */
+final class OgImageRenderer
+{
+    public const WIDTH = 1200;
+
+    public const HEIGHT = 630;
+
+    /** @var list<string> */
+    private array $fontCandidates;
+
+    public function __construct(
+        private readonly string $projectRoot,
+        private readonly ?string $boldFontOverride = null,
+    ) {
+        $this->fontCandidates = array_values(array_filter([
+            $this->boldFontOverride,
+            getenv('MINOO_OG_FONT_BOLD') ?: null,
+            '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+            '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
+            $this->projectRoot . '/storage/fonts/DejaVuSans-Bold.ttf',
+        ], static fn (?string $p): bool => $p !== null && $p !== ''));
+    }
+
+    /**
+     * @param array{0: int, 1: int, 2: int} $accentRgb
+     */
+    public function renderPng(string $title, string $subtitle, array $accentRgb): string
+    {
+        if (!extension_loaded('gd')) {
+            throw new RuntimeException('PHP GD extension is required for Open Graph images.');
+        }
+
+        $font = $this->resolveFontPath();
+        if ($font === null) {
+            throw new RuntimeException(
+                'No TrueType font found for OG images. Install ttf-dejavu or set MINOO_OG_FONT_BOLD.',
+            );
+        }
+
+        $im = imagecreatetruecolor(self::WIDTH, self::HEIGHT);
+        if ($im === false) {
+            throw new RuntimeException('imagecreatetruecolor failed.');
+        }
+
+        $bg = imagecolorallocate($im, 10, 10, 10);
+        $textPrimary = imagecolorallocate($im, 240, 236, 230);
+        $textMuted = imagecolorallocate($im, 160, 160, 150);
+        $accent = imagecolorallocate(
+            $im,
+            max(0, min(255, $accentRgb[0])),
+            max(0, min(255, $accentRgb[1])),
+            max(0, min(255, $accentRgb[2])),
+        );
+
+        imagefilledrectangle($im, 0, 0, self::WIDTH, self::HEIGHT, $bg);
+        imagefilledrectangle($im, 0, 0, 14, self::HEIGHT, $accent);
+
+        $paddingX = 72;
+        $paddingY = 64;
+        $maxTextWidth = self::WIDTH - $paddingX * 2;
+
+        $subtitleSize = 26;
+        $titleSize = 52;
+        $footerSize = 20;
+
+        $y = $paddingY + $subtitleSize;
+        $this->drawTtfLine($im, $font, $subtitleSize, $paddingX, $y, $textMuted, $subtitle);
+
+        $y += (int) ($subtitleSize * 1.8);
+        $lines = $this->wrapTitle($font, $title, $titleSize, $maxTextWidth, 4);
+        foreach ($lines as $line) {
+            $this->drawTtfLine($im, $font, $titleSize, $paddingX, $y, $textPrimary, $line);
+            $y += (int) ($titleSize * 1.15);
+        }
+
+        $footer = 'minoo.live';
+        $bbox = imagettfbbox($footerSize, 0, $font, $footer);
+        if ($bbox !== false) {
+            $fw = abs($bbox[2] - $bbox[0]);
+            $fx = self::WIDTH - $paddingX - $fw;
+            $fy = self::HEIGHT - 48;
+            imagettftext($im, $footerSize, 0, $fx, $fy, $textMuted, $font, $footer);
+        }
+
+        ob_start();
+        imagepng($im, null, 6);
+        $binary = (string) ob_get_clean();
+        imagedestroy($im);
+
+        return $binary;
+    }
+
+    private function resolveFontPath(): ?string
+    {
+        foreach ($this->fontCandidates as $path) {
+            if (is_readable($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function wrapTitle(string $font, string $title, int $fontSize, int $maxWidth, int $maxLines): array
+    {
+        $title = trim($title);
+        if ($title === '') {
+            return ['Minoo'];
+        }
+
+        $words = preg_split('/\s+/u', $title) ?: [];
+        $lines = [];
+        $current = '';
+
+        foreach ($words as $word) {
+            $trial = $current === '' ? $word : $current . ' ' . $word;
+            $w = $this->textWidth($font, $fontSize, $trial);
+            if ($w <= $maxWidth) {
+                $current = $trial;
+                continue;
+            }
+
+            if ($current !== '') {
+                $lines[] = $current;
+                $current = $word;
+            } else {
+                $lines[] = $this->truncateToWidth($font, $fontSize, $word, $maxWidth);
+                $current = '';
+            }
+
+            if (count($lines) >= $maxLines) {
+                $lines[$maxLines - 1] = $this->appendEllipsis(
+                    $font,
+                    $fontSize,
+                    $lines[$maxLines - 1],
+                    $maxWidth,
+                );
+
+                return $lines;
+            }
+        }
+
+        if ($current !== '') {
+            $lines[] = $current;
+        }
+
+        return $lines !== [] ? $lines : ['Minoo'];
+    }
+
+    private function appendEllipsis(string $font, int $fontSize, string $line, int $maxWidth): string
+    {
+        $ellipsis = '…';
+        $base = $line;
+        while ($base !== '' && $this->textWidth($font, $fontSize, $base . $ellipsis) > $maxWidth) {
+            $base = mb_substr($base, 0, -1);
+        }
+
+        return $base === '' ? $ellipsis : $base . $ellipsis;
+    }
+
+    private function truncateToWidth(string $font, int $fontSize, string $word, int $maxWidth): string
+    {
+        if ($this->textWidth($font, $fontSize, $word) <= $maxWidth) {
+            return $word;
+        }
+
+        $ellipsis = '…';
+        $cut = $word;
+        while (mb_strlen($cut) > 1 && $this->textWidth($font, $fontSize, $cut . $ellipsis) > $maxWidth) {
+            $cut = mb_substr($cut, 0, -1);
+        }
+
+        return $cut . $ellipsis;
+    }
+
+    private function textWidth(string $font, int $fontSize, string $text): int
+    {
+        $bbox = imagettfbbox($fontSize, 0, $font, $text);
+
+        return $bbox !== false ? abs((int) ($bbox[2] - $bbox[0])) : 0;
+    }
+
+    private function drawTtfLine(\GdImage $im, string $font, int $size, int $x, int $y, int $color, string $text): void
+    {
+        imagettftext($im, $size, 0, $x, $y, $color, $font, $text);
+    }
+}

--- a/src/Support/PublicOgEntityLoader.php
+++ b/src/Support/PublicOgEntityLoader.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Loads entities for Open Graph image URLs using the same public visibility
+ * rules as the corresponding HTML detail controllers.
+ */
+final class PublicOgEntityLoader
+{
+    public static function loadBusiness(EntityTypeManager $entityTypeManager, string $slug): ?EntityInterface
+    {
+        if ($slug === '') {
+            return null;
+        }
+
+        $storage = $entityTypeManager->getStorage('group');
+        $ids = $storage->getQuery()
+            ->condition('slug', $slug)
+            ->condition('type', 'business')
+            ->condition('status', 1)
+            ->execute();
+        $business = $ids !== [] ? $storage->load(reset($ids)) : null;
+
+        if ($business !== null && $business->get('type') !== 'business') {
+            $business = null;
+        }
+
+        if ($business !== null) {
+            $mediaId = $business->get('media_id');
+            if ($mediaId !== null && $mediaId !== '') {
+                $status = $business->get('copyright_status');
+                if (!in_array($status, ['community_owned', 'cc_by_nc_sa'], true)) {
+                    $business = null;
+                }
+            }
+        }
+
+        return $business;
+    }
+
+    public static function loadEvent(EntityTypeManager $entityTypeManager, string $slug): ?EntityInterface
+    {
+        if ($slug === '') {
+            return null;
+        }
+
+        $storage = $entityTypeManager->getStorage('event');
+        $ids = $storage->getQuery()
+            ->condition('slug', $slug)
+            ->condition('status', 1)
+            ->execute();
+        $event = $ids !== [] ? $storage->load(reset($ids)) : null;
+
+        if ($event !== null) {
+            $mediaId = $event->get('media_id');
+            if ($mediaId !== null && $mediaId !== '') {
+                $status = $event->get('copyright_status');
+                if (!in_array($status, ['community_owned', 'cc_by_nc_sa'], true)) {
+                    $event = null;
+                }
+            }
+        }
+
+        return $event;
+    }
+
+    public static function loadTeaching(EntityTypeManager $entityTypeManager, string $slug): ?EntityInterface
+    {
+        if ($slug === '') {
+            return null;
+        }
+
+        $storage = $entityTypeManager->getStorage('teaching');
+        $ids = $storage->getQuery()
+            ->condition('slug', $slug)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->execute();
+        $teaching = $ids !== [] ? $storage->load(reset($ids)) : null;
+
+        if ($teaching !== null) {
+            $mediaId = $teaching->get('media_id');
+            if ($mediaId !== null && $mediaId !== '') {
+                $status = $teaching->get('copyright_status');
+                if (!in_array($status, ['community_owned', 'cc_by_nc_sa'], true)) {
+                    $teaching = null;
+                }
+            }
+        }
+
+        return $teaching;
+    }
+}

--- a/templates/layouts/base.html.twig
+++ b/templates/layouts/base.html.twig
@@ -9,8 +9,8 @@
   <meta name="description" content="{% block meta_description %}{{ trans('og.default_description') }}{% endblock %}">
   <meta property="og:title" content="{% block og_title %}{{ block('title') }}{% endblock %}">
   <meta property="og:description" content="{% block og_description %}{{ trans('og.default_description') }}{% endblock %}">
-  <meta property="og:image" content="{% block og_image %}https://minoo.live/img/og-default.png{% endblock %}">
-  <meta property="og:url" content="https://minoo.live{{ path is defined ? lang_url(path) : lang_url('/') }}">
+  <meta property="og:image" content="{% block og_image %}{{ site_base_url }}/img/og-default.png{% endblock %}">
+  <meta property="og:url" content="{{ site_base_url }}{{ path is defined ? lang_url(path) : lang_url('/') }}">
   <meta property="og:type" content="{% block og_type %}website{% endblock %}">
   <meta property="og:site_name" content="Minoo">
   <meta name="twitter:card" content="summary_large_image">

--- a/templates/pages/businesses/show.html.twig
+++ b/templates/pages/businesses/show.html.twig
@@ -10,6 +10,7 @@
 
 {% block og_type %}{% if business is defined and business %}article{% else %}website{% endif %}{% endblock %}
 {% block og_description %}{% if business is defined and business %}{{ business.get('description')|default('')|striptags|slice(0, 160) }}{% else %}{{ parent() }}{% endif %}{% endblock %}
+{% block og_image %}{% if business is defined and business %}{{ site_base_url }}/og/business/{{ business.get('slug') }}.png{% else %}{{ parent() }}{% endif %}{% endblock %}
 
 {% block content %}
   {% if business is defined and business %}

--- a/templates/pages/elders/index.html.twig
+++ b/templates/pages/elders/index.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ trans('elders.title') }} — Minoo{% endblock %}
 {% block og_title %}Elder Support Program — Minoo{% endblock %}
 {% block og_description %}Rides, groceries, yard work, visits. Our Elders shouldn't have to ask twice. Request help or volunteer your time.{% endblock %}
-{% block og_image %}https://minoo.live/img/og-elder-support.png{% endblock %}
+{% block og_image %}{{ site_base_url }}/img/og-elder-support.png{% endblock %}
 
 {% block content %}
 <div class="elders-page">

--- a/templates/pages/events/show.html.twig
+++ b/templates/pages/events/show.html.twig
@@ -10,6 +10,7 @@
 
 {% block og_type %}{% if event is defined and event %}article{% else %}website{% endif %}{% endblock %}
 {% block og_description %}{% if event is defined and event %}{{ event.get('description')|default('')|striptags|slice(0, 160) }}{% else %}{{ parent() }}{% endif %}{% endblock %}
+{% block og_image %}{% if event is defined and event %}{{ site_base_url }}/og/event/{{ event.get('slug') }}.png{% else %}{{ parent() }}{% endif %}{% endblock %}
 
 {% block content %}
   {% if event is defined and event %}

--- a/templates/pages/teachings/show.html.twig
+++ b/templates/pages/teachings/show.html.twig
@@ -10,6 +10,7 @@
 
 {% block og_type %}{% if teaching is defined and teaching %}article{% else %}website{% endif %}{% endblock %}
 {% block og_description %}{% if teaching is defined and teaching %}{{ teaching.get('content')|default('')|striptags|slice(0, 160) }}{% else %}{{ parent() }}{% endif %}{% endblock %}
+{% block og_image %}{% if teaching is defined and teaching %}{{ site_base_url }}/og/teaching/{{ teaching.get('slug') }}.png{% else %}{{ parent() }}{% endif %}{% endblock %}
 
 {% block content %}
   {% if teaching is defined and teaching %}

--- a/tests/App/Integration/Http/OpenGraphRouteTest.php
+++ b/tests/App/Integration/Http/OpenGraphRouteTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use App\Entity\Community;
+use App\Entity\Event;
+use App\Entity\Group;
+use App\Entity\Teaching;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Open Graph PNG routes: public entity visibility matches HTML detail pages.
+ */
+#[CoversNothing]
+final class OpenGraphRouteTest extends HttpKernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $etm = self::$kernel->getEntityTypeManager();
+
+        $communityStorage = $etm->getStorage('community');
+        $community = new Community([
+            'title' => 'Wiikwemkoong',
+            'slug' => 'wiikwemkoong',
+            'type' => 'unceded',
+            'status' => 1,
+            'content' => 'Wiikwemkoong Unceded Territory.',
+        ]);
+        $communityStorage->save($community);
+        $communityId = $community->id();
+
+        $groupStorage = $etm->getStorage('group');
+        $public = new Group([
+            'name' => 'Nginaajiiw Salon & Spa',
+            'slug' => 'nginaajiiw-salon-spa',
+            'type' => 'business',
+            'status' => 1,
+            'consent_public' => 1,
+            'consent_ai_training' => 0,
+            'description' => 'A community-owned wellness studio.',
+            'community_id' => (string) $communityId,
+            'copyright_status' => 'community_owned',
+        ]);
+        $groupStorage->save($public);
+
+        $eventStorage = $etm->getStorage('event');
+        $event = new Event([
+            'title' => 'Spring Gathering',
+            'slug' => 'og-fixture-event',
+            'type' => 'gathering',
+            'description' => 'Public fixture event for OG route tests.',
+            'community_id' => (string) $communityId,
+            'copyright_status' => 'community_owned',
+        ]);
+        $eventStorage->save($event);
+
+        $teachingStorage = $etm->getStorage('teaching');
+        $teaching = new Teaching([
+            'title' => 'Seven Grandfather Teachings',
+            'slug' => 'og-fixture-teaching',
+            'type' => 'story',
+            'content' => 'Fixture teaching for OG route tests.',
+            'community_id' => (string) $communityId,
+            'consent_public' => 1,
+            'copyright_status' => 'community_owned',
+        ]);
+        $teachingStorage->save($teaching);
+    }
+
+    #[Test]
+    public function business_og_png_ok(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+
+        $response = $this->send('GET', '/og/business/nginaajiiw-salon-spa.png');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->headers->get('Content-Type'));
+        $body = (string) $response->getContent();
+        self::assertStringStartsWith("\x89PNG\r\n\x1a\n", $body);
+        $cache = strtolower((string) $response->headers->get('Cache-Control'));
+        self::assertStringContainsString('public', $cache);
+    }
+
+    #[Test]
+    public function business_og_png_not_found(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+
+        $response = $this->send('GET', '/og/business/does-not-exist-zzzz.png');
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function event_og_png_ok(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+
+        $response = $this->send('GET', '/og/event/og-fixture-event.png');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->headers->get('Content-Type'));
+        self::assertStringStartsWith("\x89PNG\r\n\x1a\n", (string) $response->getContent());
+    }
+
+    #[Test]
+    public function teaching_og_png_ok(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+
+        $response = $this->send('GET', '/og/teaching/og-fixture-teaching.png');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->headers->get('Content-Type'));
+        self::assertStringStartsWith("\x89PNG\r\n\x1a\n", (string) $response->getContent());
+    }
+
+    #[Test]
+    public function business_og_png_returns_304_when_etag_matches(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+
+        $first = $this->send('GET', '/og/business/nginaajiiw-salon-spa.png');
+        self::assertSame(200, $first->getStatusCode());
+        $etag = $first->headers->get('ETag');
+        self::assertNotNull($etag);
+
+        $second = $this->send('GET', '/og/business/nginaajiiw-salon-spa.png', [], [
+            'HTTP_IF_NONE_MATCH' => $etag,
+        ]);
+        self::assertSame(Response::HTTP_NOT_MODIFIED, $second->getStatusCode());
+    }
+}

--- a/tests/App/Integration/Http/baselines/business_show_private.html
+++ b/tests/App/Integration/Http/baselines/business_show_private.html
@@ -9,7 +9,7 @@
   <meta name="description" content="Connecting Indigenous communities, Elders, and volunteers across Turtle Island.">
   <meta property="og:title" content="Cedar &amp; Stone — Minoo">
   <meta property="og:description" content="Private business record.">
-  <meta property="og:image" content="https://minoo.live/img/og-default.png">
+  <meta property="og:image" content="https://minoo.live/og/business/cedar-and-stone.png">
   <meta property="og:url" content="https://minoo.live/businesses/cedar-and-stone">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Minoo">

--- a/tests/App/Integration/Http/baselines/business_show_public.html
+++ b/tests/App/Integration/Http/baselines/business_show_public.html
@@ -9,7 +9,7 @@
   <meta name="description" content="Connecting Indigenous communities, Elders, and volunteers across Turtle Island.">
   <meta property="og:title" content="Nginaajiiw Salon &amp; Spa — Minoo">
   <meta property="og:description" content="A community-owned wellness studio.">
-  <meta property="og:image" content="https://minoo.live/img/og-default.png">
+  <meta property="og:image" content="https://minoo.live/og/business/nginaajiiw-salon-spa.png">
   <meta property="og:url" content="https://minoo.live/businesses/nginaajiiw-salon-spa">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Minoo">

--- a/tests/App/Unit/Support/OgImageRendererTest.php
+++ b/tests/App/Unit/Support/OgImageRendererTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Support;
+
+use App\Support\OgImageRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OgImageRenderer::class)]
+final class OgImageRendererTest extends TestCase
+{
+    private static function resolveDejaVuBold(): ?string
+    {
+        foreach ([
+            '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+            '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
+        ] as $path) {
+            if (is_readable($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    #[Test]
+    public function renderPng_produces_valid_png_signature(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd not loaded');
+        }
+        $font = self::resolveDejaVuBold();
+        if ($font === null) {
+            self::markTestSkipped('DejaVu Sans Bold TTF not found');
+        }
+
+        $renderer = new OgImageRenderer(
+            dirname(__DIR__, 4),
+            $font,
+        );
+        $png = $renderer->renderPng('Test Title For Open Graph', 'Business', [200, 80, 60]);
+
+        self::assertStringStartsWith("\x89PNG\r\n\x1a\n", $png);
+        self::assertGreaterThan(5000, strlen($png));
+    }
+}


### PR DESCRIPTION
Adds server-generated 1200×630 PNGs at `/og/business|event|teaching/{slug}.png` with the same public visibility rules as HTML show pages. Twig `site_base_url` (from `mail.base_url` / `MINOO_BASE_URL`) drives `og:image` and `og:url`. Dockerfile gains GD + FreeType + JPEG + DejaVu fonts. Tests cover PNG responses, 404, and 304 ETag handling.

Made with [Cursor](https://cursor.com)