### PR TITLE
feat(account): self-selected home community as feed vantage (Phase 5)

### DIFF
--- a/migrations/20260616_000000_add_home_community_to_user.php
+++ b/migrations/20260616_000000_add_home_community_to_user.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Member home community (Phase 5). A logged-in member may self-select ONE home
+ * community; the feed uses it as a community-level vantage (same-community
+ * affinity boost). Consent-first: NULL by default, set only when the member
+ * chooses. No coordinates are involved; proximity stays dormant.
+ */
+return new class () extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        $columns = $schema->getConnection()->fetchAllAssociative('PRAGMA table_info(user)');
+        foreach ($columns as $column) {
+            if (($column['name'] ?? '') === 'home_community_id') {
+                return;
+            }
+        }
+
+        $schema->getConnection()->executeStatement(
+            'ALTER TABLE user ADD COLUMN home_community_id INTEGER DEFAULT NULL',
+        );
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // SQLite cannot drop a column portably; leave it. NULL is inert.
+    }
+};

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -677,6 +677,12 @@ return [
     'account.elder_set_flash' => 'You have identified as an Elder. Miigwech.',
     'account.elder_removed_flash' => 'Elder status removed.',
 
+    // Home community (Phase 5): self-selected, consent-first, community-level only.
+    'account.home_community_title' => 'Home community',
+    'account.home_community_help' => 'Pick the community you call home to personalize your feed with what is happening there. It is community-level only, never your precise location, and you can change or clear it anytime.',
+    'account.home_community_none' => 'No home community',
+    'account.home_community_save' => 'Save',
+
     // Role Management
     'coordinator.users_title' => 'Community Members',
     'coordinator.users_subtitle' => 'Manage volunteer and Elder roles for community members.',

--- a/src/Domain/Feed/FeedAssembler.php
+++ b/src/Domain/Feed/FeedAssembler.php
@@ -328,11 +328,12 @@ final class FeedAssembler implements FeedAssemblerInterface
         }
 
         try {
+            // The member's self-selected home community (Phase 5). Community-level
+            // only; no coordinates, so proximity stays dormant. NULL when unset.
             $user = $this->loader->getEntityTypeManager()->getStorage('user')->load($ctx->userId);
+            $homeCommunity = $user?->get('home_community_id');
 
-            return $user !== null && $user->get('community_id') !== null
-                ? (int) $user->get('community_id')
-                : null;
+            return $homeCommunity !== null && (int) $homeCommunity > 0 ? (int) $homeCommunity : null;
         } catch (\Throwable) {
             return null;
         }

--- a/src/Http/Controller/Account/AccountHomeController.php
+++ b/src/Http/Controller/Account/AccountHomeController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controller\Account;
 use App\Domain\Account\SavedWords;
 use App\Http\View\LayoutTwigContext;
 use App\Identity\ElderIdentity;
+use App\Identity\HomeCommunityIdentity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,10 +29,24 @@ final class AccountHomeController
 
     public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
+        $homeCommunityId = $account instanceof User ? HomeCommunityIdentity::getHomeCommunity($account) : null;
+        $communities = $this->loadCommunities();
+
+        $homeCommunityName = '';
+        foreach ($communities as $community) {
+            if ($community['id'] === $homeCommunityId) {
+                $homeCommunityName = $community['name'];
+                break;
+            }
+        }
+
         $html = $this->twig->render('pages/account/index.html.twig', LayoutTwigContext::withAccount($account, [
             'roles' => $account->getRoles(),
             'is_elder' => $account instanceof User && ElderIdentity::isElder($account),
             'saved_count' => SavedWords::countFor($this->entityTypeManager, $account),
+            'home_community_id' => $homeCommunityId,
+            'home_community_name' => $homeCommunityName,
+            'communities' => $communities,
             'path' => '/account',
         ]));
 
