### PR TITLE
feat(corpus): publish Steven Bennett corpus with consent (Phase 4)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -6248,4 +6248,10 @@
 
     a { color: var(--link); }
   }
+
+  .chat__example-audio {
+    inline-size: 100%;
+    max-inline-size: 22rem;
+    block-size: 2.25rem;
+  }
 }

--- a/scripts/import-corpus.php
+++ b/scripts/import-corpus.php
@@ -3,21 +3,26 @@
 declare(strict_types=1);
 
 /**
- * Consent-gated corpus import (Phase 4).
+ * Corpus import (Phase 4: consent granted).
  *
- * Reads per-item JSON from a community-controlled corpus directory OUTSIDE
- * this repository and materializes language entities with full provenance.
+ * Reads per-item JSON from a community-controlled corpus directory OUTSIDE this
+ * repository and materializes language entities with full provenance.
+ *
+ * CONSENT STATE: written consent has been granted by the speaker (Steven
+ * Bennett) for public display, publication, search, AI grounding, and AI
+ * training. Rows are therefore imported consent-public, AI-training-consented,
+ * and published. Before this grant the importer wrote every row with consent
+ * OFF + status 0; see git history. To return to the gated state, set the
+ * CONSENT_* / STATUS constants below back to 0.
  *
  * HARD REQUIREMENTS (do not weaken):
- *   - Every imported row gets ALL consent flags OFF and status 0
- *     (unpublished). They are visible to admins only and excluded from
- *     search and any AI grounding until written consent records exist.
- *   - Nothing from the corpus directory is ever copied into the repo.
- *     Audio/video stay in the source directory; only provenance paths are
- *     recorded.
+ *   - Orthography is recorded EXACTLY as the speaker wrote it. Never correct.
+ *   - Nothing from the corpus directory is ever copied into the repo. Audio,
+ *     video, and images stay in the source directory; only provenance paths and
+ *     a served audio URL (gated by the consent query) are recorded.
  *
- * Idempotent: items dedup on example_sentence.source_sentence_id and
- * speakers dedup on speaker.code.
+ * Idempotent: items dedup on example_sentence.source_sentence_id and speakers
+ * dedup on speaker.code.
  *
  * Usage: php scripts/import-corpus.php <corpus-dir> [--dry-run]
  */
@@ -26,6 +31,14 @@ use Waaseyaa\Foundation\Kernel\AbstractKernel;
 use Waaseyaa\Foundation\Kernel\HttpKernel;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
+
+// Phase 4 consent grant. All three ON per the speaker's written consent.
+const CONSENT_PUBLIC = 1;
+const CONSENT_AI_TRAINING = 1;
+const STATUS_PUBLISHED = 1;
+
+// Credit: Steven Bennett's public profile, the source of every corpus reel.
+const STEVEN_PROFILE_URL = 'https://www.facebook.com/profile.php?id=61582894730998';
 
 $projectRoot = dirname(__DIR__);
 
@@ -56,7 +69,7 @@ $speakerStorage = $etm->getStorage('speaker');
 $sentenceStorage = $etm->getStorage('example_sentence');
 
 /**
- * Find or create the speaker for a contributor name, consent flags OFF.
+ * Find or create the speaker for a contributor name, consent granted.
  */
 function resolveSpeaker(object $storage, string $name, bool $dryRun): ?int
 {
@@ -77,7 +90,7 @@ function resolveSpeaker(object $storage, string $name, bool $dryRun): ?int
     }
 
     if ($dryRun) {
-        echo "[dry-run] would create speaker: $name ($code), consent OFF, unpublished\n";
+        echo "[dry-run] would create speaker: $name ($code), consent granted, published\n";
         return $cache[$code] = null;
     }
 
@@ -85,15 +98,16 @@ function resolveSpeaker(object $storage, string $name, bool $dryRun): ?int
         'name' => $name,
         'code' => $code,
         'slug' => strtolower(str_replace(' ', '-', trim($name))),
-        // Consent gate: OFF until a written consent record exists.
-        'consent_public_display' => 0,
-        'consent_ai_training' => 0,
-        'status' => 0,
+        'bio' => sprintf('%s contributed this Anishinaabemowin corpus from public videos. Credit and source: %s', $name, STEVEN_PROFILE_URL),
+        // Consent granted (Phase 4).
+        'consent_public_display' => CONSENT_PUBLIC,
+        'consent_ai_training' => CONSENT_AI_TRAINING,
+        'status' => STATUS_PUBLISHED,
         'created_at' => time(),
         'updated_at' => time(),
     ]);
     $storage->save($speaker);
-    echo "[create] speaker: $name ($code) id=" . $speaker->id() . " consent OFF, unpublished\n";
+    echo "[create] speaker: $name ($code) id=" . $speaker->id() . " consent granted, published\n";
 
     return $cache[$code] = (int) $speaker->id();
 }
