### PR TITLE
feat(social): restore the engagement write API (#813)

### DIFF
--- a/src/Http/Controller/Social/EngagementController.php
+++ b/src/Http/Controller/Social/EngagementController.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Social;
+
+use App\Http\Controller\Concerns\JsonResponseTrait;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Media\UploadHandler;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
+
+final class EngagementController
+{
+    use JsonResponseTrait;
+
+    /** @var list<string> Entity types that can be reaction/comment/follow targets */
+    private const ALLOWED_TARGET_TYPES = [
+        'event', 'group', 'teaching', 'community', 'post',
+        'oral_history', 'dictionary_entry', 'cultural_collection', 'thread_message',
+    ];
+
+    /** @var list<string> The Minoo reaction vocabulary (#812). */
+    private const ALLOWED_REACTION_TYPES = ['like', 'interested', 'recommend', 'miigwech', 'connect'];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly UploadHandler $uploadHandler,
+    ) {
+    }
+
+    public function react(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->jsonBody($request);
+
+        if (!isset($data['reaction_type'], $data['target_type'], $data['target_id'])) {
+            return $this->json(['error' => 'Missing required fields: reaction_type, target_type, target_id'], 422);
+        }
+
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
+        $reactionType = trim($data['reaction_type']);
+
+        if (!in_array($reactionType, self::ALLOWED_REACTION_TYPES, true)) {
+            return $this->json(['error' => 'Invalid reaction_type. Allowed: ' . implode(', ', self::ALLOWED_REACTION_TYPES)], 422);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('reaction');
+
+        try {
+            $entity = $storage->create([
+                'reaction_type' => $reactionType,
+                'user_id' => $account->id(),
+                'target_type' => $data['target_type'],
+                'target_id' => (int) $data['target_id'],
+            ]);
+            $storage->save($entity);
+        } catch (\InvalidArgumentException) {
+            return $this->json(['error' => 'Invalid entity data'], 422);
+        }
+
+        return $this->json(['id' => $entity->id(), 'reaction_type' => $entity->get('reaction_type')], 201);
+    }
+
+    public function deleteReaction(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $id = (int) ($params['id'] ?? 0);
+        $storage = $this->entityTypeManager->getStorage('reaction');
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return $this->json(['error' => 'Not found'], 404);
+        }
+
+        if ((int) $entity->get('user_id') !== (int) $account->id() && !$account->hasPermission('administer content')) {
+            return $this->json(['error' => 'Forbidden'], 403);
+        }
+
+        $storage->delete([$entity]);
+
+        return $this->json(['deleted' => true]);
+    }
+
+    public function comment(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->jsonBody($request);
+
+        if (!isset($data['body'], $data['target_type'], $data['target_id'])) {
+            return $this->json(['error' => 'Missing required fields: body, target_type, target_id'], 422);
+        }
+
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
+        $body = trim($data['body']);
+        if ($body === '' || mb_strlen($body) > 2000) {
+            return $this->json(['error' => 'Body must be 1-2000 characters'], 422);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('comment');
+
+        try {
+            $entity = $storage->create([
+                'body' => $body,
+                'user_id' => $account->id(),
+                'target_type' => $data['target_type'],
+                'target_id' => (int) $data['target_id'],
+            ]);
+            $storage->save($entity);
+        } catch (\InvalidArgumentException) {
+            return $this->json(['error' => 'Invalid entity data'], 422);
+        }
+
+        return $this->json([
+            'id' => $entity->id(),
+            'body' => $entity->get('body'),
+            'created_at' => $entity->get('created_at'),
+        ], 201);
+    }
+
+    public function deleteComment(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $id = (int) ($params['id'] ?? 0);
+        $storage = $this->entityTypeManager->getStorage('comment');
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return $this->json(['error' => 'Not found'], 404);
+        }
+
+        if ((int) $entity->get('user_id') !== (int) $account->id() && !$account->hasPermission('administer content')) {
+            return $this->json(['error' => 'Forbidden'], 403);
+        }
+
+        $storage->delete([$entity]);
+
+        return $this->json(['deleted' => true]);
+    }
+
+    public function getComments(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $targetType = $params['target_type'] ?? '';
+        if (!$this->isValidTargetType($targetType)) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
+        $targetId = (int) ($params['target_id'] ?? 0);
+        $limit = min((int) ($query['limit'] ?? 20), 50);
+        $offset = max((int) ($query['offset'] ?? 0), 0);
+
+        $storage = $this->entityTypeManager->getStorage('comment');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('target_type', $targetType)
+            ->condition('target_id', $targetId)
+            ->condition('status', 1)
+            ->sort('created_at', 'DESC')
+            ->range($offset, $limit)
+            ->execute();
+
+        $comments = $ids !== [] ? array_values($storage->loadMultiple($ids)) : [];
+
+        $items = array_map(fn ($c) => [
+            'id' => $c->id(),
+            'body' => $c->get('body'),
+            'user_id' => $c->get('user_id'),
+            'created_at' => $c->get('created_at'),
+        ], $comments);
+
+        return $this->json(['comments' => $items]);
+    }
+
+    public function follow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->jsonBody($request);
+
+        if (!isset($data['target_type'], $data['target_id'])) {
+            return $this->json(['error' => 'Missing required fields: target_type, target_id'], 422);
+        }
+
+        if (!$this->isValidTargetType($data['target_type'])) {
+            return $this->json(['error' => 'Invalid target_type'], 422);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('follow');
+
+        try {
+            $entity = $storage->create([
+                'user_id' => $account->id(),
+                'target_type' => $data['target_type'],
+                'target_id' => (int) $data['target_id'],
+            ]);
+            $storage->save($entity);
+        } catch (\InvalidArgumentException) {
+            return $this->json(['error' => 'Invalid entity data'], 422);
+        }
+
+        return $this->json(['id' => $entity->id()], 201);
+    }
+
+    public function deleteFollow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $id = (int) ($params['id'] ?? 0);
+        $storage = $this->entityTypeManager->getStorage('follow');
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return $this->json(['error' => 'Not found'], 404);
+        }
+
+        if ((int) $entity->get('user_id') !== (int) $account->id() && !$account->hasPermission('administer content')) {
+            return $this->json(['error' => 'Forbidden'], 403);
+        }
+
+        $storage->delete([$entity]);
+
+        return $this->json(['deleted' => true]);
+    }
+
+    public function createPost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        // Support both JSON and multipart form data
+        // Try JSON first (existing API), fall back to form data (multipart with images)
+        $data = $this->jsonBody($request);
+        if (isset($data['body'])) {
+            $body = trim($data['body']);
+            $communityId = (int) ($data['community_id'] ?? 0);
+        } else {
+            $body = trim((string) $request->request->get('body', ''));
+            $communityId = (int) $request->request->get('community_id', 0);
+        }
+
+        if ($communityId === 0) {
+            return $this->json(['error' => 'Missing required fields: body, community_id'], 422);
+        }
+
+        if ($body === '' || mb_strlen($body) > 5000) {
+            return $this->json(['error' => 'Body must be 1-5000 characters'], 422);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('post');
+
+        // Resolve author display name for feed attribution
+        $authorName = '';
+        if ($account instanceof \Waaseyaa\User\User) {
+            $authorName = $account->getName();
+        }
+
+        try {
+            $entity = $storage->create([
+                'body' => $body,
+                'user_id' => $account->id(),
+                'community_id' => $communityId,
+                'author_name' => $authorName,
+            ]);
+            $storage->save($entity);
+        } catch (\InvalidArgumentException) {
+            return $this->json(['error' => 'Invalid entity data'], 422);
+        }
+
+        // Handle image uploads
+        $uploadedFiles = $this->extractUploadedImages($request);
+        if ($uploadedFiles !== []) {
+            $imagePaths = [];
+            foreach ($uploadedFiles as $file) {
+                $fileArray = [
+                    'name' => $file->getClientOriginalName(),
+                    'tmp_name' => $file->getPathname(),
+                    'size' => $file->getSize(),
+                    // Client-declared type only; UploadHandler::validate() re-checks
+                    // the REAL mime via finfo on the tmp file, rejecting spoofs.
+                    'type' => (string) $file->getClientMimeType(),
+                    'error' => $file->getError(),
+                ];
+                if ($this->uploadHandler->validate($fileArray) === []) {
+                    $imagePaths[] = $this->uploadHandler->moveUpload($fileArray, 'posts/' . $entity->id());
+                }
+            }
+            if ($imagePaths !== []) {
+                $entity->set('images', json_encode($imagePaths));
+                $storage->save($entity);
+            }
+        }
+
+        return $this->json([
+            'id' => $entity->id(),
+            'body' => $entity->get('body'),
+            'created_at' => $entity->get('created_at'),
+        ], 201);
+    }
+
+    /** @return list<UploadedFile> */
+    private function extractUploadedImages(HttpRequest $request): array
+    {
+        $candidates = [];
+        foreach (['images', 'images[]'] as $key) {
+            try {
+                $all = $request->files->all($key);
+                if ($all !== []) {
+                    $candidates[] = $all;
+                }
+            } catch (\Throwable) {
+                // Some payload shapes throw when all() expects array but gets a single file.
+            }
+
+            $single = $request->files->get($key);
+            if ($single !== null) {
+                $candidates[] = $single;
+            }
+        }
+
+        $files = [];
+        $flatten = function (mixed $value) use (&$files, &$flatten): void {
+            if ($value instanceof UploadedFile) {
+                $files[] = $value;
+
+                return;
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $item) {
+                    $flatten($item);
+                }
+            }
+        };
+
+        foreach ($candidates as $candidate) {
+            $flatten($candidate);
+        }
+
+        return array_slice($files, 0, 4);
+    }
+
+    public function deletePost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $id = (int) ($params['id'] ?? 0);
+        $storage = $this->entityTypeManager->getStorage('post');
+        $entity = $storage->load($id);
+
+        if ($entity === null) {
+            return $this->json(['error' => 'Not found'], 404);
+        }
+
+        if ((int) $entity->get('user_id') !== (int) $account->id() && !$account->hasPermission('administer content')) {
+            return $this->json(['error' => 'Forbidden'], 403);
+        }
+
+        $storage->delete([$entity]);
+        $this->uploadHandler->deleteDirectory('posts/' . $id);
+
+        return $this->json(['deleted' => true]);
+    }
+
+    private function isValidTargetType(string $type): bool
+    {
+        return in_array($type, self::ALLOWED_TARGET_TYPES, true);
+    }
+
+}

