### PR TITLE
migrate(#753): wp05 static+communities+misc → MapRoute/MapQuery

### DIFF
--- a/src/Controller/BusinessController.php
+++ b/src/Controller/BusinessController.php
@@ -11,6 +11,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class BusinessController
@@ -22,7 +24,7 @@ final class BusinessController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('group');
         $ids = $storage->getQuery()
@@ -55,7 +57,7 @@ final class BusinessController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('group');

--- a/src/Controller/CommunityController.php
+++ b/src/Controller/CommunityController.php
@@ -16,6 +16,8 @@ use Waaseyaa\Entity\EntityTypeManager;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Geo\GeoDistance;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class CommunityController
 {
     public function __construct(
@@ -26,7 +28,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('community');
         $location = $this->resolveLocation($request);
@@ -118,7 +120,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function crisisIncident(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function crisisIncident(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = (string) ($params['slug'] ?? '');
         $incident = (string) ($params['incident'] ?? '');
@@ -198,7 +200,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('community');
@@ -343,7 +345,7 @@ final class CommunityController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function autocomplete(array $params, array $query, AccountInterface $account, HttpRequest $request): JsonResponse
+    public function autocomplete(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): JsonResponse
     {
         $term = trim($request->query->getString('q'));
 

--- a/src/Controller/ContributorController.php
+++ b/src/Controller/ContributorController.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ContributorController
@@ -20,7 +22,7 @@ final class ContributorController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('contributor');
         $ids = $storage->getQuery()
@@ -40,7 +42,7 @@ final class ContributorController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('contributor');

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -18,6 +18,8 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\ContentEntityBase;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class EventController
@@ -30,7 +32,7 @@ final class EventController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $filters  = EventFilters::fromRequest($request);
         $location = $this->resolveLocation($request);
@@ -101,7 +103,7 @@ final class EventController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('event');
@@ -184,7 +186,7 @@ final class EventController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function ics(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function ics(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = (string) ($params['slug'] ?? '');
         if ($slug === '') {

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class GroupController
@@ -21,7 +23,7 @@ final class GroupController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('group');
         $ids = $storage->getQuery()
@@ -54,7 +56,7 @@ final class GroupController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('group');

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -12,6 +12,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class HomeController
 {
     public function __construct(
@@ -21,7 +23,7 @@ final class HomeController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         if ($account->isAuthenticated()) {
             return new RedirectResponse('/feed', 302);

--- a/src/Controller/LanguageController.php
+++ b/src/Controller/LanguageController.php
@@ -11,6 +11,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class LanguageController
@@ -25,7 +27,7 @@ final class LanguageController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $page = max(1, (int) ($query['page'] ?? 1));
         $offset = ($page - 1) * self::PAGE_SIZE;
@@ -56,7 +58,7 @@ final class LanguageController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('dictionary_entry');
@@ -81,7 +83,7 @@ final class LanguageController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function search(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function search(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $q = trim((string) ($query['q'] ?? ''));
 

--- a/src/Controller/LocationController.php
+++ b/src/Controller/LocationController.php
@@ -11,6 +11,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class LocationController
 {
     public function __construct(
@@ -20,7 +22,7 @@ final class LocationController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function current(array $params, array $query, AccountInterface $account, HttpRequest $request): JsonResponse
+    public function current(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): JsonResponse
     {
         $service = $this->makeService();
         $ctx = $service->fromRequest($request);
@@ -33,7 +35,7 @@ final class LocationController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function set(array $params, array $query, AccountInterface $account, HttpRequest $request): JsonResponse
+    public function set(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): JsonResponse
     {
         $body = json_decode($request->getContent(), true) ?? [];
         $communityId = $body['community_id'] ?? null;
@@ -64,7 +66,7 @@ final class LocationController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function update(array $params, array $query, AccountInterface $account, HttpRequest $request): JsonResponse
+    public function update(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): JsonResponse
     {
         $body = json_decode($request->getContent(), true) ?? [];
         $latitude = $body['latitude'] ?? null;

--- a/src/Controller/OpenGraphController.php
+++ b/src/Controller/OpenGraphController.php
@@ -16,6 +16,8 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 final class OpenGraphController
 {
     private const CACHE_MAX_AGE = 86400;
@@ -42,7 +44,7 @@ final class OpenGraphController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function businessPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function businessPng(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = (string) ($params['slug'] ?? '');
         $entity = PublicOgEntityLoader::loadBusiness($this->entityTypeManager, $slug);
@@ -54,7 +56,7 @@ final class OpenGraphController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function eventPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function eventPng(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = (string) ($params['slug'] ?? '');
         $entity = PublicOgEntityLoader::loadEvent($this->entityTypeManager, $slug);
@@ -66,7 +68,7 @@ final class OpenGraphController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function teachingPng(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function teachingPng(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = (string) ($params['slug'] ?? '');
         $entity = PublicOgEntityLoader::loadTeaching($this->entityTypeManager, $slug);
@@ -79,8 +81,8 @@ final class OpenGraphController
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
     public function sagamokSpanishRiverFloodPng(
-        array $params,
-        array $query,
+        #[MapRoute] array $params,
+        #[MapQuery] array $query,
         AccountInterface $account,
         HttpRequest $request,
     ): Response {
@@ -94,8 +96,8 @@ final class OpenGraphController
      * @param array<string, mixed> $query
      */
     public function crisisIncidentPng(
-        array $params,
-        array $query,
+        #[MapRoute] array $params,
+        #[MapQuery] array $query,
         AccountInterface $account,
         HttpRequest $request,
     ): Response {

--- a/src/Controller/OralHistoryController.php
+++ b/src/Controller/OralHistoryController.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class OralHistoryController
@@ -20,7 +22,7 @@ final class OralHistoryController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $collectionStorage = $this->entityTypeManager->getStorage('oral_history_collection');
         $collectionIds = $collectionStorage->getQuery()
@@ -48,7 +50,7 @@ final class OralHistoryController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function collection(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function collection(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $collectionStorage = $this->entityTypeManager->getStorage('oral_history_collection');
@@ -90,7 +92,7 @@ final class OralHistoryController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storyStorage = $this->entityTypeManager->getStorage('oral_history');

--- a/src/Controller/PeopleController.php
+++ b/src/Controller/PeopleController.php
@@ -10,6 +10,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class PeopleController
@@ -21,7 +23,7 @@ final class PeopleController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('resource_person');
         $queryBuilder = $storage->getQuery()
@@ -83,7 +85,7 @@ final class PeopleController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('resource_person');

--- a/src/Controller/StaticPageController.php
+++ b/src/Controller/StaticPageController.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 /**
  * Minimal render-only controller for pages that have no domain logic.
  *
@@ -25,85 +27,85 @@ final class StaticPageController
     ) {}
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function about(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function about(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/about.html.twig', '/about', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function dataSovereignty(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function dataSovereignty(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/data-sovereignty.html.twig', '/data-sovereignty', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function elders(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function elders(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/elders/index.html.twig', '/elders', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function games(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function games(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/games/index.html.twig', '/games', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function getInvolved(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function getInvolved(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/get-involved.html.twig', '/get-involved', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function howItWorks(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function howItWorks(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/how-it-works.html.twig', '/how-it-works', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function journey(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function journey(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/journey.html.twig', '/journey', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function legal(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function legal(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/legal/index.html.twig', $request->getPathInfo(), $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function matcher(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function matcher(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/matcher.html.twig', '/matcher', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function messages(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function messages(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/messages.html.twig', '/messages', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function safety(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function safety(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/safety.html.twig', '/safety', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function search(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function search(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/search/index.html.twig', '/search', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function studio(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function studio(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/studio.html.twig', '/studio', $account);
     }
 
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
-    public function volunteer(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function volunteer(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         return $this->render('pages/static/volunteer.html.twig', '/volunteer', $account);
     }

--- a/src/Controller/TeachingController.php
+++ b/src/Controller/TeachingController.php
@@ -11,6 +11,8 @@ use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
 use Symfony\Component\HttpFoundation\Response;
 
 final class TeachingController
@@ -22,7 +24,7 @@ final class TeachingController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function list(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function list(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $storage = $this->entityTypeManager->getStorage('teaching');
         $ids = $storage->getQuery()
@@ -55,7 +57,7 @@ final class TeachingController
 
     /** @param array<string, mixed> $params */
     /** @param array<string, mixed> $query */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
         $slug = $params['slug'] ?? '';
         $storage = $this->entityTypeManager->getStorage('teaching');


### PR DESCRIPTION
## Summary
- Decorates `array $params` with `#[MapRoute]` and `array $query` with `#[MapQuery]` across the largest cluster (Static + Communities + Misc).
- 13 controllers (Business, Community, Contributor, Event, Group, Home, Language, Location, OpenGraph, OralHistory, People, StaticPage, Teaching).
- Adds `use Waaseyaa\SSR\Attribute\MapRoute;` and `use Waaseyaa\SSR\Attribute\MapQuery;` to each affected file.

## Verification
- [x] PHPUnit green (1091 tests / 3375 assertions / 3 skipped baseline)
- [x] Cold-boot smoke: / 200/27k · /about 200/24k · /communities/sagamok-anishnawbek 200/32k · /language 200/45k
- [x] Cold-boot `dispatcher.deprecation` log shows zero entries naming WP05 cluster controllers (any of the 13)
- [x] Migration tool idempotent
- [x] `scripts/migrate-controller-attributes.php` NOT in PR diff

Part of #753 (v0.14 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)