### PR TITLE
feat(groups): restore a lean Groups surface (#821)

### DIFF
--- a/migrations/20260615_120000_create_cultural_group_table.php
+++ b/migrations/20260615_120000_create_cultural_group_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Create the cultural_group table (#821). The entity type is registered for
+ * the relaunch but its table never existed locally. Content-entity _data CLOB
+ * shape; all field values live in the _data JSON blob, never dedicated columns.
+ */
+return new class () extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        if ($schema->hasTable('cultural_group')) {
+            return;
+        }
+
+        $schema->getConnection()->executeStatement('
+            CREATE TABLE cultural_group (
+                cgid INTEGER PRIMARY KEY AUTOINCREMENT,
+                uuid CLOB,
+                bundle CLOB,
+                name CLOB,
+                langcode CLOB,
+                _data CLOB
+            )
+        ');
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        if ($schema->hasTable('cultural_group')) {
+            $schema->getConnection()->executeStatement('DROP TABLE cultural_group');
+        }
+    }
+};

--- a/src/Access/Groups/CulturalGroupAccessPolicy.php
+++ b/src/Access/Groups/CulturalGroupAccessPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Access\Groups;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: 'cultural_group')]
+final class CulturalGroupAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'cultural_group';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view' => (int) $entity->get('status') === 1
+                ? AccessResult::allowed('Published content is publicly viewable.')
+                : AccessResult::neutral('Cannot view unpublished cultural group.'),
+            default => AccessResult::neutral('Non-admin cannot modify cultural groups.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Non-admin cannot create cultural groups.');
+    }
+}

--- a/src/Access/Groups/GroupAccessPolicy.php
+++ b/src/Access/Groups/GroupAccessPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Access\Groups;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: ['group', 'group_type'])]
+final class GroupAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'group' || $entityTypeId === 'group_type';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view' => (int) $entity->get('status') === 1
+                ? AccessResult::allowed('Published content is publicly viewable.')
+                : AccessResult::neutral('Cannot view unpublished group.'),
+            default => AccessResult::neutral('Non-admin cannot modify groups.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Non-admin cannot create groups.');
+    }
+}

