### PR TITLE
feat(social): restore Post entity + PostAccessPolicy (#811)

### DIFF
--- a/src/Access/Feed/PostAccessPolicy.php
+++ b/src/Access/Feed/PostAccessPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Access\Feed;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: 'post')]
+final class PostAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'post';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Posts are publicly viewable.'),
+            'update' => $this->ownerCheck($entity, $account),
+            'delete' => $this->deleteCheck($entity, $account),
+            default => AccessResult::neutral('Non-admin cannot perform this operation on posts.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->isAuthenticated()) {
+            return AccessResult::allowed('Authenticated users may create posts.');
+        }
+
+        return AccessResult::neutral('Anonymous users cannot create posts.');
+    }
+
+    private function ownerCheck(EntityInterface $entity, AccountInterface $account): AccessResult
+    {
+        $userId = $entity->get('user_id');
+
+        if ($userId !== null && (int) $userId === (int) $account->id()) {
+            return AccessResult::allowed('Owner may edit own post.');
+        }
+
+        return AccessResult::neutral('Non-owner cannot edit post.');
+    }
+
+    private function deleteCheck(EntityInterface $entity, AccountInterface $account): AccessResult
+    {
+        $userId = $entity->get('user_id');
+
+        if ($userId !== null && (int) $userId === (int) $account->id()) {
+            return AccessResult::allowed('Owner may delete own post.');
+        }
+
+        if (in_array('coordinator', $account->getRoles(), true)) {
+            return AccessResult::allowed('Coordinator may delete posts.');
+        }
+
+        return AccessResult::neutral('Non-owner cannot delete post.');
+    }
+}

--- a/src/Entity/Feed/Post.php
+++ b/src/Entity/Feed/Post.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Feed;
+
+use Waaseyaa\Entity\Community\HasCommunityTrait;
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class Post extends ContentEntityBase
+{
+    use HasCommunityTrait;
+    protected string $entityTypeId = 'post';
+
+    protected array $entityKeys = [
+        'id' => 'pid',
+        'uuid' => 'uuid',
+        'label' => 'body',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        foreach (['user_id', 'body', 'community_id'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
+        if (!array_key_exists('images', $values)) {
+            $values['images'] = '[]';
+        }
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = time();
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = time();
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Provider/Entity/EntityContentProvider.php
+++ b/src/Provider/Entity/EntityContentProvider.php
@@ -6,6 +6,7 @@ namespace App\Provider\Entity;
 
 use App\Entity\Account\SavedWord;
 use App\Entity\Community\Contributor;
+use App\Entity\Feed\Post;
 use App\Entity\Games\CrosswordPuzzle;
 use App\Entity\Games\DailyChallenge;
 use App\Entity\Games\GameSession;
@@ -112,6 +113,30 @@ final class EntityContentProvider extends AppCoreServiceProvider
                 'clues' => ['type' => 'text_long', 'label' => 'Clues', 'description' => 'JSON map of word index to clue data.', 'weight' => 10],
                 'theme' => ['type' => 'string', 'label' => 'Theme', 'weight' => 15],
                 'difficulty_tier' => ['type' => 'string', 'label' => 'Difficulty', 'weight' => 20, 'default' => 'easy'],
+            ],
+        ));
+
+        // =====================================================================
+        // --- Social spine: posts (#811) ---
+        // Consent by participation: a member posts for themselves. Belongs to a
+        // community (HasCommunityTrait) so it places on the graph by vantage.
+        // =====================================================================
+
+        $this->entityType(new EntityType(
+            id: 'post',
+            label: 'Post',
+            class: Post::class,
+            keys: ['id' => 'pid', 'uuid' => 'uuid', 'label' => 'body'],
+            tenancy: ['scope' => 'community'],
+            group: 'engagement',
+            _fieldDefinitions: [
+                'body' => ['type' => 'text_long', 'label' => 'Body', 'weight' => 0],
+                'user_id' => ['type' => 'integer', 'label' => 'User ID', 'weight' => 1],
+                'community_id' => ['type' => 'integer', 'label' => 'Community ID', 'weight' => 2],
+                'images' => ['type' => 'text_long', 'label' => 'Images', 'weight' => 3],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 5, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 10],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 11],
             ],
         ));
 

