### PR TITLE
migrate(#753): wp04 engagement+messaging → MapRoute/MapQuery

### DIFF
--- a/src/Controller/BlockController.php
+++ b/src/Controller/BlockController.php
@@ -9,6 +9,8 @@ use Waaseyaa\Access\AccountInterface;
 use App\Support\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class BlockController
@@ -18,7 +20,7 @@ final class BlockController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->blockStorage();
         $ids = $storage->getQuery()
@@ -38,7 +40,7 @@ final class BlockController
         return $this->json(['blocks' => $payload]);
     }
 
-    public function store(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function store(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $blockedId = (int) ($data['blocked_id'] ?? 0);
@@ -79,7 +81,7 @@ final class BlockController
         return $this->json(['id' => (int) $block->id()], 201);
     }
 
-    public function delete(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function delete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $blockedUserId = (int) ($params['user_id'] ?? 0);
         $blockerId = (int) $account->id();

--- a/src/Controller/ChatController.php
+++ b/src/Controller/ChatController.php
@@ -10,11 +10,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class ChatController
 {
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function send(array $params, array $query, AccountInterface $account, HttpRequest $request): JsonResponse
+    public function send(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): JsonResponse
     {
         $config = self::loadConfig();
 

--- a/src/Controller/EngagementController.php
+++ b/src/Controller/EngagementController.php
@@ -10,6 +10,8 @@ use Waaseyaa\Access\AccountInterface;
 use App\Support\JsonResponseTrait;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Media\UploadHandler;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class EngagementController
@@ -27,7 +29,7 @@ final class EngagementController
         private readonly UploadHandler $uploadHandler,
     ) {}
 
-    public function react(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function react(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -58,7 +60,7 @@ final class EngagementController
         return $this->json(['id' => $entity->id(), 'reaction_type' => $entity->get('reaction_type')], 201);
     }
 
-    public function deleteReaction(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function deleteReaction(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('reaction');
@@ -77,7 +79,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function comment(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function comment(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -115,7 +117,7 @@ final class EngagementController
         ], 201);
     }
 
-    public function deleteComment(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function deleteComment(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('comment');
@@ -134,7 +136,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function getComments(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function getComments(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $targetType = $params['target_type'] ?? '';
         if (!$this->isValidTargetType($targetType)) {
@@ -166,7 +168,7 @@ final class EngagementController
         return $this->json(['comments' => $items]);
     }
 
-    public function follow(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function follow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
 
@@ -194,7 +196,7 @@ final class EngagementController
         return $this->json(['id' => $entity->id()], 201);
     }
 
-    public function deleteFollow(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function deleteFollow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('follow');
@@ -213,7 +215,7 @@ final class EngagementController
         return $this->json(['deleted' => true]);
     }
 
-    public function createPost(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function createPost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         // Support both JSON and multipart form data
         // Try JSON first (existing API), fall back to form data (multipart with images)
@@ -342,7 +344,7 @@ final class EngagementController
         return is_string($mimeType) ? $mimeType : '';
     }
 
-    public function deletePost(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function deletePost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $id = (int) ($params['id'] ?? 0);
         $storage = $this->entityTypeManager->getStorage('post');

--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -24,7 +26,7 @@ final class FeedController
         private readonly EntityTypeManager $entityTypeManager,
     ) {}
 
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if (!$account->isAuthenticated()) {
             return new RedirectResponse('/', 302);
@@ -63,7 +65,7 @@ final class FeedController
         return new Response($html, 200, $headers);
     }
 
-    public function api(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function api(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $ctx = $this->buildContext($request, $query, $account);
         $response = $this->assembler->assemble($ctx);
@@ -83,7 +85,7 @@ final class FeedController
         return new Response($json, 200, ['Content-Type' => 'application/json']);
     }
 
-    public function explore(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function explore(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $type = $query['type'] ?? 'all';
         $q = trim($query['q'] ?? '');
@@ -423,7 +425,7 @@ final class FeedController
         ];
     }
 
-    private function buildContext(HttpRequest $request, array $query, ?AccountInterface $account = null, ?string $resolvedFilter = null): FeedContext
+    private function buildContext(HttpRequest $request, #[MapQuery] array $query, ?AccountInterface $account = null, ?string $resolvedFilter = null): FeedContext
     {
         $locationCookie = $request->cookies->get('minoo_location');
         $lat = null;

--- a/src/Controller/MessagingController.php
+++ b/src/Controller/MessagingController.php
@@ -11,6 +11,8 @@ use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Mercure\MercurePublisher;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class MessagingController
@@ -21,7 +23,7 @@ final class MessagingController
         private readonly ?MercurePublisher $mercurePublisher = null,
     ) {}
 
-    public function editMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function editMessage(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $messageId = (int) ($params['message_id'] ?? 0);
@@ -70,7 +72,7 @@ final class MessagingController
         ]);
     }
 
-    public function deleteMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function deleteMessage(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $messageId = (int) ($params['message_id'] ?? 0);
@@ -102,7 +104,7 @@ final class MessagingController
         return $this->json(['deleted' => true]);
     }
 
-    public function markRead(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function markRead(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -140,7 +142,7 @@ final class MessagingController
         return $this->json(['last_read_at' => $now]);
     }
 
-    public function typing(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function typing(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -158,7 +160,7 @@ final class MessagingController
         return $this->json(['typing' => true]);
     }
 
-    public function unreadCount(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function unreadCount(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $userId = (int) $account->id();
         $participantStorage = $this->participantStorage();
@@ -179,7 +181,7 @@ final class MessagingController
         return $this->json(['unread_count' => $totalUnread]);
     }
 
-    public function indexThreads(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function indexThreads(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $participantStorage = $this->participantStorage();
         $threadStorage = $this->threadStorage();
@@ -233,7 +235,7 @@ final class MessagingController
         return $this->json(['threads' => $payload]);
     }
 
-    public function createThread(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function createThread(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $data = $this->jsonBody($request);
         $participantIds = $this->normalizeParticipantIds($data['participant_ids'] ?? []);
@@ -322,7 +324,7 @@ final class MessagingController
         return $this->json(['id' => (int) $thread->id()], 201);
     }
 
-    public function showThread(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function showThread(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isParticipant($threadId, (int) $account->id())) {
@@ -354,7 +356,7 @@ final class MessagingController
         ]);
     }
 
-    public function indexMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function indexMessages(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isParticipant($threadId, (int) $account->id())) {
@@ -415,7 +417,7 @@ final class MessagingController
         return $this->json(['messages' => $payload]);
     }
 
-    public function createMessage(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function createMessage(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $userId = (int) $account->id();
@@ -473,7 +475,7 @@ final class MessagingController
         ], 201);
     }
 
-    public function addParticipants(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function addParticipants(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         if (!$this->isThreadOwner($threadId, (int) $account->id(), $account)) {
@@ -522,7 +524,7 @@ final class MessagingController
         return $this->json(['added_participant_ids' => $added], 201);
     }
 
-    public function removeParticipant(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function removeParticipant(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $threadId = (int) ($params['id'] ?? 0);
         $targetUserId = (int) ($params['user_id'] ?? 0);
@@ -557,7 +559,7 @@ final class MessagingController
         return $this->json(['removed' => true]);
     }
 
-    public function searchUsers(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function searchUsers(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $term = mb_strtolower(trim((string) ($query['q'] ?? '')));
         if ($term === '') {
@@ -595,7 +597,7 @@ final class MessagingController
         return $this->json(['users' => $matches]);
     }
 
-    public function searchMessages(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function searchMessages(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $term = trim((string) ($query['q'] ?? ''));
         if ($term === '' || mb_strlen($term) < 2) {


### PR DESCRIPTION
## Summary
- Decorates `array $params` with `#[MapRoute]` and `array $query` with `#[MapQuery]` across the Engagement + Messaging cluster.
- 5 controllers (Block, Chat, Engagement, Feed, Messaging).
- Adds `use Waaseyaa\SSR\Attribute\MapRoute;` and `use Waaseyaa\SSR\Attribute\MapQuery;` to each affected file.

## Verification
- [x] PHPUnit green (1091/3375/3 baseline)
- [x] Cold-boot smoke: /messages 200, others 404 with non-zero framework body (controllers booted + dispatched)
- [x] Cold-boot `dispatcher.deprecation` log shows zero entries naming WP04 cluster controllers
- [x] Migration tool idempotent
- [x] `scripts/migrate-controller-attributes.php` NOT in PR diff

Part of #753 (v0.14 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)