### PR TITLE
refactor(social): remove the deferred follow surface (#833)

### DIFF
--- a/src/Http/Controller/Social/EngagementController.php
+++ b/src/Http/Controller/Social/EngagementController.php
@@ -176,52 +176,9 @@ final class EngagementController
         return $this->json(['comments' => $items]);
     }
 
-    public function follow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
-    {
-        $data = $this->jsonBody($request);
-
-        if (!isset($data['target_type'], $data['target_id'])) {
-            return $this->json(['error' => 'Missing required fields: target_type, target_id'], 422);
-        }
-
-        if (!$this->isValidTargetType($data['target_type'])) {
-            return $this->json(['error' => 'Invalid target_type'], 422);
-        }
-
-        $storage = $this->entityTypeManager->getStorage('follow');
-
-        try {
-            $entity = $storage->create([
-                'user_id' => $account->id(),
-                'target_type' => $data['target_type'],
-                'target_id' => (int) $data['target_id'],
-            ]);
-            $storage->save($entity);
-        } catch (\InvalidArgumentException) {
-            return $this->json(['error' => 'Invalid entity data'], 422);
-        }
-
-        return $this->json(['id' => $entity->id()], 201);
-    }
-
-    public function deleteFollow(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
-    {
-        $id = (int) ($params['id'] ?? 0);
-        $storage = $this->entityTypeManager->getStorage('follow');
-        $entity = $storage->load($id);
-
-        if ($entity === null) {
-            return $this->json(['error' => 'Not found'], 404);
-        }
-
-        if ((int) $entity->get('user_id') !== (int) $account->id() && !$account->hasPermission('administer content')) {
-            return $this->json(['error' => 'Forbidden'], 403);
-        }
-
-        $storage->delete([$entity]);
-
-        return $this->json(['deleted' => true]);
-    }
+    // Following is DEFERRED — no follow()/deleteFollow() surface. The follow
+    // table + the waaseyaa/engagement package stay; re-add the methods + routes
+    // when following is approved.
 
     public function createPost(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {

--- a/src/Provider/Routing/SocialApiRouteProvider.php
+++ b/src/Provider/Routing/SocialApiRouteProvider.php
@@ -47,16 +47,9 @@ final class SocialApiRouteProvider extends AppCoreServiceProvider
             RouteBuilder::create('/api/engagement/comments/{target_type}/{target_id}')
                 ->controller($ctrl . '::getComments')->allowAll()->methods('GET')->requirement('target_id', '\\d+')->build(),
         );
-        $router->addRoute(
-            'engagement.follow',
-            RouteBuilder::create('/api/engagement/follow')
-                ->controller($ctrl . '::follow')->requireAuthentication()->methods('POST')->build(),
-        );
-        $router->addRoute(
-            'engagement.deleteFollow',
-            RouteBuilder::create('/api/engagement/follow/{id}')
-                ->controller($ctrl . '::deleteFollow')->requireAuthentication()->methods('DELETE')->requirement('id', '\\d+')->build(),
-        );
+        // Following is DEFERRED: no follow routes. The follow table + the
+        // waaseyaa/engagement package (which also provides reactions/comments)
+        // stay; only the surface is withheld.
         $router->addRoute(
             'engagement.createPost',
             RouteBuilder::create('/api/engagement/post')

--- a/tests/App/Unit/Http/Controller/Social/EngagementControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Social/EngagementControllerTest.php
@@ -99,19 +99,6 @@ final class EngagementControllerTest extends TestCase
         $this->assertStringContainsString('Invalid target_type', $response->getContent());
     }
 
-    #[Test]
-    public function follow_rejects_invalid_target_type(): void
-    {
-        $request = $this->jsonRequest('POST', [
-            'target_type' => 'nonexistent',
-            'target_id' => 1,
-        ]);
-
-        $response = $this->controller->follow([], [], $this->mockAccount(), $request);
-
-        $this->assertSame(422, $response->getStatusCode());
-        $this->assertStringContainsString('Invalid target_type', $response->getContent());
-    }
 
     #[Test]
     public function getComments_rejects_invalid_target_type(): void
@@ -273,24 +260,6 @@ final class EngagementControllerTest extends TestCase
         $this->assertSame('Great event!', $json['body']);
     }
 
-    #[Test]
-    public function follow_creates_follow_and_returns_201(): void
-    {
-        $account = $this->mockAccount(42);
-        $entity = $this->mockEntity(id: 7);
-        $storage = $this->mockStorage('follow');
-        $storage->method('create')->willReturn($entity);
-
-        $request = $this->jsonRequest('POST', [
-            'target_type' => 'community', 'target_id' => 5,
-        ]);
-
-        $response = $this->controller->follow([], [], $account, $request);
-
-        $this->assertSame(201, $response->getStatusCode());
-        $json = json_decode($response->getContent(), true);
-        $this->assertSame(7, $json['id']);
-    }
 
     #[Test]
     public function create_post_returns_201(): void
@@ -515,23 +484,6 @@ final class EngagementControllerTest extends TestCase
         $this->assertSame('Invalid entity data', $json['error']);
     }
 
-    #[Test]
-    public function follow_catches_constructor_invalid_argument_exception(): void
-    {
-        $account = $this->mockAccount(42);
-        $storage = $this->mockStorage('follow');
-        $storage->method('create')->willThrowException(new \InvalidArgumentException('Bad data'));
-
-        $request = $this->jsonRequest('POST', [
-            'target_type' => 'event', 'target_id' => 1,
-        ]);
-
-        $response = $this->controller->follow([], [], $account, $request);
-
-        $this->assertSame(422, $response->getStatusCode());
-        $json = json_decode($response->getContent(), true);
-        $this->assertSame('Invalid entity data', $json['error']);
-    }
 
     #[Test]
     public function createPost_catches_constructor_invalid_argument_exception(): void


### PR DESCRIPTION
Removed follow routes + controller methods + tests. Kept the follow table + waaseyaa/engagement package. /newsletter was already gone (stale comments only). Suite 460 green.

Closes #833