### PR TITLE
fix(deploy): use JSON-aware health-check assertions

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -170,7 +170,7 @@ task('deploy:test', function (): void {
         [
             'url' => 'https://minoo.live/admin/_surface/session',
             'expect' => 200,
-            'expectBody' => ['"ok":false', '"status":401'],
+            'expectJson' => ['ok' => false, 'error.status' => 401],
         ],
     ];
 
@@ -186,6 +186,11 @@ task('deploy:test', function (): void {
         $url = $check['url'];
         $expect = $check['expect'];
         $expectBody = $check['expectBody'] ?? [];
+        // JSON assertions are pretty-print tolerant: a dotted path → expected
+        // scalar value. e.g. ['ok' => false, 'error.status' => 401] decodes
+        // the body and walks the path. Beats brittle substring matching when
+        // the server toggles JSON_PRETTY_PRINT or whitespace.
+        $expectJson = $check['expectJson'] ?? [];
 
         $lastFailure = '';
         $lastHttpCode = 0;
@@ -222,6 +227,7 @@ task('deploy:test', function (): void {
                 $lastFailure = "returned {$lastHttpCode}, expected {$expect}";
             } else {
                 $bodyOk = true;
+
                 foreach ($expectBody as $needle) {
                     if (!str_contains($body, $needle)) {
                         $bodyOk = false;
@@ -229,6 +235,34 @@ task('deploy:test', function (): void {
                         break;
                     }
                 }
+
+                if ($bodyOk && $expectJson !== []) {
+                    $decoded = json_decode($body, true);
+                    if (!is_array($decoded)) {
+                        $bodyOk = false;
+                        $lastFailure = 'body is not valid JSON';
+                    } else {
+                        foreach ($expectJson as $path => $expectedValue) {
+                            $cursor = $decoded;
+                            $found = true;
+                            foreach (explode('.', $path) as $segment) {
+                                if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
+                                    $found = false;
+                                    break;
+                                }
+                                $cursor = $cursor[$segment];
+                            }
+                            if (!$found || $cursor !== $expectedValue) {
+                                $bodyOk = false;
+                                $actual = $found ? var_export($cursor, true) : '<missing>';
+                                $expectedStr = var_export($expectedValue, true);
+                                $lastFailure = "JSON path '{$path}' expected {$expectedStr}, got {$actual}";
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 if ($bodyOk) {
                     $passed = true;
                     break;


### PR DESCRIPTION
Follow-up to #772 — the re-enabled `/admin/_surface/session` post-deploy probe failed on the alpha.186 production deploy with:

```
body missing expected substring '"ok":false'
```

The body-capture mechanism itself worked correctly. The miss was purely a brittle substring match: the framework's `JsonResponse` pretty-prints, so prod returns `"ok": false` (space after colon), while the assertion expected the compact `"ok":false`.

Worth noting: alpha.186 IS live on `minoo.live` — `/admin/_surface/session` returns the correct pretty-printed envelope and the bcrypt leak is closed. The deploy step exited with failure but no `deploy:rollback` task is defined, so the release symlink stayed flipped.

## Change

Replace `expectBody` substrings with `expectJson` dotted-path assertions:

```php
'expectJson' => ['ok' => false, 'error.status' => 401],
```

Body is decoded once per attempt; each path is walked through the array tree and compared with `!==`. Surfaces useful failure messages (`JSON path 'ok' expected false, got true`). `expectBody` still supported for non-JSON probes.

## Verified

Manually applied the JSON walk against prod's actual body — `ok` resolves to `false`, `error.status` resolves to `401`. Both assertions pass.