@@ -54,5 +69,78 @@ final class AccountHomeController
         Flash::success($isElder ? 'Elder status removed.' : 'You have identified as an Elder. Miigwech.');
 
         return new RedirectResponse('/account');
+    }
+
+    /**
+     * Self-select (or clear) the member's home community. Consent-first: an
+     * empty value clears it; any other value is accepted only when it is a real
+     * published community. Community-level only, no coordinates.
+     */
+    public function selectHomeCommunity(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $storage = $this->entityTypeManager->getStorage('user');
+        $user = $storage->load($account->id());
+
+        if (!$user instanceof User) {
+            return new RedirectResponse('/account');
+        }
+
+        $raw = trim((string) $request->request->get('home_community_id', ''));
+        $communityId = $raw !== '' && ctype_digit($raw) ? (int) $raw : null;
+
+        if ($communityId !== null && !$this->isPublishedCommunity($communityId)) {
+            $communityId = null;
+        }
+
+        HomeCommunityIdentity::setHomeCommunity($user, $communityId);
+        $storage->save($user);
+
+        Flash::success($communityId === null ? 'Home community cleared.' : 'Home community saved. Miigwech.');
+
+        return new RedirectResponse('/account');
+    }
+
+    /**
+     * Published communities for the selector, sorted by name.
+     *
+     * @return list<array{id: int, name: string}>
+     */
+    private function loadCommunities(): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('community')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('community');
+        $ids = $storage->getQuery()->accessCheck(false)
+            ->condition('status', 1)
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $communities = [];
+        foreach ($storage->loadMultiple($ids) as $community) {
+            $communities[] = [
+                'id' => (int) $community->id(),
+                'name' => (string) ($community->get('name') ?? $community->label()),
+            ];
+        }
+
+        usort($communities, static fn (array $a, array $b): int => strcasecmp($a['name'], $b['name']));
+
+        return $communities;
+    }
+
+    private function isPublishedCommunity(int $communityId): bool
+    {
+        if (!$this->entityTypeManager->hasDefinition('community')) {
+            return false;
+        }
+
+        $community = $this->entityTypeManager->getStorage('community')->load($communityId);
+
+        return $community !== null && (int) $community->get('status') === 1;
     }
 }

--- a/src/Identity/HomeCommunityIdentity.php
+++ b/src/Identity/HomeCommunityIdentity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity;
+
+use Waaseyaa\User\User;
+
+/**
+ * Home community self-selection for the User entity (Phase 5).
+ *
+ * A member may self-select ONE home community. It is consent-first (NULL until
+ * the member chooses) and community-level only: it carries no coordinates, so
+ * proximity stays dormant. The feed uses it as the same-community affinity
+ * vantage. Lives in Minoo (not Waaseyaa) like ElderIdentity, because it is
+ * domain-specific to Indigenous community platforms.
+ */
+final class HomeCommunityIdentity
+{
+    private const FIELD = 'home_community_id';
+
+    public static function getHomeCommunity(User $user): ?int
+    {
+        $value = $user->get(self::FIELD);
+
+        return $value !== null && (int) $value > 0 ? (int) $value : null;
+    }
+
+    public static function setHomeCommunity(User $user, ?int $communityId): User
+    {
+        $user->set(self::FIELD, $communityId !== null && $communityId > 0 ? $communityId : null);
+
+        return $user;
+    }
+}

--- a/src/Provider/Routing/PublicAccountRouteProvider.php
+++ b/src/Provider/Routing/PublicAccountRouteProvider.php
@@ -36,6 +36,16 @@ final class PublicAccountRouteProvider extends AppCoreServiceProvider
                 ->build(),
         );
 
