### PR TITLE
migrate(#753): wp03 newsletter → MapRoute/MapQuery

### DIFF
--- a/src/Controller/NewsletterAdminApiController.php
+++ b/src/Controller/NewsletterAdminApiController.php
@@ -17,6 +17,8 @@ use Waaseyaa\Access\AccountInterface;
 use App\Support\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class NewsletterAdminApiController
 {
     use JsonResponseTrait;
@@ -32,7 +34,7 @@ final class NewsletterAdminApiController
         private readonly RenderTokenStore $tokenStore,
     ) {}
 
-    public function listEditions(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function listEditions(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('newsletter_edition');
         $editions = $storage->loadMultiple();
@@ -53,7 +55,7 @@ final class NewsletterAdminApiController
         return $this->json($result);
     }
 
-    public function createEdition(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function createEdition(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $body = $this->jsonBody($request);
         if ($body === []) {
@@ -96,7 +98,7 @@ final class NewsletterAdminApiController
         ], 201);
     }
 
-    public function getEdition(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function getEdition(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -168,7 +170,7 @@ final class NewsletterAdminApiController
         ]);
     }
 
-    public function addItem(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function addItem(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('newsletter_edition');
@@ -218,7 +220,7 @@ final class NewsletterAdminApiController
         ], 201);
     }
 
-    public function removeItem(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function removeItem(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $editionId = (int) ($params['id'] ?? 0);
         $itemId = (int) ($params['itemId'] ?? 0);
@@ -234,7 +236,7 @@ final class NewsletterAdminApiController
         return $this->json(['deleted' => true]);
     }
 
-    public function reorderItem(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function reorderItem(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $editionId = (int) ($params['id'] ?? 0);
         $itemId = (int) ($params['itemId'] ?? 0);
@@ -264,7 +266,7 @@ final class NewsletterAdminApiController
         ]);
     }
 
-    public function entitySearch(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function entitySearch(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $q = trim($query['q'] ?? '');
         if ($q === '') {
@@ -300,7 +302,7 @@ final class NewsletterAdminApiController
         return $this->json(['results' => $results]);
     }
 
-    public function previewToken(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function previewToken(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -320,7 +322,7 @@ final class NewsletterAdminApiController
         ]);
     }
 
-    public function generate(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function generate(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -350,7 +352,7 @@ final class NewsletterAdminApiController
         }
     }
 
-    public function download(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function download(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -378,7 +380,7 @@ final class NewsletterAdminApiController
         ]);
     }
 
-    public function send(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function send(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         if ($id <= 0) {
@@ -407,7 +409,7 @@ final class NewsletterAdminApiController
         }
     }
 
-    public function spaFallback(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function spaFallback(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $indexPath = dirname(__DIR__, 2) . '/public/admin/newsletter/index.html';
 

--- a/src/Controller/NewsletterController.php
+++ b/src/Controller/NewsletterController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Domain\Newsletter\Service\RenderTokenStore;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Waaseyaa\SSR\Flash\Flash;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -27,7 +29,7 @@ final class NewsletterController
      * Internal endpoint hit by Playwright during PDF generation.
      * Public route, but requires a single-use one-time token.
      */
-    public function printPreview(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function printPreview(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $token = (string) $request->query->get('token', '');
         $editionId = (int) ($params['id'] ?? 0);
@@ -73,7 +75,7 @@ final class NewsletterController
         ]));
     }
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('newsletter_edition');
         $editions = array_filter(
@@ -91,7 +93,7 @@ final class NewsletterController
         ]));
     }
 
-    public function showCommunity(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function showCommunity(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $community = (string) ($params['community'] ?? '');
         $storage = $this->entityTypeManager->getStorage('newsletter_edition');
@@ -110,7 +112,7 @@ final class NewsletterController
         ]));
     }
 
-    public function showEdition(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function showEdition(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadPublicEdition($params);
         if ($edition === null) {
@@ -122,7 +124,7 @@ final class NewsletterController
         ]));
     }
 
-    public function downloadPdf(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function downloadPdf(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadPublicEdition($params);
         if ($edition === null) {
@@ -144,7 +146,7 @@ final class NewsletterController
         ]);
     }
 