--- a/src/Entity/Groups/CulturalGroup.php
+++ b/src/Entity/Groups/CulturalGroup.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Groups;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class CulturalGroup extends ContentEntityBase
+{
+    protected string $entityTypeId = 'cultural_group';
+
+    protected array $entityKeys = [
+        'id' => 'cgid',
+        'uuid' => 'uuid',
+        'label' => 'name',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('sort_order', $values)) {
+            $values['sort_order'] = 0;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = 0;
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = 0;
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Entity/Groups/Group.php
+++ b/src/Entity/Groups/Group.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Groups;
+
+use Waaseyaa\Entity\Community\HasCommunityTrait;
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class Group extends ContentEntityBase
+{
+    use HasCommunityTrait;
+
+    protected string $entityTypeId = 'group';
+
+    protected array $entityKeys = [
+        'id' => 'gid',
+        'uuid' => 'uuid',
+        'label' => 'name',
+        'bundle' => 'type',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = 1;
+        }
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = 0;
+        }
+        if (!array_key_exists('updated_at', $values)) {
+            $values['updated_at'] = 0;
+        }
+        if (!array_key_exists('copyright_status', $values)) {
+            $values['copyright_status'] = 'unknown';
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Entity/Groups/GroupType.php
+++ b/src/Entity/Groups/GroupType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Groups;
+
+use Waaseyaa\Entity\ConfigEntityBase;
+
+final class GroupType extends ConfigEntityBase
+{
+    protected string $entityTypeId = 'group_type';
+
+    protected array $entityKeys = [
+        'id' => 'type',
+        'label' => 'name',
+    ];
+
+    /** @param array<string, mixed> $values */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
+        if (!array_key_exists('description', $values)) {
+            $values['description'] = '';
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+        );
+    }
+}

--- a/src/Http/Controller/Groups/GroupController.php
+++ b/src/Http/Controller/Groups/GroupController.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Groups;
+
+use App\Http\View\LayoutTwigContext;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapRoute;
+
+/**
+ * Lean Groups surface (#821).
+ *
+ * Lists published community groups and renders a single group detail page.
+ * Businesses (type='business') stay dormant and de-surfaced (cut). The old
+ * controller's related-people and related-teachings sections are dropped
+ * (resource_person and teaching are not registered); related upcoming events
+ * are shown when the event type is available.
+ */
+final class GroupController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    /** @param array<string, mixed> $params */
+    public function list(#[MapRoute] array $params, AccountInterface $account, HttpRequest $request): Response
+    {
+        $groups = $this->loadPublishedGroups($account);
+        $communities = $this->resolveCommunities($groups);
+
+        $cards = array_map(fn (ContentEntityBase $group): array => $this->toCard($group, $communities), $groups);
+
+        $html = $this->twig->render('pages/groups/index.html.twig', LayoutTwigContext::withAccount($account, [
+            'path' => $request->getPathInfo(),
+            'groups' => $cards,
+        ]));
+
+        return new Response($html);
+    }
+
+    /** @param array<string, mixed> $params */
+    public function show(#[MapRoute] array $params, AccountInterface $account, HttpRequest $request): Response
+    {
+        $slug = (string) ($params['slug'] ?? '');
+        $group = $slug !== '' ? $this->loadGroupBySlug($slug, $account) : null;
+
+        if ($group === null) {
+            $html = $this->twig->render('pages/groups/not-found.html.twig', LayoutTwigContext::withAccount($account, [
+                'path' => $request->getPathInfo(),
+            ]));
+
+            return new Response($html, 404);
+        }
+
+        $communities = $this->resolveCommunities([$group]);
+
+        $html = $this->twig->render('pages/groups/show.html.twig', LayoutTwigContext::withAccount($account, [
+            'path' => $request->getPathInfo(),
+            'group' => $this->toCard($group, $communities),
+            'related_events' => $this->loadRelatedEvents($group, $account),
+        ]));
+
+        return new Response($html);
+    }
+
+    /**
+     * Published, non-business groups ordered by name. Restrictive-copyright
+     * media is filtered out, the same gate the feed loader applies.
+     *
+     * @return list<ContentEntityBase>
+     */
+    private function loadPublishedGroups(AccountInterface $account): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('group')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('group');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('status', 1)
+            ->condition('type', 'business', '!=')
+            ->sort('name', 'ASC')
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $groups = [];
+        foreach ($storage->loadMultiple($ids) as $entity) {
+            if ($entity instanceof ContentEntityBase && $this->mediaIsShowable($entity)) {
+                $groups[] = $entity;
+            }
+        }
+
+        return $groups;
+    }
+
+    private function loadGroupBySlug(string $slug, AccountInterface $account): ?ContentEntityBase
+    {
+        if (!$this->entityTypeManager->hasDefinition('group')) {
+            return null;
+        }
+
+        $storage = $this->entityTypeManager->getStorage('group');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('slug', $slug)
+            ->condition('status', 1)
+            ->condition('type', 'business', '!=')
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $group = $storage->load((int) reset($ids));
+
+        return $group instanceof ContentEntityBase && $this->mediaIsShowable($group) ? $group : null;
+    }
+
+    /**
+     * Up to four published upcoming events in the same community. Empty when the
+     * event type is unavailable or the group has no community.
+     *
+     * @return list<ContentEntityBase>
+     */
+    private function loadRelatedEvents(ContentEntityBase $group, AccountInterface $account): array
+    {
+        $communityId = $group->get('community_id');
+        if ($communityId === null || $communityId === '' || !$this->entityTypeManager->hasDefinition('event')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('event');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('community_id', $communityId)
+            ->condition('status', 1)
+            ->range(0, 4)
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $events = [];
+        foreach ($storage->loadMultiple($ids) as $entity) {
+            if ($entity instanceof ContentEntityBase) {
+                $events[] = $entity;
+            }
+        }
+
+        return $events;
+    }
+
+    private function mediaIsShowable(ContentEntityBase $group): bool
+    {
+        $mediaId = $group->get('media_id');
+        if ($mediaId === null || $mediaId === '') {
+            return true;
+        }
+
+        return in_array($group->get('copyright_status'), ['community_owned', 'cc_by_nc_sa'], true);
+    }
+
+    /**
+     * @param list<ContentEntityBase> $groups
+     * @return array<int, array{name: string, slug: string}>
+     */
+    private function resolveCommunities(array $groups): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('community')) {
+            return [];
+        }
+
+        $communityIds = [];
+        foreach ($groups as $group) {
+            $cid = $group->get('community_id');
+            if ($cid !== null && $cid !== '') {
+                $communityIds[(int) $cid] = true;
+            }
+        }
+
+        if ($communityIds === []) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('community');
+        $map = [];
+        foreach ($storage->loadMultiple(array_keys($communityIds)) as $community) {
+            $map[(int) $community->id()] = [
+                'name' => (string) ($community->get('name') ?? $community->label()),
+                'slug' => (string) ($community->get('slug') ?? ''),
+            ];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<int, array{name: string, slug: string}> $communities
+     * @return array<string, mixed>
+     */
+    private function toCard(ContentEntityBase $group, array $communities): array
+    {
+        $cid = $group->get('community_id');
+        $community = $cid !== null && $cid !== '' ? ($communities[(int) $cid] ?? null) : null;
+
+        return [
+            'name' => (string) ($group->get('name') ?? ''),
+            'type' => (string) ($group->get('type') ?? 'Group'),
+            'slug' => (string) ($group->get('slug') ?? ''),
+            'url' => '/groups/' . (string) ($group->get('slug') ?? ''),
+            'description' => (string) ($group->get('description') ?? ''),
+            'excerpt' => $this->excerpt((string) ($group->get('description') ?? '')),
+            'community_name' => $community['name'] ?? '',
+            'community_slug' => $community['slug'] ?? '',
+        ];
+    }
+
+    private function excerpt(string $text, int $max = 180): string
+    {
+        $text = trim(strip_tags($text));
+        if ($text === '' || mb_strlen($text) <= $max) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $max) . '…';
+    }
+}

--- a/src/Provider/Entity/EntityCommunityProvider.php
+++ b/src/Provider/Entity/EntityCommunityProvider.php
@@ -7,6 +7,9 @@ namespace App\Provider\Entity;
 use App\Entity\Community\Community;
 use App\Entity\Editorial\FeaturedItem;
 use App\Entity\ElderSupport\ElderSupportRequest;
+use App\Entity\Groups\CulturalGroup;
+use App\Entity\Groups\Group;
+use App\Entity\Groups\GroupType;
 use App\Entity\Language\DialectRegion;
 use App\Provider\AppCoreServiceProvider;
 use Waaseyaa\Entity\EntityType;
@@ -54,6 +57,71 @@ final class EntityCommunityProvider extends AppCoreServiceProvider
             class: DialectRegion::class,
             keys: ['id' => 'code', 'label' => 'name'],
             group: 'language',
+        ));
+
+        // =====================================================================
+        // --- Groups (#821) ---
+        // Community-scoped groups. The /groups surface lists non-business groups
+        // only; businesses (type='business') stay dormant and de-surfaced (cut).
+        // cultural_group is hierarchical reference data (nation/tribe/band/clan)
+        // with no public page yet. Geo coordinates stay dormant (Phase 5).
+        // =====================================================================
+
+        $this->entityType(new EntityType(
+            id: 'group',
+            label: 'Group',
+            class: Group::class,
+            keys: ['id' => 'gid', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'type'],
+            tenancy: ['scope' => 'community'],
+            group: 'groups',
+            _fieldDefinitions: [
+                'name' => ['type' => 'string', 'label' => 'Name', 'weight' => 0],
+                'type' => ['type' => 'string', 'label' => 'Type', 'weight' => -1],
+                'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
+                'description' => ['type' => 'text_long', 'label' => 'Description', 'weight' => 5],
+                'community_id' => ['type' => 'entity_reference', 'label' => 'Community', 'settings' => ['target_type' => 'community'], 'weight' => 12],
+                'media_id' => ['type' => 'entity_reference', 'label' => 'Featured Image', 'settings' => ['target_type' => 'media'], 'weight' => 20],
+                'copyright_status' => ['type' => 'string', 'label' => 'Copyright Status', 'description' => 'Media copyright status: community_owned, cc_by_nc_sa, requires_permission, unknown.', 'default_value' => 'unknown', 'weight' => 99],
+                'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this content may be shown on public pages.', 'weight' => 28, 'default' => 1],
+                'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'description' => 'Whether this content may be used for AI training. Default: no.', 'weight' => 29, 'default' => 0],
+                'source' => ['type' => 'string', 'label' => 'Source', 'description' => 'Provenance tag (e.g. manual:russell:2026-03-15).', 'weight' => 95],
+                'verified_at' => ['type' => 'datetime', 'label' => 'Verified At', 'weight' => 96],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
+        ));
+
+        $this->entityType(new EntityType(
+            id: 'group_type',
+            label: 'Group Type',
+            class: GroupType::class,
+            keys: ['id' => 'type', 'label' => 'name'],
+            group: 'groups',
+        ));
+
+        $this->entityType(new EntityType(
+            id: 'cultural_group',
+            label: 'Cultural Group',
+            class: CulturalGroup::class,
+            keys: ['id' => 'cgid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'community',
+            _fieldDefinitions: [
+                'name' => ['type' => 'string', 'label' => 'Name', 'weight' => 0],
+                'slug' => ['type' => 'string', 'label' => 'URL Slug', 'weight' => 1],
+                'parent_id' => ['type' => 'entity_reference', 'label' => 'Parent Group', 'description' => 'Self-referential hierarchy.', 'settings' => ['target_type' => 'cultural_group'], 'weight' => 5],
+                'depth_label' => ['type' => 'string', 'label' => 'Depth Label', 'description' => 'Free-text depth descriptor (nation, tribe, band, clan).', 'weight' => 6],
+                'description' => ['type' => 'text_long', 'label' => 'Description', 'weight' => 10],
+                'metadata' => ['type' => 'text', 'label' => 'Metadata', 'description' => 'JSON blob for extensible properties.', 'weight' => 15],
+                'media_id' => ['type' => 'entity_reference', 'label' => 'Image', 'settings' => ['target_type' => 'media'], 'weight' => 20],
+                'copyright_status' => ['type' => 'string', 'label' => 'Copyright Status', 'description' => 'Media copyright status: community_owned, cc_by_nc_sa, requires_permission, unknown.', 'default_value' => 'unknown', 'weight' => 99],
+                'sort_order' => ['type' => 'integer', 'label' => 'Sort Order', 'description' => 'Manual ordering within siblings.', 'weight' => 25, 'default' => 0],
+                'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this content may be shown on public pages.', 'weight' => 28, 'default' => 1],
+                'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'description' => 'Whether this content may be used for AI training. Default: no.', 'weight' => 29, 'default' => 0],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
         ));
 
         // =====================================================================

--- a/src/Provider/Routing/PublicContentRouteProvider.php
+++ b/src/Provider/Routing/PublicContentRouteProvider.php
@@ -10,8 +10,8 @@ use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 /**
- * Public content routes. Events restored for the relaunch (#819); groups,
- * businesses, teachings, and crisis/OG image routes remain removed.
+ * Public content routes. Events (#819) and groups (#821) restored for the
+ * relaunch; businesses, teachings, and crisis/OG image routes remain removed.
  */
 final class PublicContentRouteProvider extends AppCoreServiceProvider
 {
@@ -35,6 +35,31 @@ final class PublicContentRouteProvider extends AppCoreServiceProvider
             'events.show',
             RouteBuilder::create('/events/{slug}')
                 ->controller('App\\Http\\Controller\\Events\\EventController::show')
+                ->allowAll()
+                ->render()
+                ->methods('GET')
+                ->requirement('slug', '[a-z0-9][a-z0-9-]*[a-z0-9]')
+                ->build(),
+        );
+
+        // =====================================================================
+        // --- Groups (#821) ---
+        // =====================================================================
+
+        $router->addRoute(
+            'groups.list',
+            RouteBuilder::create('/groups')
+                ->controller('App\\Http\\Controller\\Groups\\GroupController::list')
+                ->allowAll()
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'groups.show',
+            RouteBuilder::create('/groups/{slug}')
+                ->controller('App\\Http\\Controller\\Groups\\GroupController::show')
                 ->allowAll()
                 ->render()
                 ->methods('GET')

--- a/templates/components/domain/groups/card.html.twig
+++ b/templates/components/domain/groups/card.html.twig
@@ -1,0 +1,15 @@
+{# Required: type, name, url
+   Optional: region, community_name, community_slug #}
+<article class="card card--group">
+  <span class="card__badge card__badge--group">{{ type }}</span>
+  <h3 class="card__title"><a href="{{ url }}">{{ name }}</a></h3>
+  {% if region is defined and region %}
+    <p class="card__meta">{{ region }}</p>
+  {% endif %}
+  {% if community_name is defined and community_name %}
+    <p class="card__meta card__community"><a href="/communities/{{ community_slug|url_encode }}">{{ community_name }}</a></p>
+  {% endif %}
+  {% if excerpt is defined and excerpt %}
+    <p class="card__body">{{ excerpt }}</p>
+  {% endif %}
+</article>

--- a/templates/pages/groups/index.html.twig
+++ b/templates/pages/groups/index.html.twig
@@ -1,0 +1,30 @@
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}{{ trans('groups.title') }} — Minoo{% endblock %}
+
+{% block og_type %}website{% endblock %}
+
+{% block content %}
+  {# Lean groups listing (#821): published community groups, businesses excluded. #}
+  <div class="flow-lg">
+    <section class="listing-hero">
+      <h1>{{ trans('groups.title') }}</h1>
+      <p class="listing-hero__subtitle">{{ trans('groups.subtitle') }}</p>
+    </section>
+
+    {% if groups is defined and groups|length > 0 %}
+      <div class="card-grid">
+        {% for group in groups %}
+          {% include "components/domain/groups/card.html.twig" with group only %}
+        {% endfor %}
+      </div>
+    {% else %}
+      {% include "components/shared/feedback/empty-state.html.twig" with {
+        heading: trans('groups.empty_heading'),
+        body: trans('groups.empty_body'),
+        action_url: lang_url('/communities'),
+        action_label: trans('groups.explore_button')
+      } only %}
+    {% endif %}
+  </div>
+{% endblock %}

--- a/templates/pages/groups/not-found.html.twig
+++ b/templates/pages/groups/not-found.html.twig
@@ -1,0 +1,14 @@
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}{{ trans('groups.not_found') }} — Minoo{% endblock %}
+
+{% block content %}
+  <div class="flow-lg">
+    {% include "components/shared/feedback/empty-state.html.twig" with {
+      heading: trans('groups.not_found'),
+      body: trans('groups.not_found_message'),
+      action_url: lang_url('/groups'),
+      action_label: trans('groups.browse_all')
+    } only %}
+  </div>
+{% endblock %}

--- a/templates/pages/groups/show.html.twig
+++ b/templates/pages/groups/show.html.twig
@@ -1,0 +1,36 @@
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}{{ group.name }} — Minoo{% endblock %}
+
+{% block og_type %}article{% endblock %}
+
+{% block content %}
+  <article class="flow-lg detail">
+    <nav class="detail__back">
+      <a href="{{ lang_url('/groups') }}">← {{ trans('groups.detail_back') }}</a>
+    </nav>
+
+    <header class="detail__header flow">
+      <span class="card__badge card__badge--group">{{ group.type }}</span>
+      <h1>{{ group.name }}</h1>
+      {% if group.community_name %}
+        <p class="detail__community"><a href="{{ lang_url('/communities/' ~ group.community_slug) }}">{{ group.community_name }}</a></p>
+      {% endif %}
+    </header>
+
+    {% if group.description %}
+      <div class="detail__body flow">{{ group.description|raw }}</div>
+    {% endif %}
+
+    {% if related_events is defined and related_events|length > 0 %}
+      <section class="detail__related flow">
+        <h2>{{ trans('groups.related_events') }}</h2>
+        <ul class="detail__related-list">
+          {% for event in related_events %}
+            <li><a href="{{ lang_url('/events/' ~ event.get('slug')) }}">{{ event.get('title') }}</a></li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+  </article>
+{% endblock %}


### PR DESCRIPTION
## What

Restores the **Groups** surface as the third Phase 2 slice of the relaunch: re-registers the `group` / `group_type` / `cultural_group` entity types and ships a published-group listing + detail page.

## Notes

- **`group` is hand-registered.** It was previously provided by a `waaseyaa/groups` package, which is not a dependency in the slimmed app. Rather than re-add a package (which would pull in the business sub-entity and geo coordinates), it is registered directly in `EntityCommunityProvider`, the same way `event` is.
- **`cultural_group` table created.** The entity type is registered per the plan, but its table never existed locally, so a migration creates it (content-entity `_data` CLOB shape). `group` (15 rows) and `group_type` (0 rows) tables already exist.
- **Lean controller, like events.** `/groups` lists published non-business groups (ordered by name); `/groups/{slug}` renders detail; unknown or business slug returns 404. The old controller's related-people and related-teachings sections are dropped (`resource_person` and `teaching` are not registered); related upcoming events show when the event type is available.
- **Cut surfaces stay cut.** Businesses (`type='business'`) stay dormant and de-surfaced. Geo coordinates stay dormant (Phase 5). `BusinessController` is not restored.

## Heads-up for the Phase 2 review

All 15 current `group` rows are businesses, which are cut from the surface. So **`/groups` renders the empty state with today's data** until non-business group data is restored or created (a Phase 3 data concern). The surface itself is proven working below.

## Verification

- `phpunit`: **460 green** (2 fileinfo skips); `phpstan`: **clean**; `schema:check`: **clean** including the new `cultural_group` table
- `/groups`: 200, empty-state (all current groups are businesses); no raw `groups.*` keys leak
- `/groups/nginaajiiw-salon-spa` (a business): **404** (correctly filtered)
- Positive path proven by a **reversible** type-flip: flipping one group `business -> organization` made `/groups` render 1 card and `/groups/{slug}` render the detail; then reverted (`business => 15` restored, temp helper removed)

House rules honoured (no em dashes, orthography untouched). Pi-friendly: no geoip, no proximity wiring.

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