+        // Member home community (Phase 5): self-selected, consent-first.
+        $router->addRoute(
+            'account.home_community',
+            RouteBuilder::create('/account/home-community')
+                ->controller('App\Http\Controller\Account\AccountHomeController::selectHomeCommunity')
+                ->requireAuthentication()
+                ->methods('POST')
+                ->build(),
+        );
+
         // --- Personal word lists (#806) ---
         $router->addRoute(
             'account.words',

--- a/templates/pages/account/index.html.twig
+++ b/templates/pages/account/index.html.twig
@@ -53,6 +53,22 @@
     {% endif %}
   </div>
 
+  <div class="actions">
+    <h2>{{ trans('account.home_community_title') }}</h2>
+    <p class="text-secondary">{{ trans('account.home_community_help') }}</p>
+    <form method="post" action="/account/home-community" class="home-community-form">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <label class="visually-hidden" for="home-community-select">{{ trans('account.home_community_title') }}</label>
+      <select id="home-community-select" name="home_community_id" class="search-form__input">
+        <option value="">{{ trans('account.home_community_none') }}</option>
+        {% for community in communities|default([]) %}
+          <option value="{{ community.id }}"{% if community.id == home_community_id %} selected{% endif %}>{{ community.name }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn--primary">{{ trans('account.home_community_save') }}</button>
+    </form>
+  </div>
+
   {% if 'admin' in roles %}
   <div class="actions">
     <h2>{{ trans('admin.users_title') }}</h2>

--- a/tests/App/Unit/Http/Controller/Account/AccountHomeControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Account/AccountHomeControllerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Http\Controller\Account;
 
+use App\Entity\Community\Community;
 use App\Http\Controller\Account\AccountHomeController;
 use App\Identity\ElderIdentity;
+use App\Identity\HomeCommunityIdentity;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -165,5 +167,81 @@ final class AccountHomeControllerTest extends TestCase
 
         $this->assertSame(302, $response->getStatusCode());
         $this->assertFalse(ElderIdentity::isElder($user));
+    }
+
+    #[Test]
+    public function select_home_community_saves_a_valid_published_community(): void
+    {
+        $userStorage = $this->createMock(EntityStorageInterface::class);
+        $user = new User(['uid' => 1, 'name' => 'Test']);
+        $userStorage->method('load')->with(1)->willReturn($user);
+        $userStorage->expects($this->once())->method('save')->with($user);
+
+        $communityStorage = $this->createMock(EntityStorageInterface::class);
+        $communityStorage->method('load')->with(10)->willReturn(new Community(['cid' => 10, 'name' => 'Sagamok', 'status' => 1]));
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(true);
+        $etm->method('getStorage')->willReturnCallback(
+            fn (string $type): EntityStorageInterface => $type === 'community' ? $communityStorage : $userStorage,
+        );
+
+        $controller = $this->createController(etm: $etm);
+        $request = HttpRequest::create('/account/home-community', 'POST', ['home_community_id' => '10']);
+
+        $_SESSION = [];
+        $response = $controller->selectHomeCommunity([], [], new User(['uid' => 1]), $request);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/account', $response->headers->get('Location'));
+        $this->assertSame(10, HomeCommunityIdentity::getHomeCommunity($user));
+    }
+
+    #[Test]
+    public function select_home_community_clears_on_empty_value(): void
+    {
+        $userStorage = $this->createMock(EntityStorageInterface::class);
+        $user = new User(['uid' => 1, 'home_community_id' => 10]);
+        $userStorage->method('load')->with(1)->willReturn($user);
+        $userStorage->expects($this->once())->method('save')->with($user);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getStorage')->willReturn($userStorage);
+
+        $controller = $this->createController(etm: $etm);
+        $request = HttpRequest::create('/account/home-community', 'POST', ['home_community_id' => '']);
+
+        $_SESSION = [];
+        $response = $controller->selectHomeCommunity([], [], new User(['uid' => 1]), $request);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertNull(HomeCommunityIdentity::getHomeCommunity($user));
+    }
+
+    #[Test]
+    public function select_home_community_rejects_an_unpublished_community(): void
+    {
+        $userStorage = $this->createMock(EntityStorageInterface::class);
+        $user = new User(['uid' => 1, 'name' => 'Test']);
+        $userStorage->method('load')->with(1)->willReturn($user);
+        $userStorage->expects($this->once())->method('save')->with($user);
+
+        $communityStorage = $this->createMock(EntityStorageInterface::class);
+        // status 0 -> not published -> rejected and cleared.
+        $communityStorage->method('load')->with(10)->willReturn(new Community(['cid' => 10, 'name' => 'Draft', 'status' => 0]));
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('hasDefinition')->willReturn(true);
+        $etm->method('getStorage')->willReturnCallback(
+            fn (string $type): EntityStorageInterface => $type === 'community' ? $communityStorage : $userStorage,
+        );
+
+        $controller = $this->createController(etm: $etm);
+        $request = HttpRequest::create('/account/home-community', 'POST', ['home_community_id' => '10']);
+
+        $_SESSION = [];
+        $controller->selectHomeCommunity([], [], new User(['uid' => 1]), $request);
+
+        $this->assertNull(HomeCommunityIdentity::getHomeCommunity($user));
     }
 }