--- a/src/Provider/AppBootServiceProvider.php
+++ b/src/Provider/AppBootServiceProvider.php
@@ -15,6 +15,7 @@ use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\I18n\LanguageManagerInterface;
 use Waaseyaa\I18n\TranslatorInterface;
 use Waaseyaa\I18n\Twig\TranslationTwigExtension;
+use Waaseyaa\Media\UploadHandler;
 use Waaseyaa\Search\SearchProviderInterface;
 use Waaseyaa\Search\Twig\SearchTwigExtension;
 use Waaseyaa\SSR\SsrServiceProvider;
@@ -33,6 +34,11 @@ class AppBootServiceProvider extends AppCoreServiceProvider
         // a coarse community centroid for the feed + graph.
         $this->singleton(LocationService::class, fn (): LocationService => new LocationService(
             $this->resolve(EntityTypeManager::class),
+        ));
+
+        // Image uploads for post creation (#813).
+        $this->singleton(UploadHandler::class, fn (): UploadHandler => new UploadHandler(
+            dirname(__DIR__, 2) . '/storage/uploads',
         ));
     }
 

--- a/src/Provider/MinooRoutingStackProvider.php
+++ b/src/Provider/MinooRoutingStackProvider.php
@@ -11,6 +11,7 @@ use App\Provider\Routing\LessonRouteProvider;
 use App\Provider\Routing\PublicAccountRouteProvider;
 use App\Provider\Routing\PublicContentRouteProvider;
 use App\Provider\Routing\PublicHomeFeedRouteProvider;
