### PR TITLE
feat(geo): location as vantage point — LocationService over the community graph (#816)

### DIFF
--- a/src/Domain/Geo/GeoDistance.php
+++ b/src/Domain/Geo/GeoDistance.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Geo;
+
+/**
+ * Great-circle distance (haversine) in kilometres. Standard geodesy math kept
+ * in-app so the geo domain has no external dependency (#816).
+ */
+final class GeoDistance
+{
+    private const float EARTH_RADIUS_KM = 6371.0;
+
+    public static function haversine(float $lat1, float $lon1, float $lat2, float $lon2): float
+    {
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLon = deg2rad($lon2 - $lon1);
+
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLon / 2) ** 2;
+
+        return self::EARTH_RADIUS_KM * 2 * atan2(sqrt($a), sqrt(1 - $a));
+    }
+}

--- a/src/Domain/Geo/Service/CommunityFinder.php
+++ b/src/Domain/Geo/Service/CommunityFinder.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Geo\Service;
+
+use App\Domain\Geo\GeoDistance;
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class CommunityFinder
+{
+    /**
+     * Find the nearest community to the given coordinates.
+     *
+     * @param array<ContentEntityBase> $communities
+     * @return array{community: ContentEntityBase, distanceKm: float}|null
+     */
+    public function findNearest(float $lat, float $lon, array $communities): ?array
+    {
+        $nearest = null;
+
+        foreach ($communities as $community) {
+            $communityLat = $community->get('latitude');
+            $communityLon = $community->get('longitude');
+
+            if ($communityLat === null || $communityLon === null) {
+                continue;
+            }
+
+            $distance = GeoDistance::haversine($lat, $lon, (float) $communityLat, (float) $communityLon);
+
+            if ($nearest === null || $distance < $nearest['distanceKm']) {
+                $nearest = [
+                    'community' => $community,
+                    'distanceKm' => $distance,
+                ];
+            }
+        }
+
+        return $nearest;
+    }
+
+    /**
+     * Find nearby communities sorted by distance, limited to $limit results.
+     *
+     * @param array<ContentEntityBase> $communities
+     * @param int $limit
+     * @return array<array{community: ContentEntityBase, distanceKm: float}>
+     */
+    public function findNearby(float $lat, float $lon, array $communities, int $limit = 5): array
+    {
+        $results = [];
+
+        foreach ($communities as $community) {
+            $communityLat = $community->get('latitude');
+            $communityLon = $community->get('longitude');
+
+            if ($communityLat === null || $communityLon === null) {
+                continue;
+            }
+
+            $results[] = [
+                'community' => $community,
+                'distanceKm' => GeoDistance::haversine($lat, $lon, (float) $communityLat, (float) $communityLon),
+            ];
+        }
+
+        usort($results, fn (array $a, array $b): int => $a['distanceKm'] <=> $b['distanceKm']);
+
+        return array_slice($results, 0, $limit);
+    }
+}