--- a/tests/App/Unit/Identity/HomeCommunityIdentityTest.php
+++ b/tests/App/Unit/Identity/HomeCommunityIdentityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity;
+
+use App\Identity\HomeCommunityIdentity;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\User\User;
+
+#[CoversClass(HomeCommunityIdentity::class)]
+final class HomeCommunityIdentityTest extends TestCase
+{
+    #[Test]
+    public function defaults_to_null(): void
+    {
+        $this->assertNull(HomeCommunityIdentity::getHomeCommunity(new User()));
+    }
+
+    #[Test]
+    public function set_and_get_round_trip(): void
+    {
+        $user = new User();
+        HomeCommunityIdentity::setHomeCommunity($user, 42);
+        $this->assertSame(42, HomeCommunityIdentity::getHomeCommunity($user));
+    }
+
+    #[Test]
+    public function null_clears_the_home_community(): void
+    {
+        $user = new User();
+        HomeCommunityIdentity::setHomeCommunity($user, 42);
+        HomeCommunityIdentity::setHomeCommunity($user, null);
+        $this->assertNull(HomeCommunityIdentity::getHomeCommunity($user));
+    }
+
+    #[Test]
+    public function zero_is_treated_as_unset(): void
+    {
+        $user = new User();
+        HomeCommunityIdentity::setHomeCommunity($user, 0);
+        $this->assertNull(HomeCommunityIdentity::getHomeCommunity($user));
+    }
+
+    #[Test]
+    public function reads_value_from_constructor(): void
+    {
+        $this->assertSame(7, HomeCommunityIdentity::getHomeCommunity(new User(['home_community_id' => 7])));
+    }
+
+    #[Test]
+    public function set_returns_the_user(): void
+    {
+        $user = new User();
+        $this->assertSame($user, HomeCommunityIdentity::setHomeCommunity($user, 5));
+    }
+}


### PR DESCRIPTION
Members self-select ONE home community on `/account`. **Consent-first** (NULL until chosen) and **community-level only** — no coordinates, so proximity/coordinate-snapping stays dormant.

- Migration: `home_community_id` on the user table (NULL default).
- `HomeCommunityIdentity`: get/set on the User entity, mirroring `ElderIdentity`; zero and NULL both mean unset.
- `AccountHomeController`: a styled selector (all published communities, sorted, + "No home community") and a POST handler that saves only a real published community, clears on empty, and rejects unpublished.
- `FeedAssembler::resolveUserCommunityId` now reads `home_community_id` (it previously read a `community_id` field that never existed) and drives the same-community affinity boost. **Lat/lon stay null; the geo/haversine path remains unwired.**
- Tests: `HomeCommunityIdentityTest` + 3 new `AccountHomeControllerTest` cases (saves valid, clears on empty, rejects unpublished).

Verified: `/account` renders the selector (647 options, consent copy, styled); setting a home community persists and is read back by the feed resolver; the member must opt in. **473 tests green, phpstan + schema:check clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)