### PR TITLE
feat(corpus): migration to publish the consented corpus on deploy

### DIFF
--- a/migrations/20260616_010000_publish_consented_corpus.php
+++ b/migrations/20260616_010000_publish_consented_corpus.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Publish the consented corpus (Phase 4 consent grant, applied on deploy).
+ *
+ * The production database was seeded with the 27 Steven Bennett corpus rows
+ * (example_sentence) + the speaker with ALL consent flags OFF and unpublished,
+ * pending written consent. Consent has now been granted for public display,
+ * publication, search, AI grounding, and AI training, so this flips the
+ * existing rows ON. Idempotent: re-running sets the same values; if a fresh
+ * import already wrote them ON (scripts/import-corpus.php), this is a no-op.
+ *
+ * Values live in the _data JSON blob, so json_set is used. No row is created
+ * here and nothing from the corpus directory is read; only the consent state of
+ * already-present rows changes.
+ */
+return new class () extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        $connection = $schema->getConnection();
+
+        $connection->executeStatement(
+            "UPDATE example_sentence
+             SET _data = json_set(_data, '$.consent_public', 1, '$.consent_ai_training', 1, '$.status', 1)
+             WHERE json_extract(_data, '$.source_sentence_id') LIKE 'corpus:%'",
+        );
+
+        $connection->executeStatement(
+            "UPDATE speaker
+             SET _data = json_set(_data, '$.consent_public_display', 1, '$.consent_ai_training', 1, '$.status', 1)
+             WHERE json_extract(_data, '$.code') = 'sb'",
+        );
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $connection = $schema->getConnection();
+
+        $connection->executeStatement(
+            "UPDATE example_sentence
+             SET _data = json_set(_data, '$.consent_public', 0, '$.consent_ai_training', 0, '$.status', 0)
+             WHERE json_extract(_data, '$.source_sentence_id') LIKE 'corpus:%'",
+        );
+
+        $connection->executeStatement(
+            "UPDATE speaker
+             SET _data = json_set(_data, '$.consent_public_display', 0, '$.consent_ai_training', 0, '$.status', 0)
+             WHERE json_extract(_data, '$.code') = 'sb'",
+        );
+    }
+};


### PR DESCRIPTION
The production DB was seeded with the 27-row corpus + speaker with all consent flags OFF. Phase 4 granted written consent, so this migration flips the existing rows ON (`consent_public`, `consent_ai_training`, published) via an idempotent `json_set` update.

It **creates no rows** and reads nothing from the corpus directory, so it applies the consent on the Pi (where the corpus dir is not present) through the standard `db:init` path. No-op where a fresh import already wrote the rows ON; `down()` re-gates them. Verified locally: a simulated consent-OFF state flips to 27/27 consent-public + published, orthography untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)