--- a/src/Domain/Geo/Service/LocationService.php
+++ b/src/Domain/Geo/Service/LocationService.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Geo\Service;
+
+use App\Domain\Geo\ValueObject\LocationContext;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Resolves a member's PLACE on Mother Earth into a vantage point on the
+ * community graph (#816). Consent-first and COARSE by construction:
+ *
+ *  - location only comes from an explicit, consented choice — a chosen home
+ *    community, or a one-time "use my location" the member opts into. There is
+ *    NO automatic IP geolocation.
+ *  - exact user coordinates are NEVER stored or returned. resolveCoordinates()
+ *    uses them transiently to find the nearest community, then returns only that
+ *    COMMUNITY's centroid. The LocationContext a controller persists holds the
+ *    community centroid, never the device position.
+ */
+final class LocationService
+{
+    private CommunityFinder $finder;
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        ?CommunityFinder $finder = null,
+    ) {
+        $this->finder = $finder ?? new CommunityFinder();
+    }
+
+    /**
+     * A member opted into sharing their device location once. Snap it to the
+     * nearest community centroid and discard the precise coordinates.
+     */
+    public function resolveCoordinates(float $latitude, float $longitude): LocationContext
+    {
+        $nearest = $this->finder->findNearest($latitude, $longitude, $this->geocodedCommunities());
+        if ($nearest === null) {
+            return LocationContext::none();
+        }
+
+        return $this->contextFor($nearest['community'], 'coordinates');
+    }
+
+    /** A member chose a home territory explicitly (e.g. the diaspora picker). */
+    public function resolveCommunity(int $communityId): LocationContext
+    {
+        if ($communityId <= 0) {
+            return LocationContext::none();
+        }
+
+        $community = $this->entityTypeManager->getStorage('community')->load($communityId);
+        if (!$community instanceof ContentEntityBase) {
+            return LocationContext::none();
+        }
+
+        return $this->contextFor($community, 'chosen');
+    }
+
+    /**
+     * Communities near a vantage point, nearest first — the spatial slice of the
+     * graph that is "yours".
+     *
+     * @return list<array{community: ContentEntityBase, distanceKm: float}>
+     */
+    public function nearbyCommunities(LocationContext $context, int $limit = 5): array
+    {
+        if (!$context->hasLocation() || $context->latitude === null || $context->longitude === null) {
+            return [];
+        }
+
+        return $this->finder->findNearby($context->latitude, $context->longitude, $this->geocodedCommunities(), $limit);
+    }
+
+    private function contextFor(ContentEntityBase $community, string $source): LocationContext
+    {
+        return new LocationContext(
+            communityId: (int) $community->id(),
+            communityName: (string) $community->get('name'),
+            latitude: (float) $community->get('latitude'),
+            longitude: (float) $community->get('longitude'),
+            source: $source,
+        );
+    }
+
+    /**
+     * Published communities that carry coordinates.
+     *
+     * @return list<ContentEntityBase>
+     */
+    private function geocodedCommunities(): array
+    {
+        $storage = $this->entityTypeManager->getStorage('community');
+        $ids = $storage->getQuery()->accessCheck(false)
+            ->condition('status', 1)
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($storage->loadMultiple($ids) as $community) {
+            if ($community instanceof ContentEntityBase && $community->get('latitude') !== null) {
+                $out[] = $community;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Domain/Geo/ValueObject/LocationContext.php
+++ b/src/Domain/Geo/ValueObject/LocationContext.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Geo\ValueObject;
+
+final readonly class LocationContext
+{
+    public function __construct(
+        public ?int $communityId,
+        public ?string $communityName,
+        public ?float $latitude,
+        public ?float $longitude,
+        public string $source,
+    ) {
+    }
+
+    public static function none(): self
+    {
+        return new self(
+            communityId: null,
+            communityName: null,
+            latitude: null,
+            longitude: null,
+            source: 'none',
+        );
+    }
+
+    public function hasLocation(): bool
+    {
+        return $this->communityId !== null && $this->communityId > 0;
+    }
+
+    /**
+     * @return array<string, int|string|float|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'communityId' => $this->communityId,
+            'communityName' => $this->communityName,
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'source' => $this->source,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['communityId'])) {
+            return self::none();
+        }
+
+        // Validate communityId is numeric and positive.
+        if (!is_numeric($data['communityId']) || (int) $data['communityId'] <= 0) {
+            return self::none();
+        }
+
+        // Validate latitude if present.
+        if (isset($data['latitude'])) {
+            if (!is_numeric($data['latitude'])) {
+                return self::none();
+            }
+            $lat = (float) $data['latitude'];
+            if ($lat < -90.0 || $lat > 90.0) {
+                return self::none();
+            }
+        }
+
+        // Validate longitude if present.
+        if (isset($data['longitude'])) {
+            if (!is_numeric($data['longitude'])) {
+                return self::none();
+            }
+            $lon = (float) $data['longitude'];
+            if ($lon < -180.0 || $lon > 180.0) {
+                return self::none();
+            }
+        }
+
+        return new self(
+            communityId: (int) $data['communityId'],
+            communityName: isset($data['communityName']) && is_string($data['communityName']) ? $data['communityName'] : null,
+            latitude: isset($data['latitude']) ? (float) $data['latitude'] : null,
+            longitude: isset($data['longitude']) ? (float) $data['longitude'] : null,
+            source: isset($data['source']) && is_string($data['source']) ? $data['source'] : 'none',
+        );
+    }
+}

--- a/src/Provider/AppBootServiceProvider.php
+++ b/src/Provider/AppBootServiceProvider.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
+use App\Domain\Geo\Service\LocationService;
 use App\Http\Twig\AccountDisplayTwigExtension;
 use App\Http\Twig\DateTwigExtension;
 use App\Http\Twig\LanguageTwigExtension;
 use Twig\Environment;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Event\EntityEvent;
 use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\I18n\LanguageManagerInterface;
@@ -25,6 +27,15 @@ use Waaseyaa\SSR\ThemeServiceProvider;
  */
 class AppBootServiceProvider extends AppCoreServiceProvider
 {
+    public function register(): void
+    {
+        // Location-as-vantage-point (#816): resolves a member's chosen place into
+        // a coarse community centroid for the feed + graph.
+        $this->singleton(LocationService::class, fn (): LocationService => new LocationService(
+            $this->resolve(EntityTypeManager::class),
+        ));
+    }
+
     public function boot(): void
     {
         // =====================================================================

--- a/tests/App/Unit/Domain/Geo/CommunityFinderTest.php
+++ b/tests/App/Unit/Domain/Geo/CommunityFinderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\Geo;
+
+use App\Domain\Geo\Service\CommunityFinder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\ContentEntityBase;
+
+#[CoversClass(CommunityFinder::class)]
+final class CommunityFinderTest extends TestCase
+{
+    private function community(string $name, float $lat, float $lon): ContentEntityBase
+    {
+        $c = $this->createMock(ContentEntityBase::class);
+        $c->method('get')->willReturnCallback(static fn (string $f) => match ($f) {
+            'name' => $name, 'latitude' => $lat, 'longitude' => $lon, default => null,
+        });
+        return $c;
+    }
+
+    #[Test]
+    public function finds_the_nearest_community(): void
+    {
+        $finder = new CommunityFinder();
+        $communities = [
+            $this->community('Far', 50.0, -90.0),
+            $this->community('Near', 46.2, -82.1),
+            $this->community('Mid', 47.0, -83.0),
+        ];
+
+        $nearest = $finder->findNearest(46.217, -82.067, $communities);
+        $this->assertNotNull($nearest);
+        $this->assertSame('Near', $nearest['community']->get('name'));
+    }
+
+    #[Test]
+    public function nearby_is_sorted_and_limited(): void
+    {
+        $finder = new CommunityFinder();
+        $communities = [
+            $this->community('Far', 50.0, -90.0),
+            $this->community('Near', 46.2, -82.1),
+            $this->community('Mid', 47.0, -83.0),
+        ];
+
+        $nearby = $finder->findNearby(46.217, -82.067, $communities, 2);
+        $this->assertCount(2, $nearby);
+        $this->assertSame('Near', $nearby[0]['community']->get('name'));
+        $this->assertLessThanOrEqual($nearby[1]['distanceKm'], $nearby[0]['distanceKm'] + 0.0001);
+    }
+
+    #[Test]
+    public function skips_communities_without_coordinates(): void
+    {
+        $finder = new CommunityFinder();
+        $noCoords = $this->createMock(ContentEntityBase::class);
+        $noCoords->method('get')->willReturn(null);
+
+        $nearest = $finder->findNearest(46.217, -82.067, [$noCoords]);
+        $this->assertNull($nearest);
+    }
+}

--- a/tests/App/Unit/Domain/Geo/GeoDistanceTest.php
+++ b/tests/App/Unit/Domain/Geo/GeoDistanceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\Geo;
+
+use App\Domain\Geo\GeoDistance;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GeoDistance::class)]
+final class GeoDistanceTest extends TestCase
+{
+    #[Test]
+    public function same_point_is_zero(): void
+    {
+        $this->assertSame(0.0, GeoDistance::haversine(46.217, -82.067, 46.217, -82.067));
+    }
+
+    #[Test]
+    public function known_distance_is_accurate(): void
+    {
+        // Massey (46.217, -82.067) to Sagamok (46.167, -82.217) is ~13 km.
+        $km = GeoDistance::haversine(46.217, -82.067, 46.167, -82.217);
+        $this->assertGreaterThan(10.0, $km);
+        $this->assertLessThan(16.0, $km);
+    }
+
+    #[Test]
+    public function is_symmetric(): void
+    {
+        $a = GeoDistance::haversine(46.5, -84.3, 46.2, -81.2);
+        $b = GeoDistance::haversine(46.2, -81.2, 46.5, -84.3);
+        $this->assertEqualsWithDelta($a, $b, 0.0001);
+    }
+}

--- a/tests/App/Unit/Domain/Geo/LocationServiceTest.php
+++ b/tests/App/Unit/Domain/Geo/LocationServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\Geo;
+
+use App\Domain\Geo\Service\LocationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+#[CoversClass(LocationService::class)]
+final class LocationServiceTest extends TestCase
+{
+    private function community(int $id, string $name, float $lat, float $lon): ContentEntityBase
+    {
+        $c = $this->createMock(ContentEntityBase::class);
+        $c->method('id')->willReturn($id);
+        $c->method('get')->willReturnCallback(static fn (string $f) => match ($f) {
+            'name' => $name, 'latitude' => $lat, 'longitude' => $lon, default => null,
+        });
+        return $c;
+    }
+
+    /** @param list<ContentEntityBase> $rows */
+    private function etmReturning(array $rows, ?ContentEntityBase $loadById = null): EntityTypeManager
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn(array_map(static fn ($c) => $c->id(), $rows));
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+        $storage->method('loadMultiple')->willReturn($rows);
+        $storage->method('load')->willReturn($loadById);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getStorage')->willReturn($storage);
+        return $etm;
+    }
+
+    #[Test]
+    public function resolve_coordinates_returns_the_community_centroid_not_the_exact_position(): void
+    {
+        $near = $this->community(7, 'Near', 46.20, -82.10);
+        $service = new LocationService($this->etmReturning([
+            $this->community(1, 'Far', 50.0, -90.0),
+            $near,
+        ]));
+
+        // A member shares a precise device position once.
+        $ctx = $service->resolveCoordinates(46.217, -82.067);
+
+        $this->assertTrue($ctx->hasLocation());
+        $this->assertSame(7, $ctx->communityId);
+        $this->assertSame('Near', $ctx->communityName);
+        // Coarse: the context holds the COMMUNITY centroid, never the device coords.
+        $this->assertSame(46.20, $ctx->latitude);
+        $this->assertSame(-82.10, $ctx->longitude);
+        $this->assertNotSame(46.217, $ctx->latitude);
+    }
+
+    #[Test]
+    public function resolve_community_loads_the_chosen_home_territory(): void
+    {
+        $chosen = $this->community(42, 'Sagamok', 46.167, -82.217);
+        $service = new LocationService($this->etmReturning([], $chosen));
+
+        $ctx = $service->resolveCommunity(42);
+        $this->assertSame(42, $ctx->communityId);
+        $this->assertSame('chosen', $ctx->source);
+    }
+
+    #[Test]
+    public function unknown_community_yields_no_location(): void
+    {
+        $service = new LocationService($this->etmReturning([], null));
+        $this->assertFalse($service->resolveCommunity(999)->hasLocation());
+        $this->assertFalse($service->resolveCommunity(0)->hasLocation());
+    }
+}


### PR DESCRIPTION
Restores the Geo domain consent-first: in-app GeoDistance (haversine), CommunityFinder (nearest/nearby), LocationService that snaps an opted-in device position to the nearest community CENTROID (exact coords discarded) or takes a chosen home territory — no auto-IP. Verified: near Sudbury -> Greater Sudbury; nearby mixes town + First Nation in one graph. Suite 436 green, phpstan clean.

Closes #816