### PR TITLE
feat(lesson): make Lesson 1 public now that corpus consent is granted (Phase 4B)

### DIFF
--- a/src/Http/Controller/Lesson/LessonController.php
+++ b/src/Http/Controller/Lesson/LessonController.php
@@ -15,17 +15,13 @@ use Waaseyaa\SSR\Attribute\MapQuery;
 use Waaseyaa\SSR\Attribute\MapRoute;
 
 /**
- * Lesson 1 (Kitchen) course surface over the migrated Elder corpus.
+ * Lesson 1 (Kitchen) course surface over the Elder corpus.
  *
- * CONSENT GATE. The corpus rows this renders are consent-gated (consent flags
- * off, status 0, admin-only). Until written consent records exist for the 27
- * corpus items, every route here is admin-gated via guard(). The
- * Anishinaabemowin is read verbatim from the migrated corpus at runtime and is
- * never committed to the repo or altered. Audio and whiteboard thumbnails are
- * streamed from the community-controlled corpus directory, never copied in.
- *
- * To make this surface public after written consent: publish the rows and relax
- * the guard()/route gate. That is a deliberate, separate step, not a default.
+ * Public since Phase 4: written consent has been granted, so the corpus rows
+ * are published (consent_public + status 1) and these routes are open. The
+ * Anishinaabemowin is read verbatim from the corpus at runtime, never altered
+ * or committed. Audio and whiteboard thumbnails are streamed from the
+ * community-controlled corpus directory (MINOO_CORPUS_PATH), never copied in.
  */
 final class LessonController
 {
@@ -48,10 +44,6 @@ final class LessonController
     /** Landing: the list of available lessons (Lesson 1 for now). */
     public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        if (($denied = $this->guard($account)) !== null) {
-            return $denied;
-        }
-
         $def = $this->lessonDefinition();
 
         $html = $this->twig->render('pages/lesson/index.html.twig', LayoutTwigContext::withAccount($account, [
@@ -68,10 +60,6 @@ final class LessonController
     /** Lesson 1: Kitchen, 16 cards grouped by section. */
     public function lessonOne(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        if (($denied = $this->guard($account)) !== null) {
-            return $denied;
-        }
-
         $def = $this->lessonDefinition();
         $corpus = $this->corpusRowsBySourceId();
 
@@ -115,10 +103,6 @@ final class LessonController
     /** Stream a whiteboard thumbnail or audio clip from the corpus directory. */
     public function media(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        if (($denied = $this->guard($account)) !== null) {
-            return $denied;
-        }
-
         $kind = (string) ($params['kind'] ?? '');
         $id = (string) ($params['id'] ?? '');
 
@@ -140,29 +124,23 @@ final class LessonController
 
         return new Response((string) file_get_contents($file), 200, [
             'Content-Type' => $contentType,
-            // Private: consent-gated content behind an auth gate. Never let a
-            // shared cache or CDN hold it.
-            'Cache-Control' => 'private, max-age=3600',
+            'Cache-Control' => 'public, max-age=3600',
         ]);
-    }
-
-    /** Admin-only until written corpus consent exists. */
-    private function guard(AccountInterface $account): ?Response
-    {
-        if ($account->hasPermission('administer content')) {
-            return null;
-        }
-
-        return new Response('Forbidden', 403);
     }
 
     /** @return array<string, EntityInterface> keyed by source_sentence_id */
     private function corpusRowsBySourceId(): array
     {
         $storage = $this->entityTypeManager->getStorage('example_sentence');
-        // Admin-gated surface: deliberately read the consent-gated rows for the
-        // curated lesson. The route guard is the access control boundary here.
-        $ids = $storage->getQuery()->accessCheck(false)->execute();
+        // Public surface: only published, consent-public corpus rows. Guard the
+        // empty set so loadMultiple([]) cannot dump the whole table.
+        $ids = $storage->getQuery()->accessCheck(false)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->execute();
+        if ($ids === []) {
+            return [];
+        }
 
         $rows = [];
         foreach ($storage->loadMultiple($ids) as $entity) {

--- a/src/Provider/Routing/LessonRouteProvider.php
+++ b/src/Provider/Routing/LessonRouteProvider.php
@@ -12,10 +12,9 @@ use Waaseyaa\Routing\WaaseyaaRouter;
 /**
  * Lesson (course) surface routes.
  *
- * Every route is admin-gated (requireAuthentication + an in-controller
- * "administer content" check) because the lesson renders consent-gated Elder
- * corpus content. This stays gated until written consent records exist; see
- * LessonController.
+ * Public since Phase 4: written consent has been granted for the corpus, so the
+ * lesson (and its media) are open. The Anishinaabemowin is read verbatim from
+ * the community-controlled corpus directory at runtime and never committed.
  */
 final class LessonRouteProvider extends AppCoreServiceProvider
 {
@@ -25,7 +24,7 @@ final class LessonRouteProvider extends AppCoreServiceProvider
             'lesson.index',
             RouteBuilder::create('/lesson')
                 ->controller('App\\Http\\Controller\\Lesson\\LessonController::index')
-                ->requireAuthentication()
+                ->allowAll()
                 ->render()
                 ->methods('GET')
                 ->build(),
@@ -35,7 +34,7 @@ final class LessonRouteProvider extends AppCoreServiceProvider
             'lesson.one',
             RouteBuilder::create('/lesson/1')
                 ->controller('App\\Http\\Controller\\Lesson\\LessonController::lessonOne')
-                ->requireAuthentication()
+                ->allowAll()
                 ->render()
                 ->methods('GET')
                 ->build(),
@@ -45,7 +44,7 @@ final class LessonRouteProvider extends AppCoreServiceProvider
             'lesson.media',
             RouteBuilder::create('/lesson/media/{kind}/{id}')
                 ->controller('App\\Http\\Controller\\Lesson\\LessonController::media')
-                ->requireAuthentication()
+                ->allowAll()
                 ->methods('GET')
                 ->requirement('kind', 'thumb|audio')
                 ->requirement('id', 'sb-[0-9]+')

--- a/tests/App/Unit/Http/Controller/Lesson/LessonControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Lesson/LessonControllerTest.php
@@ -15,9 +15,10 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
 /**
- * Security-focused tests for the consent-gated lesson media endpoint:
- * the auth guard and the path allowlist. These run before any filesystem
- * access, so they need no corpus directory or database.
+ * Security-focused tests for the public lesson media endpoint: the kind/id
+ * path allowlist (only thumb|audio for the 16 Lesson 1 ids, no traversal).
+ * These run before any filesystem access, so they need no corpus directory or
+ * database.
  */
 #[CoversClass(LessonController::class)]
 final class LessonControllerTest extends TestCase
@@ -43,12 +44,6 @@ final class LessonControllerTest extends TestCase
         return $this->controller()
             ->media($params, [], $this->account($admin), HttpRequest::create('/'))
             ->getStatusCode();
-    }
-
-    #[Test]
-    public function mediaForbiddenForNonAdmin(): void
-    {
-        self::assertSame(403, $this->get(['kind' => 'thumb', 'id' => 'sb-005'], false));
     }
 
     #[Test]


### PR DESCRIPTION
Lesson 1 (Kitchen, 16 cards) was admin-gated while the corpus was consent-gated. Phase 4 granted written consent + published the corpus, so the lesson opens to everyone.

- Routes `/lesson`, `/lesson/1`, `/lesson/media` now `allowAll` (were `requireAuthentication`).
- Dropped the administer-content guard; the controller reads only published, consent-public corpus rows (`status=1 AND consent_public=1`) with an empty-set guard against the `loadMultiple([])` footgun; media cache is now public.
- Dropped the obsolete admin-forbidden test; the kind/id path allowlist + traversal tests still lock the media boundary.

Verified: `/lesson` + `/lesson/1` public (16 cards, 4 groups, linked from home); audio + thumb media serve (200); orthography verbatim; Steven Bennett credited. 464 tests green, phpstan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)