-    public function submitForm(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function submitForm(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (! $account->isAuthenticated()) {
             return new RedirectResponse('/login?redirect=/newsletter/submit');
@@ -153,7 +155,7 @@ final class NewsletterController
         return new Response($this->twig->render('pages/newsletter/public/submit.html.twig'));
     }
 
-    public function submitPost(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function submitPost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         // TODO: rate-limit this endpoint explicitly. For v1 it inherits any
         // global rate limiting from RateLimitMiddleware. See #648.
@@ -206,7 +208,7 @@ final class NewsletterController
         return new RedirectResponse('/newsletter');
     }
 
-    private function loadPublicEdition(array $params): ?EntityInterface
+    private function loadPublicEdition(#[MapRoute] array $params): ?EntityInterface
     {
         $community = (string) ($params['community'] ?? '');
         $vol = (int) ($params['volume'] ?? 0);

--- a/src/Controller/NewsletterEditorController.php
+++ b/src/Controller/NewsletterEditorController.php
@@ -10,6 +10,8 @@ use App\Domain\Newsletter\Service\EditionLifecycle;
 use App\Domain\Newsletter\Service\NewsletterAssembler;
 use App\Domain\Newsletter\Service\NewsletterDispatcher;
 use App\Domain\Newsletter\Service\NewsletterRenderer;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Waaseyaa\SSR\Flash\Flash;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -31,7 +33,7 @@ final class NewsletterEditorController
     ) {
     }
 
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('newsletter_edition');
         $editions = $storage->loadMultiple();
@@ -41,7 +43,7 @@ final class NewsletterEditorController
         ]));
     }
 
-    public function create(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function create(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $communityId = $request->request->get('community_id') ?: null;
         $publishDate = (string) $request->request->get('publish_date');
@@ -75,7 +77,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/' . $edition->id());
     }
 
-    public function assemble(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function assemble(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadEditionOrFail($params['id'] ?? null);
 
@@ -92,7 +94,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/' . $edition->id());
     }
 
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadEditionOrFail($params['id'] ?? null);
 
@@ -113,7 +115,7 @@ final class NewsletterEditorController
         ]));
     }
 
-    public function approve(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function approve(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadEditionOrFail($params['id'] ?? null);
 
@@ -128,7 +130,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/' . $edition->id());
     }
 
-    public function generate(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function generate(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadEditionOrFail($params['id'] ?? null);
 
@@ -146,7 +148,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/' . $edition->id());
     }
 
-    public function send(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function send(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $edition = $this->loadEditionOrFail($params['id'] ?? null);
 
@@ -177,7 +179,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/' . $edition->id());
     }
 
-    public function submissionsList(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function submissionsList(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $coordinatorCommunity = $this->resolveCoordinatorCommunity($request);
 
@@ -193,7 +195,7 @@ final class NewsletterEditorController
         ]));
     }
 
-    public function submissionApprove(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function submissionApprove(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('newsletter_submission');
         $sub = $storage->load((int) ($params['id'] ?? 0));
@@ -213,7 +215,7 @@ final class NewsletterEditorController
         return new RedirectResponse('/coordinator/newsletter/submissions');
     }
 
-    public function submissionReject(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function submissionReject(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('newsletter_submission');
         $sub = $storage->load((int) ($params['id'] ?? 0));


### PR DESCRIPTION
## Summary
- Decorates `array $params` with `#[MapRoute]` and `array $query` with `#[MapQuery]` across the Newsletter cluster.
- 3 controllers (NewsletterAdminApi 24 entries, NewsletterEditor 18, Newsletter 14).
- Adds `use Waaseyaa\SSR\Attribute\MapRoute;` and `use Waaseyaa\SSR\Attribute\MapQuery;` to each affected file.

## Verification
- [x] PHPUnit green (1091 tests / 3375 assertions / 3 skipped baseline)
- [x] Cold-boot smoke: `/newsletter` 200/21703 · `/admin/api/newsletter` 403/118 · `/admin/newsletter/editor` 403/118 (all non-zero body)
- [x] Cold-boot `dispatcher.deprecation` log shows zero entries naming WP03 cluster controllers
- [x] Migration tool idempotent
- [x] `scripts/migrate-controller-attributes.php` NOT in PR diff (transient working file)

Part of #753 (v0.14 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)