@@ -135,24 +149,24 @@ foreach ($files as $file) {
         'ojibwe_text' => (string) $item['ojibwe'],
         'english_text' => (string) ($item['english'] ?? ''),
         'speaker_id' => $speakerId,
-        // Audio stays in the community-controlled corpus directory; no URL
-        // is published. The provenance record carries the source paths.
-        'audio_url' => '',
+        // Audio stays in the community-controlled corpus directory and is served
+        // by CorpusAudioController, which re-checks the consent gate per request.
+        'audio_url' => '/media/corpus/audio/' . $item['id'],
         'source_sentence_id' => $sourceId,
         'source_url' => (string) ($item['source_url'] ?? ''),
         'source_date' => (string) ($item['source_date'] ?? ''),
         'provenance' => json_encode($item, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
         'language_code' => 'oj',
-        // Consent gate: OFF + unpublished until written consent exists.
-        'consent_public' => 0,
-        'consent_ai_training' => 0,
-        'status' => 0,
+        // Consent granted (Phase 4).
+        'consent_public' => CONSENT_PUBLIC,
+        'consent_ai_training' => CONSENT_AI_TRAINING,
+        'status' => STATUS_PUBLISHED,
         'created_at' => time(),
         'updated_at' => time(),
     ]);
     $sentenceStorage->save($sentence);
     $created++;
-    echo "[import] {$item['id']} -> example_sentence " . $sentence->id() . " (consent OFF, unpublished)\n";
+    echo "[import] {$item['id']} -> example_sentence " . $sentence->id() . " (consent granted, published)\n";
 }
 
 echo "\nDone. created=$created skipped=$skipped failed=$failed\n";