--- a/tests/App/Unit/Access/Feed/PostAccessPolicyTest.php
+++ b/tests/App/Unit/Access/Feed/PostAccessPolicyTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Access\Feed;
+
+use App\Access\Feed\PostAccessPolicy;
+use App\Entity\Feed\Post;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+
+#[CoversClass(PostAccessPolicy::class)]
+final class PostAccessPolicyTest extends TestCase
+{
+    #[Test]
+    public function anonymous_can_view_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'Hello community', 'user_id' => 42, 'community_id' => 1]);
+        $account = $this->createAnonymousAccount();
+
+        $result = $policy->access($post, 'view', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_create_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $account = $this->createAnonymousAccount();
+
+        $result = $policy->createAccess('post', 'post', $account);
+
+        $this->assertFalse($result->isAllowed());
+    }
+
+    #[Test]
+    public function authenticated_can_create_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $account = $this->createAuthenticatedAccount(10);
+
+        $result = $policy->createAccess('post', 'post', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function author_can_edit_own_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'My post', 'user_id' => 10, 'community_id' => 1]);
+        $account = $this->createAuthenticatedAccount(10);
+
+        $result = $policy->access($post, 'update', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function non_author_cannot_edit_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'Their post', 'user_id' => 10, 'community_id' => 1]);
+        $account = $this->createAuthenticatedAccount(99);
+
+        $result = $policy->access($post, 'update', $account);
+
+        $this->assertFalse($result->isAllowed());
+    }
+
+    #[Test]
+    public function author_can_delete_own_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'My post', 'user_id' => 10, 'community_id' => 1]);
+        $account = $this->createAuthenticatedAccount(10);
+
+        $result = $policy->access($post, 'delete', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function non_author_cannot_delete_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'Their post', 'user_id' => 10, 'community_id' => 1]);
+        $account = $this->createAuthenticatedAccount(99);
+
+        $result = $policy->access($post, 'delete', $account);
+
+        $this->assertFalse($result->isAllowed());
+    }
+
+    #[Test]
+    public function coordinator_can_delete_any_post(): void
+    {
+        $policy = new PostAccessPolicy();
+        $post = new Post(['body' => 'Their post', 'user_id' => 10, 'community_id' => 1]);
+        $account = $this->createCoordinatorAccount(99);
+
+        $result = $policy->access($post, 'delete', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function applies_to_post_type(): void
+    {
+        $policy = new PostAccessPolicy();
+
+        $this->assertTrue($policy->appliesTo('post'));
+        $this->assertFalse($policy->appliesTo('event'));
+    }
+
+    private function createAnonymousAccount(): AccountInterface
+    {
+        return new class () implements AccountInterface {
+            public function id(): int
+            {
+                return 0;
+            }
+            public function hasPermission(string $permission): bool
+            {
+                return $permission === 'access content';
+            }
+            public function getRoles(): array
+            {
+                return ['anonymous'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    private function createAuthenticatedAccount(int $id): AccountInterface
+    {
+        return new class ($id) implements AccountInterface {
+            public function __construct(private readonly int $uid)
+            {
+            }
+            public function id(): int
+            {
+                return $this->uid;
+            }
+            public function hasPermission(string $permission): bool
+            {
+                return $permission === 'access content';
+            }
+            public function getRoles(): array
+            {
+                return ['authenticated'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    private function createCoordinatorAccount(int $id): AccountInterface
+    {
+        return new class ($id) implements AccountInterface {
+            public function __construct(private readonly int $uid)
+            {
+            }
+            public function id(): int
+            {
+                return $this->uid;
+            }
+            public function hasPermission(string $permission): bool
+            {
+                return $permission === 'access content';
+            }
+            public function getRoles(): array
+            {
+                return ['authenticated', 'coordinator'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/tests/App/Unit/Entity/Feed/PostTest.php
+++ b/tests/App/Unit/Entity/Feed/PostTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity\Feed;
+
+use App\Entity\Feed\Post;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Post::class)]
+final class PostTest extends TestCase
+{
+    #[Test]
+    public function it_creates_with_defaults(): void
+    {
+        $before = time();
+        $post = new Post([
+            'body' => 'Community gathering this weekend!',
+            'user_id' => 1,
+            'community_id' => 5,
+        ]);
+        $after = time();
+
+        $this->assertSame('Community gathering this weekend!', $post->get('body'));
+        $this->assertSame(1, $post->get('user_id'));
+        $this->assertSame(5, $post->get('community_id'));
+        $this->assertSame(1, $post->get('status'));
+        $this->assertGreaterThanOrEqual($before, $post->get('created_at'));
+        $this->assertLessThanOrEqual($after, $post->get('created_at'));
+        $this->assertGreaterThanOrEqual($before, $post->get('updated_at'));
+        $this->assertLessThanOrEqual($after, $post->get('updated_at'));
+    }
+
+    #[Test]
+    public function it_exposes_entity_type_id(): void
+    {
+        $post = new Post(['body' => 'Test', 'user_id' => 1, 'community_id' => 1]);
+
+        $this->assertSame('post', $post->getEntityTypeId());
+    }
+
+    #[Test]
+    public function it_allows_status_override(): void
+    {
+        $post = new Post([
+            'body' => 'Draft post',
+            'user_id' => 1,
+            'community_id' => 1,
+            'status' => 0,
+        ]);
+
+        $this->assertSame(0, $post->get('status'));
+    }
+
+    #[Test]
+    public function it_accepts_timestamps(): void
+    {
+        $post = new Post([
+            'body' => 'Test',
+            'user_id' => 1,
+            'community_id' => 1,
+            'created_at' => 1711000000,
+            'updated_at' => 1711000100,
+        ]);
+
+        $this->assertSame(1711000000, $post->get('created_at'));
+        $this->assertSame(1711000100, $post->get('updated_at'));
+    }
+
+    #[Test]
+    public function constructor_requires_required_fields(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([]);
+    }
+
+    #[Test]
+    public function constructor_requires_community_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([
+            'body' => 'Test',
+            'user_id' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function constructor_requires_body(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Post([
+            'user_id' => 1,
+            'community_id' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
First slice of the Sovereign Social spine. Restores the Post entity + PostAccessPolicy from af26981^ onto alpha.209 and registers the post EntityType against the dormant post table (4 rows). Consent by participation: public view, auth create, owner/coordinator delete. Suite 416 green, phpstan + schema:check clean.

Closes #811