### PR TITLE
feat(community): restore the 646-row community geo index (#815)

### DIFF
--- a/src/Access/Community/CommunityAccessPolicy.php
+++ b/src/Access/Community/CommunityAccessPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Access\Community;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: 'community')]
+final class CommunityAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'community';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Communities are publicly viewable.'),
+            default => AccessResult::neutral('Only admins can modify communities.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin can create communities.');
+        }
+
+        return AccessResult::neutral('Only admins can create communities.');
+    }
+}

--- a/src/Entity/Community/Community.php
+++ b/src/Entity/Community/Community.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Community;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class Community extends ContentEntityBase
+{
+    protected string $entityTypeId = 'community';
+
+    protected array $entityKeys = [
+        'id' => 'cid',
+        'uuid' => 'uuid',
+        'label' => 'name',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = 0;
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = 0;
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Provider/Entity/EntityCommunityProvider.php
+++ b/src/Provider/Entity/EntityCommunityProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Provider\Entity;
 
+use App\Entity\Community\Community;
 use App\Entity\Editorial\FeaturedItem;
 use App\Entity\ElderSupport\ElderSupportRequest;
 use App\Entity\Language\DialectRegion;
@@ -53,6 +54,44 @@ final class EntityCommunityProvider extends AppCoreServiceProvider
             class: DialectRegion::class,
             keys: ['id' => 'code', 'label' => 'name'],
             group: 'language',
+        ));
+
+        // =====================================================================
+        // --- Community graph: the 646-row community table (#815) ---
+        // Public institutional data (no consent gate). The authoritative geo
+        // index for "location as vantage point"; the curated MamaweswenNations
+        // (#60) layers on top for the seven nations' detail pages.
+        // =====================================================================
+
+        $this->entityType(new EntityType(
+            id: 'community',
+            label: 'Community',
+            class: Community::class,
+            keys: ['id' => 'cid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'communities',
+            _fieldDefinitions: [
+                'name' => ['type' => 'string', 'label' => 'Name', 'weight' => 0],
+                'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
+                'community_type' => ['type' => 'string', 'label' => 'Community Type', 'weight' => 5],
+                'municipality_type' => ['type' => 'string', 'label' => 'Municipality Type', 'weight' => 6],
+                'province' => ['type' => 'string', 'label' => 'Province', 'weight' => 10],
+                'region' => ['type' => 'string', 'label' => 'Region', 'weight' => 11],
+                'latitude' => ['type' => 'float', 'label' => 'Latitude', 'weight' => 15],
+                'longitude' => ['type' => 'float', 'label' => 'Longitude', 'weight' => 16],
+                'population' => ['type' => 'integer', 'label' => 'Population', 'weight' => 20],
+                'population_year' => ['type' => 'integer', 'label' => 'Population Year', 'weight' => 21],
+                'nation' => ['type' => 'string', 'label' => 'Nation/Linguistic Group', 'weight' => 25],
+                'treaty' => ['type' => 'string', 'label' => 'Treaty', 'weight' => 26],
+                'reserve_name' => ['type' => 'string', 'label' => 'Reserve Name', 'weight' => 27],
+                'language_group' => ['type' => 'string', 'label' => 'Language Group', 'weight' => 30],
+                'website' => ['type' => 'string', 'label' => 'Website', 'weight' => 35],
+                'inac_id' => ['type' => 'string', 'label' => 'INAC Band Number', 'weight' => 40],
+                'statcan_csd' => ['type' => 'string', 'label' => 'StatsCan CSD Code', 'weight' => 41],
+                'nc_id' => ['type' => 'string', 'label' => 'NorthCloud ID', 'weight' => 42],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 50, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 60],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 61],
+            ],
         ));
 
         // =====================================================================

--- a/tests/App/Integration/BootTest.php
+++ b/tests/App/Integration/BootTest.php
@@ -75,6 +75,8 @@ final class BootTest extends TestCase
             // Sovereign Social spine: post (#811) + engagement from
             // waaseyaa/engagement (#812).
             'post', 'reaction', 'comment', 'follow',