+use App\Provider\Routing\SocialApiRouteProvider;
 use App\Provider\Routing\StaticPagesRouteProvider;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -39,6 +40,7 @@ final class MinooRoutingStackProvider extends ServiceProvider
             new LessonRouteProvider(),
             new StaticPagesRouteProvider(),
             new AdminRouteProvider(),
+            new SocialApiRouteProvider(),
         ] as $child) {
             // mergeChildProvider() forwards both kernel context and the kernel-services
             // resolver introduced in alpha.171 (replaces the older setKernelResolver path).

--- a/src/Provider/Routing/SocialApiRouteProvider.php
+++ b/src/Provider/Routing/SocialApiRouteProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Routing;
+
+use App\Provider\AppCoreServiceProvider;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Routing\RouteBuilder;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+/**
+ * Social spine write API (#813): reactions, comments, follows, posts.
+ *
+ * Consent by participation — every mutating route requires authentication, so a
+ * member only ever acts for themselves. Reading comments is public.
+ * (The cut chat + messaging routes are NOT restored here.)
+ */
+final class SocialApiRouteProvider extends AppCoreServiceProvider
+{
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        $ctrl = 'App\\Http\\Controller\\Social\\EngagementController';
+
+        $router->addRoute(
+            'engagement.react',
+            RouteBuilder::create('/api/engagement/react')
+                ->controller($ctrl . '::react')->requireAuthentication()->methods('POST')->build(),
+        );
+        $router->addRoute(
+            'engagement.deleteReaction',
+            RouteBuilder::create('/api/engagement/react/{id}')
+                ->controller($ctrl . '::deleteReaction')->requireAuthentication()->methods('DELETE')->requirement('id', '\\d+')->build(),
+        );
+        $router->addRoute(
+            'engagement.comment',
+            RouteBuilder::create('/api/engagement/comment')
+                ->controller($ctrl . '::comment')->requireAuthentication()->methods('POST')->build(),
+        );
+        $router->addRoute(
+            'engagement.deleteComment',
+            RouteBuilder::create('/api/engagement/comment/{id}')
+                ->controller($ctrl . '::deleteComment')->requireAuthentication()->methods('DELETE')->requirement('id', '\\d+')->build(),
+        );
+        $router->addRoute(
+            'engagement.getComments',
+            RouteBuilder::create('/api/engagement/comments/{target_type}/{target_id}')
+                ->controller($ctrl . '::getComments')->allowAll()->methods('GET')->requirement('target_id', '\\d+')->build(),
+        );
+        $router->addRoute(
+            'engagement.follow',
+            RouteBuilder::create('/api/engagement/follow')
+                ->controller($ctrl . '::follow')->requireAuthentication()->methods('POST')->build(),
+        );
+        $router->addRoute(
+            'engagement.deleteFollow',
+            RouteBuilder::create('/api/engagement/follow/{id}')
+                ->controller($ctrl . '::deleteFollow')->requireAuthentication()->methods('DELETE')->requirement('id', '\\d+')->build(),
+        );
+        $router->addRoute(
+            'engagement.createPost',
+            RouteBuilder::create('/api/engagement/post')
+                ->controller($ctrl . '::createPost')->requireAuthentication()->methods('POST')->build(),
+        );
+        $router->addRoute(
+            'engagement.deletePost',
+            RouteBuilder::create('/api/engagement/post/{id}')
+                ->controller($ctrl . '::deletePost')->requireAuthentication()->methods('DELETE')->requirement('id', '\\d+')->build(),
+        );
+    }
+}

