### PR TITLE
fix(deploy): pin waaseyaa framework checkout to composer.lock version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,28 @@ jobs:
           path: minoo
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Resolve the exact waaseyaa monorepo tag composer pinned. Using
+      # `ref: main` here would let upstream-in-flight changes (lock file drift,
+      # admin SPA package.json edits) silently break a deploy of a commit that
+      # passed CI yesterday. The version comes straight from composer.lock so
+      # it stays in lockstep with `composer install` on the same commit.
+      - name: Resolve waaseyaa framework tag from composer.lock
+        id: ws_ref
+        working-directory: minoo
+        run: |
+          REF=$(jq -er '.packages[] | select(.name == "waaseyaa/admin-surface") | .version' composer.lock)
+          if [[ -z "${REF}" || "${REF}" == "null" ]]; then
+            echo "::error::Could not extract waaseyaa/admin-surface version from composer.lock" >&2
+            exit 1
+          fi
+          echo "Resolved waaseyaa framework tag: ${REF}"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout waaseyaa framework
         uses: actions/checkout@v6
         with:
           repository: waaseyaa/framework
-          ref: main
+          ref: ${{ steps.ws_ref.outputs.ref }}
           path: waaseyaa
 
       # -----------------------------------------------------------------------

--- a/scripts/build-admin-spa.sh
+++ b/scripts/build-admin-spa.sh
@@ -55,7 +55,18 @@ export NUXT_PUBLIC_APP_NAME="${NUXT_PUBLIC_APP_NAME:-Minoo}"
 export NUXT_PUBLIC_BASE_URL="${NUXT_PUBLIC_BASE_URL:-}"
 export NUXT_BACKEND_URL="${NUXT_BACKEND_URL:-http://127.0.0.1:8081}"
 
-(cd "$ADMIN_PKG" && npm ci && npm run generate)
+# Prefer `npm ci` for reproducibility, but fall back to `npm install` when
+# upstream's package-lock.json has drifted from package.json. Waaseyaa
+# framework tags have shipped with out-of-sync locks more than once; without
+# this fallback, every drifted alpha breaks Minoo deploys for no Minoo reason.
+(
+  cd "$ADMIN_PKG"
+  if ! npm ci --no-audit --no-fund; then
+    echo "build-admin-spa: npm ci failed — falling back to npm install (upstream lock drift)." >&2
+    npm install --no-audit --no-fund
+  fi
+  npm run generate
+)
 
 rm -rf "$ROOT/public/admin"
 mkdir -p "$ROOT/public/admin"


### PR DESCRIPTION
## Problem
Every waaseyaa alpha bump has a non-zero chance of breaking the Minoo production deploy through no fault of Minoo. The alpha.188 deploy failed at "Build admin SPA" with:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: cac@6.7.14 from lock file
npm error Missing: commander@13.1.0 from lock file
```

Two compounding root causes:

1. **`.github/workflows/deploy.yml` checks out `waaseyaa/framework` at `ref: main`.** Composer pins `waaseyaa/*` to a specific tag in `composer.lock`, but the deploy builds the admin SPA against whatever upstream's `main` happens to be at the moment the deploy runs. So a PR can pass CI on the SHA we shipped and then fail the deploy because `main` drifted in between.
2. **Even at the pinned tag, `waaseyaa/framework` has shipped `package-lock.json` out of sync with `package.json` more than once.** `npm ci` is strict and bails on that, even though `npm install` would resolve cleanly.

## Fix
- **deploy.yml**: new "Resolve waaseyaa framework tag" step reads the version straight from `composer.lock` (`jq -er '.packages[] | select(.name == "waaseyaa/admin-surface") | .version'`) and uses it as `ref:` for the framework checkout. Same source of truth `composer install` uses on the same commit — reproducible.
- **scripts/build-admin-spa.sh**: try `npm ci --no-audit --no-fund` first for reproducibility; on failure, log a clear "upstream lock drift" message and fall back to `npm install --no-audit --no-fund`.

## Test plan
- [x] `python3 -c "yaml.safe_load(...)"` clean
- [x] `bash -n scripts/build-admin-spa.sh` clean
- [x] Local rehearsal: `jq -er '.packages[]|select(.name=="waaseyaa/admin-surface")|.version' composer.lock` → `v0.1.0-alpha.188`
- [ ] CI green
- [ ] Deploy of this merge succeeds (the actual proof)

## Follow-up
- File upstream issue on `waaseyaa/framework` for the recurring `packages/admin/package-lock.json` drift so it gets fixed at the source (the npm fallback above is a defense, not a fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)