+            // Community graph geo index (#815).
+            'community',
         ];
 
         foreach ($minooTypes as $typeId) {

--- a/tests/App/Unit/Access/Community/CommunityAccessPolicyTest.php
+++ b/tests/App/Unit/Access/Community/CommunityAccessPolicyTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Access\Community;
+
+use App\Access\Community\CommunityAccessPolicy;
+use App\Entity\Community\Community;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+
+#[CoversClass(CommunityAccessPolicy::class)]
+final class CommunityAccessPolicyTest extends TestCase
+{
+    #[Test]
+    public function anyone_can_view_a_community(): void
+    {
+        $policy = new CommunityAccessPolicy();
+        $entity = new Community(['name' => 'Sagamok', 'community_type' => 'first_nation']);
+        $account = $this->createAnonymousAccount();
+
+        $result = $policy->access($entity, 'view', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_create_community(): void
+    {
+        $policy = new CommunityAccessPolicy();
+        $account = $this->createAnonymousAccount();
+
+        $result = $policy->createAccess('community', '', $account);
+
+        $this->assertFalse($result->isAllowed());
+    }
+
+    #[Test]
+    public function admin_can_create_community(): void
+    {
+        $policy = new CommunityAccessPolicy();
+        $account = $this->createAdminAccount();
+
+        $result = $policy->createAccess('community', '', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_update_community(): void
+    {
+        $policy = new CommunityAccessPolicy();
+        $entity = new Community(['name' => 'Sagamok', 'community_type' => 'first_nation']);
+        $account = $this->createAnonymousAccount();
+
+        $result = $policy->access($entity, 'update', $account);
+
+        $this->assertFalse($result->isAllowed());
+    }
+
+    #[Test]
+    public function admin_can_update_community(): void
+    {
+        $policy = new CommunityAccessPolicy();
+        $entity = new Community(['name' => 'Sagamok', 'community_type' => 'first_nation']);
+        $account = $this->createAdminAccount();
+
+        $result = $policy->access($entity, 'update', $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function it_applies_to_community_type(): void
+    {
+        $policy = new CommunityAccessPolicy();
+
+        $this->assertTrue($policy->appliesTo('community'));
+        $this->assertFalse($policy->appliesTo('event'));
+    }
+
+    private function createAnonymousAccount(): AccountInterface
+    {
+        return new class () implements AccountInterface {
+            public function id(): int
+            {
+                return 0;
+            }
+            public function hasPermission(string $permission): bool
+            {
+                return false;
+            }
+            public function getRoles(): array
+            {
+                return ['anonymous'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    private function createAdminAccount(): AccountInterface
+    {
+        return new class () implements AccountInterface {
+            public function id(): int
+            {
+                return 1;
+            }
+            public function hasPermission(string $permission): bool
+            {
+                return true;
+            }
+            public function getRoles(): array
+            {
+                return ['administrator'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/tests/App/Unit/Entity/Community/CommunityTest.php
+++ b/tests/App/Unit/Entity/Community/CommunityTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity\Community;
+
+use App\Entity\Community\Community;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Community::class)]
+final class CommunityTest extends TestCase
+{
+    #[Test]
+    public function it_creates_with_required_fields(): void
+    {
+        $community = new Community([
+            'name' => 'Sagamok Anishnawbek',
+            'community_type' => 'first_nation',
+        ]);
+
+        $this->assertSame('Sagamok Anishnawbek', $community->get('name'));
+        $this->assertSame('first_nation', $community->get('community_type'));
+        $this->assertSame('community', $community->getEntityTypeId());
+    }
+
+    #[Test]
+    public function it_defaults_status_to_published(): void
+    {
+        $community = new Community(['name' => 'Test']);
+
+        $this->assertSame(1, $community->get('status'));
+    }
+
+    #[Test]
+    public function it_defaults_timestamps_to_zero(): void
+    {
+        $community = new Community(['name' => 'Test', 'community_type' => 'town']);
+
+        $this->assertSame(0, $community->get('created_at'));
+        $this->assertSame(0, $community->get('updated_at'));
+    }
+
+    #[Test]
+    public function it_supports_optional_geo_fields(): void
+    {
+        $community = new Community([
+            'name' => 'Sagamok Anishnawbek',
+            'community_type' => 'first_nation',
+            'latitude' => 46.15,
+            'longitude' => -81.95,
+            'population' => 3200,
+        ]);
+
+        $this->assertSame(46.15, $community->get('latitude'));
+        $this->assertSame(-81.95, $community->get('longitude'));
+        $this->assertSame(3200, $community->get('population'));
+    }
+
+    #[Test]
+    public function it_supports_all_metadata_fields(): void
+    {
+        $community = new Community([
+            'name' => 'Sagamok Anishnawbek',
+            'slug' => 'sagamok-anishnawbek',
+            'community_type' => 'first_nation',
+            'province' => 'Ontario',
+            'region' => 'North Shore of Lake Huron',
+            'nation' => 'Anishinaabe',
+            'treaty' => 'Robinson-Huron Treaty',
+            'reserve_name' => 'Sagamok',
+            'language_group' => 'Ojibwe',
+            'website' => 'https://sagamok.ca',
+            'inac_id' => '196',
+            'statcan_csd' => '3552091',
+            'nc_id' => 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            'population_year' => 2026,
+        ]);
+
+        $this->assertSame('sagamok-anishnawbek', $community->get('slug'));
+        $this->assertSame('Ontario', $community->get('province'));
+        $this->assertSame('Anishinaabe', $community->get('nation'));
+        $this->assertSame('Robinson-Huron Treaty', $community->get('treaty'));
+        $this->assertSame('196', $community->get('inac_id'));
+        $this->assertSame('3552091', $community->get('statcan_csd'));
+        $this->assertSame('a1b2c3d4-e5f6-7890-abcd-ef1234567890', $community->get('nc_id'));
+        $this->assertSame(2026, $community->get('population_year'));
+    }
+}


### PR DESCRIPTION
Restores Community entity + CommunityAccessPolicy + registration against the dormant community table (646 rows, all geocoded) — the authoritative geo index for location-as-vantage-point. Public institutional data; the curated MamaweswenNations (#60) layers on top. Suite 427 green, phpstan + schema:check clean.

Closes #815