### PR TITLE
migrate(#753): wp02 games → MapRoute/MapQuery

### DIFF
--- a/src/Controller/AgimController.php
+++ b/src/Controller/AgimController.php
@@ -12,6 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class AgimController
@@ -76,7 +78,7 @@ final class AgimController
     }
 
     /** Render the Agim game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/games/agim.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/agim',
@@ -88,7 +90,7 @@ final class AgimController
      * GET /api/games/agim/start?level={1-4}
      * Creates a new game session for the requested level.
      */
-    public function start(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function start(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $raw = (int) ($query['level'] ?? 1);
         $level = isset(self::TIERS[$raw]) ? $raw : 1;
@@ -120,7 +122,7 @@ final class AgimController
      * GET /api/games/agim/prompt?session_token=X
      * Returns the next numeral to answer.
      */
-    public function prompt(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function prompt(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = $query['session_token'] ?? '';
         if ($token === '') {
@@ -150,7 +152,7 @@ final class AgimController
      * Body: {session_token, numeral, answer}
      * Validates the answer, updates session state.
      */
-    public function answer(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function answer(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -211,7 +213,7 @@ final class AgimController
      * Body: {session_token}
      * Returns teaching data for all numbers in the level.
      */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function complete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -268,7 +270,7 @@ final class AgimController
     }
 
     /** GET /api/games/agim/stats — auth required (enforced at route level). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function stats(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(
             GameStatsCalculator::build($this->entityTypeManager, $account, 'agim', ['abandoned'], ['completed']),

--- a/src/Controller/CrosswordController.php
+++ b/src/Controller/CrosswordController.php
@@ -12,6 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CrosswordController
@@ -30,7 +32,7 @@ final class CrosswordController
     }
 
     /** Render the crossword game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/games/crossword.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/crossword',
@@ -39,7 +41,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/daily — today's puzzle. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function daily(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $puzzleId = "daily-{$today}";
@@ -72,7 +74,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/random — random practice puzzle. */
-    public function random(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function random(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $tier = $query['tier'] ?? 'easy';
         if (!in_array($tier, ['easy', 'medium', 'hard'], true)) {
@@ -119,7 +121,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/themes — list theme packs with progress. */
-    public function themes(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function themes(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $puzzleStorage = $this->entityTypeManager->getStorage('crossword_puzzle');
         $allIds = $puzzleStorage->getQuery()->execute();
@@ -172,7 +174,7 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/theme/{slug} — next unsolved puzzle in theme. */
-    public function theme(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function theme(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         if ($slug === '') {
@@ -244,7 +246,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/check — validate a word. */
-    public function check(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function check(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -326,7 +328,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/complete — submit finished puzzle. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function complete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -415,13 +417,13 @@ final class CrosswordController
     }
 
     /** GET /api/games/crossword/stats — player stats (auth required). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function stats(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'crossword', ['abandoned'], ['completed']));
     }
 
     /** POST /api/games/crossword/hint — reveal a letter (tracked server-side). */
-    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function hint(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -477,7 +479,7 @@ final class CrosswordController
     }
 
     /** POST /api/games/crossword/abandon — give up on current puzzle. */
-    public function abandon(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function abandon(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';

--- a/src/Controller/GuessPriceController.php
+++ b/src/Controller/GuessPriceController.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 /**
  * SSR page for the Guess the Price mini-game (no API, no GameSession).
  *
@@ -23,7 +25,7 @@ final class GuessPriceController
     ) {}
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/games/guess-price.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => $request->getPathInfo(),

--- a/src/Controller/JourneyController.php
+++ b/src/Controller/JourneyController.php
@@ -13,6 +13,8 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use App\Support\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -45,7 +47,7 @@ class JourneyController
     // ── Page ──────────────────────────────────────────────────────────────
 
     /** GET /games/journey */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/static/journey.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/journey',
@@ -56,7 +58,7 @@ class JourneyController
     // ── Scene listing and loading ─────────────────────────────────────────
 
     /** GET /api/games/journey/scenes — list all scenes (no hotspot coords). */
-    public function scenes(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function scenes(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(['scenes' => JourneyEngine::listScenes()]);
     }
@@ -67,7 +69,7 @@ class JourneyController
      * Returns scene data safe for the client (no hotspot coordinates) plus
      * a session token used for all subsequent tap/hint/complete calls.
      */
-    public function scene(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function scene(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         if ($slug === '') {
@@ -99,7 +101,7 @@ class JourneyController
      * The client never receives hotspot coordinates. It sends where the
      * player tapped; the server decides if it hit anything.
      */
-    public function tap(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function tap(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -170,7 +172,7 @@ class JourneyController
      * hint ("top-left", "bottom-right", etc.) — enough for the player to
      * narrow the search without revealing the exact location.
      */
-    public function hint(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function hint(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -232,7 +234,7 @@ class JourneyController
      * Called when the client detects scene_complete in a tap response.
      * Returns star rating, narrative card, and homestead unlock (if any).
      */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function complete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data  = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -279,7 +281,7 @@ class JourneyController
     // ── Stats ─────────────────────────────────────────────────────────────
 
     /** GET /api/games/journey/stats */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function stats(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'journey', ['abandoned'], ['completed']));
     }

--- a/src/Controller/MatcherController.php
+++ b/src/Controller/MatcherController.php
@@ -12,6 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class MatcherController
@@ -30,7 +32,7 @@ final class MatcherController
     }
 
     /** Render the game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/static/matcher.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/matcher',
@@ -40,7 +42,7 @@ final class MatcherController
     }
 
     /** GET /api/games/matcher/daily — today's matching pairs. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function daily(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $difficulty = 'easy';
@@ -71,7 +73,7 @@ final class MatcherController
     }
 
     /** GET /api/games/matcher/practice — random pairs by difficulty. */
-    public function practice(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function practice(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $difficulty = $query['difficulty'] ?? 'easy';
         if (!in_array($difficulty, ['easy', 'medium', 'hard'], true)) {
@@ -107,7 +109,7 @@ final class MatcherController
     }
 
     /** POST /api/games/matcher/match — validate a single match attempt. */
-    public function match(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function match(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -152,7 +154,7 @@ final class MatcherController
     }
 
     /** POST /api/games/matcher/complete — finish game, record stats. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function complete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -201,7 +203,7 @@ final class MatcherController
     }
 
     /** GET /api/games/matcher/stats — player stats. */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function stats(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build(
             $this->entityTypeManager,

--- a/src/Controller/ShkodaController.php
+++ b/src/Controller/ShkodaController.php
@@ -12,6 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\GateInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,13 +33,13 @@ final class ShkodaController
     }
 
     /** Redirect legacy /games/ishkode URL to /games/shkoda. */
-    public function redirectLegacy(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function redirectLegacy(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return new RedirectResponse('/games/shkoda', 301);
     }
 
     /** Render the game page. */
-    public function page(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function page(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $html = $this->twig->render('pages/games/shkoda.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/games/shkoda',
@@ -47,7 +49,7 @@ final class ShkodaController
     }
 
     /** GET /api/games/shkoda/daily — today's challenge metadata. */
-    public function daily(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function daily(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $today = date('Y-m-d');
         $dayOfWeek = (int) date('w');
@@ -115,7 +117,7 @@ final class ShkodaController
     }
 
     /** GET /api/games/shkoda/word — random word for practice/streak. */
-    public function word(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function word(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $mode = ($query['mode'] ?? 'practice') === 'streak' ? 'streak' : 'practice';
         $tier = $query['tier'] ?? 'easy';
@@ -174,7 +176,7 @@ final class ShkodaController
     }
 
     /** POST /api/games/shkoda/guess — validate a letter (daily mode only). */
-    public function guess(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function guess(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -254,7 +256,7 @@ final class ShkodaController
     }
 
     /** POST /api/games/shkoda/complete — submit completed game, get teaching data + stats. */
-    public function complete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function complete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $token = $data['session_token'] ?? '';
@@ -322,7 +324,7 @@ final class ShkodaController
     }
 
     /** GET /api/games/shkoda/stats — player stats (auth required). */
-    public function stats(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function stats(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->json(GameStatsCalculator::build($this->entityTypeManager, $account, 'shkoda'));
     }


### PR DESCRIPTION
## Summary
- Decorates `array $params` with `#[MapRoute]` and `array $query` with `#[MapQuery]` across the Games cluster.
- 6 controllers (Shkoda, Crossword, Agim, Journey, Matcher, GuessPrice).
- Adds `use Waaseyaa\SSR\Attribute\MapRoute;` and `use Waaseyaa\SSR\Attribute\MapQuery;` to each affected file.
- Token-aware byte splice (`token_get_all`); migration tool is transient and excluded from the diff.

## Verification
- [x] PHPUnit green: `OK, but some tests were skipped! Tests: 1091, Assertions: 3375, Skipped: 3.` (matches main baseline)
- [x] Cold-boot smoke routes return 200/non-zero body for all 6 controllers (`/games/shkoda`, `/games/crossword`, `/games/agim`, `/games/journey`, `/games/matcher`, `/games/guess-price`)
- [x] Cold-boot `dispatcher.deprecation` log shows zero entries naming WP02 cluster controllers
- [x] Migration tool idempotent (second `--dry-run` empty)
- [x] `scripts/migrate-controller-attributes.php` NOT in PR diff (transient working file, excluded via `.git/info/exclude`)
- [x] `GameControllerTrait` confirmed out-of-scope (no `\$params`/`\$query` params)

## Stats
- 6 files changed, 49 insertions(+), 37 deletions(-)
- 74 attribute splices (37 `#[MapRoute]` + 37 `#[MapQuery]`)
- 12 use-statement insertions (6 `MapRoute` + 6 `MapQuery`)

Part of #753 (v0.14 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)