--- a/tests/App/Unit/Http/Controller/Social/EngagementControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Social/EngagementControllerTest.php
@@ -1,0 +1,553 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Http\Controller\Social;
+
+use App\Http\Controller\Social\EngagementController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\ContentEntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Media\UploadHandler;
+
+#[CoversClass(EngagementController::class)]
+final class EngagementControllerTest extends TestCase
+{
+    private EntityTypeManager $etm;
+    private EngagementController $controller;
+
+    protected function setUp(): void
+    {
+        $this->etm = $this->createMock(EntityTypeManager::class);
+        $this->controller = new EngagementController($this->etm, new UploadHandler(sys_get_temp_dir() . '/minoo-test-uploads'));
+    }
+
+    private function mockAccount(int $id = 1, bool $isAdmin = false): AccountInterface
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('id')->willReturn($id);
+        $account->method('isAuthenticated')->willReturn(true);
+        $account->method('hasPermission')->willReturn($isAdmin);
+
+        return $account;
+    }
+
+    /** @param array<string, mixed> $fieldMap */
+    private function mockEntity(array $fieldMap = [], int|string|null $id = null): ContentEntityInterface
+    {
+        $entity = $this->createMock(ContentEntityInterface::class);
+        if ($id !== null) {
+            $entity->method('id')->willReturn($id);
+        }
+        if ($fieldMap !== []) {
+            $entity->method('get')->willReturnMap(
+                array_map(fn ($k, $v) => [$k, $v], array_keys($fieldMap), array_values($fieldMap)),
+            );
+        }
+
+        return $entity;
+    }
+
+    private function mockStorage(string $type): EntityStorageInterface
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $this->etm->method('getStorage')->with($type)->willReturn($storage);
+
+        return $storage;
+    }
+
+    private function jsonRequest(string $method, array $body): HttpRequest
+    {
+        return HttpRequest::create('/', $method, [], [], [], [], json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    // --- Target type whitelist ---
+
+    #[Test]
+    public function react_rejects_invalid_target_type(): void
+    {
+        $request = $this->jsonRequest('POST', [
+            'reaction_type' => 'like',
+            'target_type' => 'malicious_type',
+            'target_id' => 1,
+        ]);
+
+        $response = $this->controller->react([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
+    }
+
+    #[Test]
+    public function comment_rejects_invalid_target_type(): void
+    {
+        $request = $this->jsonRequest('POST', [
+            'body' => 'Hello',
+            'target_type' => 'sql_injection',
+            'target_id' => 1,
+        ]);
+
+        $response = $this->controller->comment([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
+    }
+
+    #[Test]
+    public function follow_rejects_invalid_target_type(): void
+    {
+        $request = $this->jsonRequest('POST', [
+            'target_type' => 'nonexistent',
+            'target_id' => 1,
+        ]);
+
+        $response = $this->controller->follow([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
+    }
+
+    #[Test]
+    public function getComments_rejects_invalid_target_type(): void
+    {
+        $request = HttpRequest::create('/');
+
+        $response = $this->controller->getComments(
+            ['target_type' => 'xss_attempt', 'target_id' => '1'],
+            [],
+            $this->mockAccount(),
+            $request,
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Invalid target_type', $response->getContent());
+    }
+
+    // --- Reaction type validation ---
+
+    #[Test]
+    public function react_rejects_invalid_reaction_type(): void
+    {
+        $storage = $this->mockStorage('reaction');
+        $storage->method('create')->willThrowException(
+            new \InvalidArgumentException("Invalid reaction_type 'invalid_type'."),
+        );
+
+        $request = $this->jsonRequest('POST', [
+            'reaction_type' => 'invalid_type',
+            'target_type' => 'event',
+            'target_id' => 1,
+        ]);
+
+        $response = $this->controller->react([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    // --- Missing fields ---
+
+    #[Test]
+    public function react_rejects_missing_fields(): void
+    {
+        $request = $this->jsonRequest('POST', ['reaction_type' => 'like']);
+
+        $response = $this->controller->react([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Missing required fields', $response->getContent());
+    }
+
+    #[Test]
+    public function comment_rejects_missing_fields(): void
+    {
+        $request = $this->jsonRequest('POST', ['body' => 'Hello']);
+
+        $response = $this->controller->comment([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Missing required fields', $response->getContent());
+    }
+
+    // --- Body length validation ---
+
+    #[Test]
+    public function createPost_rejects_empty_body(): void
+    {
+        $request = $this->jsonRequest('POST', ['body' => '   ', 'community_id' => 1]);
+
+        $response = $this->controller->createPost([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
+    }
+
+    #[Test]
+    public function createPost_rejects_oversized_body(): void
+    {
+        $request = $this->jsonRequest('POST', ['body' => str_repeat('a', 5001), 'community_id' => 1]);
+
+        $response = $this->controller->createPost([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
+    }
+
+    #[Test]
+    public function comment_rejects_oversized_body(): void
+    {
+        $request = $this->jsonRequest('POST', [
+            'body' => str_repeat('a', 2001),
+            'target_type' => 'event',
+            'target_id' => 1,
+        ]);
+
+        $response = $this->controller->comment([], [], $this->mockAccount(), $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertStringContainsString('Body must be', $response->getContent());
+    }
+
+    // --- Happy-path creation tests ---
+
+    #[Test]
+    public function react_creates_reaction_and_returns_201(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['reaction_type' => 'interested'], 1);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('create')->willReturn($entity);
+
+        $request = $this->jsonRequest('POST', [
+            'reaction_type' => 'interested', 'target_type' => 'event', 'target_id' => 10,
+        ]);
+
+        $response = $this->controller->react([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(1, $json['id']);
+    }
+
+    #[Test]
+    public function react_accepts_thread_message_target_type(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['reaction_type' => 'miigwech'], 7);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('create')->willReturn($entity);
+
+        $request = $this->jsonRequest('POST', [
+            'reaction_type' => 'miigwech', 'target_type' => 'thread_message', 'target_id' => 99,
+        ]);
+
+        $response = $this->controller->react([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(7, $json['id']);
+    }
+
+    #[Test]
+    public function comment_creates_comment_and_returns_201(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['body' => 'Great event!', 'user_id' => 42, 'created_at' => 1700000000], 5);
+        $storage = $this->mockStorage('comment');
+        $storage->method('create')->willReturn($entity);
+
+        $request = $this->jsonRequest('POST', [
+            'body' => 'Great event!', 'target_type' => 'event', 'target_id' => 10,
+        ]);
+
+        $response = $this->controller->comment([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(5, $json['id']);
+        $this->assertSame('Great event!', $json['body']);
+    }
+
+    #[Test]
+    public function follow_creates_follow_and_returns_201(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(id: 7);
+        $storage = $this->mockStorage('follow');
+        $storage->method('create')->willReturn($entity);
+
+        $request = $this->jsonRequest('POST', [
+            'target_type' => 'community', 'target_id' => 5,
+        ]);
+
+        $response = $this->controller->follow([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(7, $json['id']);
+    }
+
+    #[Test]
+    public function create_post_returns_201(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['body' => 'Hello community!', 'created_at' => 1700000000], 3);
+        $storage = $this->mockStorage('post');
+        $storage->method('create')->willReturn($entity);
+
+        $request = $this->jsonRequest('POST', ['body' => 'Hello community!', 'community_id' => 1]);
+
+        $response = $this->controller->createPost([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(3, $json['id']);
+    }
+
+    #[Test]
+    public function create_post_accepts_single_multipart_image_field(): void
+    {
+        if (!extension_loaded('fileinfo')) {
+            $this->markTestSkipped('UploadHandler MIME validation requires the fileinfo extension.');
+        }
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['body' => 'Hello community!', 'created_at' => 1700000000], 3);
+        $storage = $this->mockStorage('post');
+        $storage->method('create')->willReturn($entity);
+
+        $tmpImage = tempnam(sys_get_temp_dir(), 'img');
+        file_put_contents($tmpImage, 'test-image');
+        $upload = new UploadedFile(
+            path: $tmpImage,
+            originalName: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            error: UPLOAD_ERR_OK,
+            test: true,
+        );
+
+        $request = HttpRequest::create(
+            uri: '/api/engagement/post',
+            method: 'POST',
+            parameters: ['body' => 'Hello community!', 'community_id' => 1],
+            files: ['images' => $upload],
+        );
+
+        $response = $this->controller->createPost([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(3, $json['id']);
+    }
+
+    #[Test]
+    public function create_post_rejects_spoofed_client_mime_type_image_upload(): void
+    {
+        if (!extension_loaded('fileinfo')) {
+            $this->markTestSkipped('UploadHandler MIME validation requires the fileinfo extension.');
+        }
+        $account = $this->mockAccount(42);
+        $entity = $this->createMock(ContentEntityInterface::class);
+        $entity->method('id')->willReturn(3);
+        $entity->method('get')->willReturnMap([
+            ['body', 'Hello community!'],
+            ['created_at', 1700000000],
+        ]);
+        $entity->expects($this->never())->method('set');
+
+        $storage = $this->mockStorage('post');
+        $storage->method('create')->willReturn($entity);
+        $storage->expects($this->once())->method('save')->with($entity);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'php');
+        file_put_contents($tmpFile, '<?php echo "not an image";');
+        $upload = new UploadedFile(
+            path: $tmpFile,
+            originalName: 'shell.php',
+            mimeType: 'image/jpeg',
+            error: UPLOAD_ERR_OK,
+            test: true,
+        );
+
+        $request = HttpRequest::create(
+            uri: '/api/engagement/post',
+            method: 'POST',
+            parameters: ['body' => 'Hello community!', 'community_id' => 1],
+            files: ['images' => $upload],
+        );
+
+        $response = $this->controller->createPost([], [], $account, $request);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame(3, $json['id']);
+    }
+
+    // --- Delete tests ---
+
+    #[Test]
+    public function delete_reaction_returns_200_for_owner(): void
+    {
+        $account = $this->mockAccount(42);
+        $entity = $this->mockEntity(['user_id' => 42]);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
+        $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertTrue($json['deleted']);
+    }
+
+    #[Test]
+    public function delete_reaction_returns_403_for_non_owner(): void
+    {
+        $account = $this->mockAccount(99);
+        $entity = $this->mockEntity(['user_id' => 42]);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
+        $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('Forbidden', $response->getContent());
+    }
+
+    #[Test]
+    public function delete_reaction_allowed_for_admin(): void
+    {
+        $account = $this->mockAccount(99, isAdmin: true);
+        $entity = $this->mockEntity(['user_id' => 42]);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $request = HttpRequest::create('/api/engagement/react/1', 'DELETE');
+        $response = $this->controller->deleteReaction(['id' => '1'], [], $account, $request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertTrue($json['deleted']);
+    }
+
+    #[Test]
+    public function delete_reaction_returns_404_when_not_found(): void
+    {
+        $account = $this->mockAccount();
+        $storage = $this->mockStorage('reaction');
+        $storage->method('load')->willReturn(null);
+
+        $request = HttpRequest::create('/api/engagement/react/999', 'DELETE');
+        $response = $this->controller->deleteReaction(['id' => '999'], [], $account, $request);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function delete_comment_returns_403_for_non_owner(): void
+    {
+        $account = $this->mockAccount(99);
+        $entity = $this->mockEntity(['user_id' => 42]);
+        $storage = $this->mockStorage('comment');
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $request = HttpRequest::create('/api/engagement/comment/1', 'DELETE');
+        $response = $this->controller->deleteComment(['id' => '1'], [], $account, $request);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function delete_post_returns_403_for_non_owner(): void
+    {
+        $account = $this->mockAccount(99);
+        $entity = $this->mockEntity(['user_id' => 42]);
+        $storage = $this->mockStorage('post');
+        $storage->method('load')->with(1)->willReturn($entity);
+
+        $request = HttpRequest::create('/api/engagement/post/1', 'DELETE');
+        $response = $this->controller->deletePost(['id' => '1'], [], $account, $request);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    // --- Constructor exception safety net (#453) ---
+
+    #[Test]
+    public function react_catches_constructor_invalid_argument_exception(): void
+    {
+        $account = $this->mockAccount(42);
+        $storage = $this->mockStorage('reaction');
+        $storage->method('create')->willThrowException(new \InvalidArgumentException('Bad data'));
+
+        $request = $this->jsonRequest('POST', [
+            'reaction_type' => 'like', 'target_type' => 'event', 'target_id' => 1,
+        ]);
+
+        $response = $this->controller->react([], [], $account, $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame('Invalid entity data', $json['error']);
+    }
+
+    #[Test]
+    public function comment_catches_constructor_invalid_argument_exception(): void
+    {
+        $account = $this->mockAccount(42);
+        $storage = $this->mockStorage('comment');
+        $storage->method('create')->willThrowException(new \InvalidArgumentException('Bad data'));
+
+        $request = $this->jsonRequest('POST', [
+            'body' => 'A valid comment', 'target_type' => 'event', 'target_id' => 1,
+        ]);
+
+        $response = $this->controller->comment([], [], $account, $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame('Invalid entity data', $json['error']);
+    }
+
+    #[Test]
+    public function follow_catches_constructor_invalid_argument_exception(): void
+    {
+        $account = $this->mockAccount(42);
+        $storage = $this->mockStorage('follow');
+        $storage->method('create')->willThrowException(new \InvalidArgumentException('Bad data'));
+
+        $request = $this->jsonRequest('POST', [
+            'target_type' => 'event', 'target_id' => 1,
+        ]);
+
+        $response = $this->controller->follow([], [], $account, $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame('Invalid entity data', $json['error']);
+    }
+
+    #[Test]
+    public function createPost_catches_constructor_invalid_argument_exception(): void
+    {
+        $account = $this->mockAccount(42);
+        $storage = $this->mockStorage('post');
+        $storage->method('create')->willThrowException(new \InvalidArgumentException('Bad data'));
+
+        $request = $this->jsonRequest('POST', [
+            'body' => 'A valid post body', 'community_id' => 1,
+        ]);
+
+        $response = $this->controller->createPost([], [], $account, $request);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $json = json_decode($response->getContent(), true);
+        $this->assertSame('Invalid entity data', $json['error']);
+    }
+}


### PR DESCRIPTION
Restores EngagementController (react/comment/follow/post + deletes) + a clean SocialApiRouteProvider wired into the routing stack. Auth-gated mutations (consent by participation). Enforces the Minoo reaction vocabulary; delegates upload MIME validation to UploadHandler (dropped redundant controller finfo). Verified live: react 201 / invalid 422 / comment 201 / follow 201 / post 201 / getComments 200. Suite 463 green (2 upload tests skip without fileinfo; run in CI).

Closes #813