--- a/src/Http/Controller/Language/CorpusAudioController.php
+++ b/src/Http/Controller/Language/CorpusAudioController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Language;
+
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapRoute;
+
+/**
+ * Public corpus audio (#822 / Phase 4).
+ *
+ * Streams a single example-sentence audio clip from the community-controlled
+ * corpus directory (MINOO_CORPUS_PATH), which is NEVER committed to the repo.
+ *
+ * Consent boundary: a clip is served ONLY when its example_sentence row is
+ * consent_public = 1 AND status = 1. The consent gate that governs the text in
+ * search and the cite-only chat governs the audio too. The audio itself is the
+ * speaker's own public Facebook reel (recorded in source_url), so a consented
+ * row's clip is public. Path traversal is impossible: the id is regex-validated
+ * to the corpus naming scheme before any filesystem access, and only the exact
+ * <id>.opus under audio/ is read.
+ */
+final class CorpusAudioController
+{
+    private const string DEFAULT_CORPUS_PATH = 'C:/Users/jones/Projects/LLC/anishinaabemowin/content/corpus';
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {
+    }
+
+    /** @param array<string, mixed> $params */
+    public function audio(#[MapRoute] array $params, AccountInterface $account, HttpRequest $request): Response
+    {
+        $id = (string) ($params['id'] ?? '');
+
+        // Strict allowlist on shape: corpus ids are lowercase letters, digits,
+        // and hyphens only. No '.', '/', or '\' can reach the path.
+        if ($id === '' || preg_match('/^[a-z0-9-]+$/', $id) !== 1) {
+            return new Response('Not found', 404);
+        }
+
+        if (!$this->isConsentedSentence($id, $account)) {
+            return new Response('Not found', 404);
+        }
+
+        $file = $this->corpusPath() . '/audio/' . $id . '.opus';
+        if (!is_file($file)) {
+            return new Response('Not found', 404);
+        }
+
+        return new Response((string) file_get_contents($file), 200, [
+            'Content-Type' => 'audio/ogg',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    /**
+     * True only when a published, consent-public example_sentence carries this
+     * corpus id. The query is the access boundary for the audio.
+     */
+    private function isConsentedSentence(string $id, AccountInterface $account): bool
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            return false;
+        }
+
+        $ids = $this->entityTypeManager->getStorage('example_sentence')->getQuery()
+            ->setAccount($account)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->condition('source_sentence_id', 'corpus:' . $id)
+            ->range(0, 1)
+            ->execute();
+
+        return $ids !== [];
+    }
+
+    private function corpusPath(): string
+    {
+        $env = getenv('MINOO_CORPUS_PATH');
+
+        return is_string($env) && $env !== '' ? rtrim($env, '/\\') : self::DEFAULT_CORPUS_PATH;
+    }
+}

--- a/src/Provider/Routing/PublicContentRouteProvider.php
+++ b/src/Provider/Routing/PublicContentRouteProvider.php
@@ -85,6 +85,18 @@ final class PublicContentRouteProvider extends AppCoreServiceProvider
         // --- Language ---
         // =====================================================================
 
+        // Corpus audio: served from MINOO_CORPUS_PATH (never committed), gated to
+        // consent_public + published example_sentence rows (Phase 4).
+        $router->addRoute(
+            'corpus.audio',
+            RouteBuilder::create('/media/corpus/audio/{id}')
+                ->controller('App\\Http\\Controller\\Language\\CorpusAudioController::audio')
+                ->allowAll()
+                ->methods('GET')
+                ->requirement('id', '[a-z0-9][a-z0-9-]*')
+                ->build(),
+        );
+
         $router->addRoute(
             'language.list',
             RouteBuilder::create('/language')

--- a/templates/layouts/base.html.twig
+++ b/templates/layouts/base.html.twig
@@ -20,7 +20,7 @@
   {% if csrf_token is defined %}
     <meta name="csrf-token" content="{{ csrf_token }}">
   {% endif %}
-  <link rel="stylesheet" href="/css/minoo.css?v=88">
+  <link rel="stylesheet" href="/css/minoo.css?v=89">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   {% block head %}{% endblock %}
   {# Analytics seam (#777): Waaseyaa/Anokii analytics mounts here later.

--- a/templates/pages/chat/index.html.twig
+++ b/templates/pages/chat/index.html.twig
@@ -51,6 +51,9 @@
                 <li class="chat__example">
                   <p class="chat__example-oj" lang="oj">{{ s.ojibwe_text }}</p>
                   {% if s.english_text %}<p class="chat__example-en">{{ s.english_text }}</p>{% endif %}
+                  {% if s.audio_url %}
+                    <audio class="chat__example-audio" controls preload="none" src="{{ s.audio_url }}">{{ trans('language.audio_unsupported') }}</audio>
+                  {% endif %}
                   {% if s.source_url %}
                     <p class="chat__example-source"><a href="{{ s.source_url }}" target="_blank" rel="noopener noreferrer">{{ trans('chat.source_label') }}</a></p>
                   {% endif %}

--- a/tests/App/Unit/Http/Controller/Language/CorpusAudioControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Language/CorpusAudioControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Http\Controller\Language;
+
+use App\Http\Controller\Language\CorpusAudioController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+/**
+ * Locks the corpus-audio consent boundary (Phase 4). Audio is served ONLY for a
+ * consent_public + published example_sentence; a bad id never reaches the
+ * filesystem, and a non-consented id 404s without serving anything.
+ */
+#[CoversClass(CorpusAudioController::class)]
+final class CorpusAudioControllerTest extends TestCase
+{
+    private AccountInterface $account;
+
+    protected function setUp(): void
+    {
+        $this->account = $this->createMock(AccountInterface::class);
+    }
+
+    #[Test]
+    public function rejects_a_traversal_shaped_id_before_touching_storage(): void
+    {
+        $etm = $this->createMock(EntityTypeManager::class);
+        // A non-allowlisted id must be refused before any storage/filesystem access.
+        $etm->expects($this->never())->method('getStorage');
+        $etm->expects($this->never())->method('hasDefinition');
+
+        $controller = new CorpusAudioController($etm);
+        $response = $controller->audio(['id' => '../../etc/passwd'], $this->account, HttpRequest::create('/media/corpus/audio/x'));
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function non_consented_id_returns_404(): void
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('setAccount')->willReturnSelf();
+        $query->method('condition')->willReturnSelf();
+        $query->method('range')->willReturnSelf();
+        // No published, consent-public row carries this id.
+        $query->method('execute')->willReturn([]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(true);
+        $etm->method('getStorage')->willReturn($storage);
+
+        $controller = new CorpusAudioController($etm);
+        $response = $controller->audio(['id' => 'sb-999'], $this->account, HttpRequest::create('/media/corpus/audio/sb-999'));
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
**Phase 4: corpus publish + consent.** Written consent granted by the speaker, so the corpus import flips from the gated state to published with all consent flags ON (confirmed: `consent_public` + `consent_ai_training` + published).

## What landed
- **Import (`scripts/import-corpus.php`):** imports the **27** Steven Bennett `example_sentence` rows + the `Steven Bennett` speaker with `consent_public = 1`, `consent_ai_training = 1`, `status = 1`. Full provenance (source reel URL, source date, full item JSON in `provenance`, `speaker_id`). **Orthography stored exactly as written, never corrected.** Steven is credited in the speaker `bio` via his public profile. Idempotent; `CONSENT_*` constants document the grant and the git diff shows the flip from the old consent-OFF gate.
- **Public audio (`CorpusAudioController` + `/media/corpus/audio/{id}`):** streams a clip from `MINOO_CORPUS_PATH`, **gated to consent_public + published rows** (the consent query is the access boundary), regex-validated id so no request value reaches the path. The clips are the speaker's own public Facebook reels.
- **Chat:** the example block now renders an `<audio>` player and links the source reel.
- **Test:** `CorpusAudioControllerTest` locks the gate (traversal id never touches storage; non-consented id 404s). The existing `ChatControllerTest` already locks the text consent gate.

## Nothing from the content directory is committed
The corpus `items/` JSON and `audio/` stay under `MINOO_CORPUS_PATH` (default points at `Projects\LLC\anishinaabemowin\content\corpus`). The 27 DB rows live only in the local, gitignored database. The Pi import (Phase 6) runs this same script against the corpus directory at deploy time.

## Verified locally
- 27 rows imported; consent flags, provenance, and **verbatim orthography** confirmed (`Shoogan Mookman`, `N'kwetang`, lowercase `kik`).
- `/chat?q=knife` cites the corpus (`Shoogan Mookman` / "butter knife") with a working audio player.
- `/media/corpus/audio/sb-001` serves the opus (200, `audio/ogg`, 186 KB); an unknown id 404s.
- **465 tests green, phpstan clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
