### PR TITLE
feat(#851): mount Anokii shell at /admin/anokii

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "symfony/process": "^8.0",
         "waaseyaa/access": "^0.1.0-alpha.248",
         "waaseyaa/admin-surface": "^0.1.0-alpha.248",
+        "waaseyaa/anokii": "^0.1.0-alpha.10",
         "waaseyaa/api": "^0.1.0-alpha.248",
         "waaseyaa/auth": "^0.1.0-alpha.248",
         "waaseyaa/bimaaji": "0.1.0-alpha.248",

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
                 "App\\Provider\\MinooEntityStackProvider",
                 "App\\Provider\\MinooRoutingStackProvider",
                 "App\\Provider\\AppBootServiceProvider",
+                "App\\Provider\\AnokiiServiceProvider",
                 "App\\Provider\\AppCommandServiceProvider",
                 "App\\Provider\\BimaajiBridgeProvider"
             ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46948a1280066f447044321450caee47",
+    "content-hash": "b4125faf0374bb6ed0e36800ae5c5de4",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -4022,6 +4022,57 @@
             "time": "2026-06-23T11:05:38+00:00"
         },
         {
+            "name": "waaseyaa/ai-pipeline",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/ai-pipeline.git",
+                "reference": "ee202f161f96178f24e63c3b89c5e7b2e479f880"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/ai-pipeline/zipball/ee202f161f96178f24e63c3b89c5e7b2e479f880",
+                "reference": "ee202f161f96178f24e63c3b89c5e7b2e479f880",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.5",
+                "waaseyaa/ai-vector": "^0.1.0-alpha.248",
+                "waaseyaa/entity": "^0.1.0-alpha.248",
+                "waaseyaa/queue": "^0.1.0-alpha.248"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\AI\\Pipeline\\AIPipelineServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\AI\\Pipeline\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "AI processing pipelines with queue-based execution for Waaseyaa",
+            "support": {
+                "issues": "https://github.com/waaseyaa/ai-pipeline/issues",
+                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
             "name": "waaseyaa/ai-schema",
             "version": "v0.1.0-alpha.248",
             "source": {
@@ -4168,6 +4219,50 @@
             "time": "2026-06-23T11:05:38+00:00"
         },
         {
+            "name": "waaseyaa/anokii",
+            "version": "v0.1.0-alpha.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/anokii.git",
+                "reference": "f9c48174798277e0b399d5226378f5e83b1c0551"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/anokii/zipball/f9c48174798277e0b399d5226378f5e83b1c0551",
+                "reference": "f9c48174798277e0b399d5226378f5e83b1c0551",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/yaml": "^7.0",
+                "waaseyaa/full": "^0.1.0-alpha.209"
+            },
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "Anokii\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Russell Jones",
+                    "email": "jonesrussell42@gmail.com"
+                },
+                {
+                    "name": "Anokii Project Contributors"
+                }
+            ],
+            "description": "Anokii, the first opinionated distribution built on Waaseyaa. Sovereign workspace for First Nations. OCAP-by-architecture. Working name pending language-keeper verification.",
+            "support": {
+                "issues": "https://github.com/waaseyaa/anokii/issues",
+                "source": "https://github.com/waaseyaa/anokii/tree/v0.1.0-alpha.10"
+            },
+            "time": "2026-06-23T16:39:29+00:00"
+        },
+        {
             "name": "waaseyaa/api",
             "version": "v0.1.0-alpha.248",
             "source": {
@@ -4233,6 +4328,55 @@
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
                 "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
+            "name": "waaseyaa/attachment",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/attachment.git",
+                "reference": "41691895213f0440e0cce411f77b88a9af291d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/attachment/zipball/41691895213f0440e0cce411f77b88a9af291d7a",
+                "reference": "41691895213f0440e0cce411f77b88a9af291d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.5",
+                "waaseyaa/access": "^0.1.0-alpha.248",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.248",
+                "waaseyaa/entity": "^0.1.0-alpha.248",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.248",
+                "waaseyaa/foundation": "^0.1.0-alpha.248"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\Attachment\\AttachmentServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\Attachment\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Attachment content type with parent-entity reference and at-most-one-active invariant.",
+            "support": {
+                "issues": "https://github.com/waaseyaa/attachment/issues",
+                "source": "https://github.com/waaseyaa/attachment/tree/v0.1.0-alpha.248"
             },
             "time": "2026-06-23T11:05:38+00:00"
         },
@@ -4535,6 +4679,51 @@
             "time": "2026-06-23T11:05:38+00:00"
         },
         {
+            "name": "waaseyaa/cms",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/cms.git",
+                "reference": "738f7dca21cb3b35c2ee6ef2979091dd9dbf85b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/cms/zipball/738f7dca21cb3b35c2ee6ef2979091dd9dbf85b3",
+                "reference": "738f7dca21cb3b35c2ee6ef2979091dd9dbf85b3",
+                "shasum": ""
+            },
+            "require": {
+                "waaseyaa/api": "^0.1.0-alpha.248",
+                "waaseyaa/cli": "^0.1.0-alpha.248",
+                "waaseyaa/core": "^0.1.0-alpha.248",
+                "waaseyaa/media": "^0.1.0-alpha.248",
+                "waaseyaa/menu": "^0.1.0-alpha.248",
+                "waaseyaa/node": "^0.1.0-alpha.248",
+                "waaseyaa/path": "^0.1.0-alpha.248",
+                "waaseyaa/seo": "^0.1.0-alpha.248",
+                "waaseyaa/ssr": "^0.1.0-alpha.248",
+                "waaseyaa/taxonomy": "^0.1.0-alpha.248",
+                "waaseyaa/workflows": "^0.1.0-alpha.248"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Waaseyaa — complete headless CMS with admin and CLI.",
+            "support": {
+                "issues": "https://github.com/waaseyaa/cms/issues",
+                "source": "https://github.com/waaseyaa/cms/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
             "name": "waaseyaa/config",
             "version": "v0.1.0-alpha.248",
             "source": {
@@ -4578,6 +4767,63 @@
                 "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.248"
             },
             "time": "2026-05-18T18:57:37+00:00"
+        },
+        {
+            "name": "waaseyaa/core",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/core.git",
+                "reference": "3a75514cc2c62dd4ba5955c869d5943239169112"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/core/zipball/3a75514cc2c62dd4ba5955c869d5943239169112",
+                "reference": "3a75514cc2c62dd4ba5955c869d5943239169112",
+                "shasum": ""
+            },
+            "require": {
+                "waaseyaa/access": "^0.1.0-alpha.248",
+                "waaseyaa/cache": "^0.1.0-alpha.248",
+                "waaseyaa/config": "^0.1.0-alpha.248",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.248",
+                "waaseyaa/entity": "^0.1.0-alpha.248",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.248",
+                "waaseyaa/error-handler": "^0.1.0-alpha.248",
+                "waaseyaa/field": "^0.1.0-alpha.248",
+                "waaseyaa/foundation": "^0.1.0-alpha.248",
+                "waaseyaa/i18n": "^0.1.0-alpha.248",
+                "waaseyaa/plugin": "^0.1.0-alpha.248",
+                "waaseyaa/queue": "^0.1.0-alpha.248",
+                "waaseyaa/routing": "^0.1.0-alpha.248",
+                "waaseyaa/scheduler": "^0.1.0-alpha.248",
+                "waaseyaa/state": "^0.1.0-alpha.248",
+                "waaseyaa/typed-data": "^0.1.0-alpha.248",
+                "waaseyaa/user": "^0.1.0-alpha.248",
+                "waaseyaa/validation": "^0.1.0-alpha.248"
+            },
+            "suggest": {
+                "waaseyaa/debug": "^0.1.0-alpha.248",
+                "waaseyaa/telescope": "^0.1.0-alpha.248",
+                "waaseyaa/testing": "^0.1.0-alpha.248"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
+            "support": {
+                "issues": "https://github.com/waaseyaa/core/issues",
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
@@ -4783,6 +5029,50 @@
             "time": "2026-06-23T11:05:38+00:00"
         },
         {
+            "name": "waaseyaa/error-handler",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/error-handler.git",
+                "reference": "7aaa725c4a6e0440ce259c21f046446914f1d3f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/error-handler/zipball/7aaa725c4a6e0440ce259c21f046446914f1d3f0",
+                "reference": "7aaa725c4a6e0440ce259c21f046446914f1d3f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.5",
+                "waaseyaa/foundation": "^0.1.0-alpha.248"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\ErrorHandler\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Rich exception pages, solution hints, and editor links for Waaseyaa",
+            "support": {
+                "issues": "https://github.com/waaseyaa/error-handler/issues",
+                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
             "name": "waaseyaa/field",
             "version": "v0.1.0-alpha.248",
             "source": {
@@ -4900,6 +5190,55 @@
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
                 "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
+            "name": "waaseyaa/full",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/full.git",
+                "reference": "38015e3169509fa1f52f7049c1d89f6d6ece9117"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/full/zipball/38015e3169509fa1f52f7049c1d89f6d6ece9117",
+                "reference": "38015e3169509fa1f52f7049c1d89f6d6ece9117",
+                "shasum": ""
+            },
+            "require": {
+                "waaseyaa/ai-agent": "^0.1.0-alpha.248",
+                "waaseyaa/ai-pipeline": "^0.1.0-alpha.248",
+                "waaseyaa/ai-schema": "^0.1.0-alpha.248",
+                "waaseyaa/ai-tools": "^0.1.0-alpha.248",
+                "waaseyaa/ai-vector": "^0.1.0-alpha.248",
+                "waaseyaa/attachment": "^0.1.0-alpha.248",
+                "waaseyaa/cms": "^0.1.0-alpha.248",
+                "waaseyaa/mcp": "^0.1.0-alpha.248",
+                "waaseyaa/relationship": "^0.1.0-alpha.248",
+                "waaseyaa/search": "^0.1.0-alpha.248",
+                "waaseyaa/structured-import": "^0.1.0-alpha.248"
+            },
+            "suggest": {
+                "waaseyaa/graphql": "^0.1.0-alpha.248",
+                "waaseyaa/inertia": "^0.1.0-alpha.248"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Waaseyaa full platform — CMS + AI + SSR + MCP.",
+            "support": {
+                "issues": "https://github.com/waaseyaa/full/issues",
+                "source": "https://github.com/waaseyaa/full/tree/v0.1.0-alpha.248"
             },
             "time": "2026-06-23T11:05:38+00:00"
         },
@@ -6035,6 +6374,53 @@
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
                 "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.248"
+            },
+            "time": "2026-06-23T11:05:38+00:00"
+        },
+        {
+            "name": "waaseyaa/structured-import",
+            "version": "v0.1.0-alpha.248",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/structured-import.git",
+                "reference": "c1c7c9f67f7efda0562c4164e1769af58e39ee1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/structured-import/zipball/c1c7c9f67f7efda0562c4164e1769af58e39ee1e",
+                "reference": "c1c7c9f67f7efda0562c4164e1769af58e39ee1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.5",
+                "waaseyaa/entity": "^0.1.0-alpha.248",
+                "waaseyaa/field": "^0.1.0-alpha.248",
+                "waaseyaa/foundation": "^0.1.0-alpha.248"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\StructuredImport\\StructuredImportServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\StructuredImport\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Pluggable structured-import pipeline for entity-template ingestion (default: GFM 2-column table).",
+            "support": {
+                "issues": "https://github.com/waaseyaa/structured-import/issues",
+                "source": "https://github.com/waaseyaa/structured-import/tree/v0.1.0-alpha.248"
             },
             "time": "2026-06-23T11:05:38+00:00"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4125faf0374bb6ed0e36800ae5c5de4",
+    "content-hash": "41ee696bd9a04227f27f63bdaf80f547",
     "packages": [
         {
             "name": "defuse/php-encryption",

--- a/src/Http/Controller/Anokii/AnokiiAdminController.php
+++ b/src/Http/Controller/Anokii/AnokiiAdminController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
+use Waaseyaa\User\User;
+
+/**
+ * Anokii admin shell landing (#851).
+ *
+ * Renders the empty, themed Anokii workspace chrome at /admin/anokii. The route
+ * is role-gated (admin / elder_coordinator) by {@see \App\Provider\Routing\AnokiiRouteProvider},
+ * so by the time this runs the account is an authorised staff member.
+ *
+ * No tools are wired yet — the nav advertises the planned tabs (Transcribe,
+ * Ingest, Curate) as "coming soon". The page extends the Anokii package shell
+ * via the `@anokii` namespace; it never forks it.
+ */
+final class AnokiiAdminController
+{
+    public function __construct(
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $active = (string) ($params['sub'] ?? 'home');
+
+        $html = $this->twig->render('pages/anokii/index.html.twig', [
+            'path' => $request->getPathInfo(),
+            'nav' => $this->nav(),
+            'nav_active' => $active,
+            'home_path' => '/admin/anokii',
+            'logout_path' => '/logout',
+            'user_label' => $this->accountLabel($account),
+            'user_role' => $this->accountRole($account),
+            'user_initials' => $this->initials($this->accountLabel($account)),
+        ]);
+
+        return new Response($html);
+    }
+
+    /**
+     * Sidebar nav. The workspace tabs are placeholders until their issues land
+     * (#853 transcribe, #854 ingest, #855 curate); each links nowhere yet and is
+     * flagged "Soon" so the chrome reads as intentionally empty.
+     *
+     * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
+     */
+    private function nav(): array
+    {
+        return [
+            ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
+            ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '#', 'group' => 'Language', 'badge' => 'Soon'],
+            ['id' => 'ingest', 'label' => 'Ingest', 'href' => '#', 'badge' => 'Soon'],
+            ['id' => 'curate', 'label' => 'Curate', 'href' => '#', 'badge' => 'Soon'],
+        ];
+    }
+
+    private function accountLabel(AccountInterface $account): string
+    {
+        if ($account instanceof User) {
+            $name = trim($account->getName());
+            if ($name !== '') {
+                return $name;
+            }
+            $email = trim($account->getEmail());
+            if ($email !== '') {
+                return $email;
+            }
+        }
+
+        return 'Staff';
+    }
+
+    private function accountRole(AccountInterface $account): string
+    {
+        $roles = $account->getRoles();
+
+        return $roles !== [] ? (string) reset($roles) : 'staff';
+    }
+
+    private function initials(string $label): string
+    {
+        $parts = preg_split('/[\s@._-]+/', $label, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $initials = '';
+        foreach ($parts as $part) {
+            $initials .= strtoupper(substr($part, 0, 1));
+            if (strlen($initials) === 2) {
+                break;
+            }
+        }
+
+        return $initials !== '' ? $initials : '?';
+    }
+}

--- a/src/Provider/AnokiiServiceProvider.php
+++ b/src/Provider/AnokiiServiceProvider.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider;
+
+use Twig\Environment;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
+use Waaseyaa\SSR\SsrServiceProvider;
+use Waaseyaa\SSR\ThemeServiceProvider;
+
+/**
+ * Anokii distribution wiring (Tier 3-lite, #851).
+ *
+ * Minoo embeds only the Anokii *shell* — the themeable admin chrome — and
+ * deliberately does NOT register Anokii\Provider\CoIntelligenceServiceProvider.
+ * That keeps Anokii's graph entity types (incl. a `community` type that would
+ * collide with Minoo's own), its keyword-RAG chat routes, and its single-admin
+ * auth out of the build. Minoo owns auth (role-gated routes) and the entities.
+ *
+ * This provider has exactly two jobs:
+ *   1. Make the package's Twig templates resolvable under the `@anokii`
+ *      namespace, so Minoo pages can `{% extends "@anokii/_shell.html.twig" %}`
+ *      without forking the shell.
+ *   2. Apply Minoo theming by exposing the brand identity and a block of
+ *      `--anokii-*` / `--color-*` token overrides (the Minoo palette) as Twig
+ *      globals, which the extending template injects into the shell's
+ *      `shell_styles` block. The shell is token-driven, so rebranding is purely
+ *      an override of these custom properties — the template is never forked.
+ *
+ * No routes, entity types, commands, or middleware are registered here; the
+ * `/admin/anokii` surface is mounted by {@see Routing\AnokiiRouteProvider}.
+ */
+final class AnokiiServiceProvider extends AppCoreServiceProvider
+{
+    /** Twig namespace the Anokii package templates are exposed under. */
+    private const string TEMPLATE_NAMESPACE = 'anokii';
+
+    public function boot(): void
+    {
+        $templateDir = dirname(__DIR__, 2) . '/vendor/waaseyaa/anokii/templates/anokii';
+        if (!is_dir($templateDir)) {
+            // Package not installed (or layout changed) — fail soft so the rest
+            // of the app still boots; the route provider's render will surface
+            // the missing template clearly if the surface is hit.
+            return;
+        }
+
+        $themeCss = $this->minooThemeTokens();
+
+        foreach ($this->twigEnvironments() as $twig) {
+            $this->registerTemplateNamespace($twig, $templateDir);
+            // Brand identity + theme tokens consumed by templates/pages/anokii/*.
+            $twig->addGlobal('anokii_brand_title', 'Minoo');
+            $twig->addGlobal('anokii_brand_tag', 'Language Workspace');
+            $twig->addGlobal('anokii_theme_css', $themeCss);
+        }
+    }
+
+    /**
+     * The SSR and theme Twig environments, de-duplicated by object identity.
+     *
+     * SsrServiceProvider re-uses the ThemeServiceProvider environment, so this
+     * is usually a single instance; the dedup keeps the loop correct either way.
+     *
+     * @return list<Environment>
+     */
+    private function twigEnvironments(): array
+    {
+        $environments = [];
+        foreach ([SsrServiceProvider::getTwigEnvironment(), ThemeServiceProvider::getTwigEnvironment()] as $env) {
+            if ($env instanceof Environment) {
+                $environments[spl_object_id($env)] = $env;
+            }
+        }
+
+        return array_values($environments);
+    }
+
+    /**
+     * Register $dir under the `@anokii` namespace on the given environment's
+     * loader. Idempotent: re-registration of the same path is skipped.
+     */
+    private function registerTemplateNamespace(Environment $twig, string $dir): void
+    {
+        $loader = $twig->getLoader();
+
+        if ($loader instanceof FilesystemLoader) {
+            if (!in_array($dir, $loader->getPaths(self::TEMPLATE_NAMESPACE), true)) {
+                $loader->addPath($dir, self::TEMPLATE_NAMESPACE);
+            }
+
+            return;
+        }
+
+        if ($loader instanceof ChainLoader) {
+            // The SSR/theme loader is a ChainLoader of plain FilesystemLoaders
+            // (default namespace only). Add a dedicated namespaced loader to the
+            // chain so `@anokii/...` resolves without touching the existing ones.
+            $namespaced = new FilesystemLoader();
+            $namespaced->addPath($dir, self::TEMPLATE_NAMESPACE);
+            $loader->addLoader($namespaced);
+        }
+    }
+
+    /**
+     * Minoo palette as `--color-*` overrides for the Anokii shell.
+     *
+     * The shell aliases its `--anokii-shell-*` tokens to these generic
+     * `--color-*` custom properties (with neutral grey fallbacks), so overriding
+     * them rebrands the chrome. Light by default with a dark-scheme override,
+     * mirroring Minoo's own light/dark handling. Values track public/css/tokens.css
+     * (language teal accent, earth-tone surfaces). CSS is inline in the shell, so
+     * there is no external stylesheet to cache-bust here.
+     */
+    private function minooThemeTokens(): string
+    {
+        return <<<'CSS'
+:root{
+  --color-primary: #2a9d8f;        /* Minoo "language" teal */
+  --color-primary-ink: #ffffff;
+  --color-bg: #f5f0eb;             /* surface-light */
+  --color-card: #ffffff;
+  --color-ink: #1a1a1a;
+  --color-line: #e0dbd4;          /* border-light */
+  --color-muted: #6b6b6b;
+  --color-side-bg: #0a0a0a;       /* surface-dark sidebar */
+  --color-side-line: #1e1e1e;
+  --color-side-muted: #9a958d;
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --color-bg: #0a0a0a;
+    --color-card: #141414;
+    --color-ink: #f0ece6;
+    --color-line: #1e1e1e;
+    --color-muted: #888888;
+  }
+}
+CSS;
+    }
+}

--- a/src/Provider/MinooRoutingStackProvider.php
+++ b/src/Provider/MinooRoutingStackProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Provider;
 
 use App\Provider\Routing\AdminRouteProvider;
+use App\Provider\Routing\AnokiiRouteProvider;
 use App\Provider\Routing\AuthApiRouteProvider;
 use App\Provider\Routing\GamesApiRouteProvider;
 use App\Provider\Routing\LessonRouteProvider;
@@ -39,6 +40,9 @@ final class MinooRoutingStackProvider extends ServiceProvider
             new GamesApiRouteProvider(),
             new LessonRouteProvider(),
             new StaticPagesRouteProvider(),
+            // Anokii shell must register before the admin-surface SPA catch-all
+            // so its priority-100 /admin/anokii routes win over admin_spa.
+            new AnokiiRouteProvider(),
             new AdminRouteProvider(),
             new SocialApiRouteProvider(),
         ] as $child) {

--- a/src/Provider/Routing/AnokiiRouteProvider.php
+++ b/src/Provider/Routing/AnokiiRouteProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Routing;
+
+use App\Provider\AppCoreServiceProvider;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Routing\RouteBuilder;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+/**
+ * Anokii admin shell routes (#851).
+ *
+ * Mounts the role-gated Anokii workspace at /admin/anokii. These routes carry
+ * an explicit priority (>= 100) so they win over the priority-0 `admin_spa`
+ * `/admin/{path}` catch-all (registered by {@see AdminRouteProvider}) — without
+ * it, GET /admin/anokii would fall through to the Vue admin SPA. This provider
+ * is therefore merged BEFORE AdminRouteProvider in {@see \App\Provider\MinooRoutingStackProvider}.
+ *
+ * Gating uses Minoo's own roles (`admin`, `elder_coordinator`), mirroring the
+ * /staff/* idiom — NOT Anokii's single-admin DashboardGate. The `{sub}` route
+ * is a forward-looking catch-all for future tabs (Transcribe / Ingest / Curate);
+ * for now every path renders the same landing shell.
+ */
+final class AnokiiRouteProvider extends AppCoreServiceProvider
+{
+    /** Beats the priority-0 admin_spa /admin/{path} catch-all. */
+    private const int ROUTE_PRIORITY = 100;
+
+    /** Roles permitted into the Anokii workspace (Minoo staff roles). */
+    private const string STAFF_ROLES = 'admin,elder_coordinator';
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        $router->addRoute(
+            'anokii.home',
+            RouteBuilder::create('/admin/anokii')
+                ->controller('App\Http\Controller\Anokii\AnokiiAdminController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::ROUTE_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        // Forward-looking: future workspace tabs live under /admin/anokii/{sub}.
+        // All currently resolve to the same landing shell. The requirement keeps
+        // this off the admin-surface `_surface` API namespace.
+        $router->addRoute(
+            'anokii.section',
+            RouteBuilder::create('/admin/anokii/{sub}')
+                ->controller('App\Http\Controller\Anokii\AnokiiAdminController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::ROUTE_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->requirement('sub', '[a-z][a-z0-9-]*')
+                ->build(),
+        );
+    }
+}

--- a/templates/pages/anokii/index.html.twig
+++ b/templates/pages/anokii/index.html.twig
@@ -1,0 +1,44 @@
+{#
+  Anokii admin shell landing (#851).
+
+  Extends the Anokii package shell via the @anokii namespace (registered by
+  App\Provider\AnokiiServiceProvider) — never forked. Theming is applied by
+  overriding the shell's --color-* tokens in the shell_styles block, using the
+  Minoo palette supplied as the `anokii_theme_css` global. Brand identity comes
+  from the `anokii_brand_*` globals. Nav + user-chip context come from
+  AnokiiAdminController.
+
+  Empty by design: the workspace tabs (Transcribe / Ingest / Curate) are
+  advertised as "Soon" until their issues land (#853, #854, #855).
+#}
+{% extends "@anokii/_shell.html.twig" %}
+
+{% block title %}{{ anokii_brand_title|default('Minoo') }} — {{ anokii_brand_tag|default('Language Workspace') }}{% endblock %}
+
+{% block shell_styles %}
+  {{ anokii_theme_css|default('')|raw }}
+  .anokii-lede{ max-width: 56ch; }
+  .anokii-lede h1{ font-size: 1.6rem; line-height: 1.2; margin-bottom: .5rem; }
+  .anokii-lede p{ color: var(--anokii-shell-muted); }
+  .anokii-soon{ margin-top: 1.75rem; display: grid; gap: .75rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+  .anokii-soon .card{ background: var(--anokii-shell-card); border: 1px solid var(--anokii-shell-line); border-radius: 12px; padding: 14px 16px; }
+  .anokii-soon .card b{ display: block; }
+  .anokii-soon .card small{ color: var(--anokii-shell-muted); }
+{% endblock %}
+
+{% block brand %}
+  <b>{{ anokii_brand_title|default('Minoo') }}</b>&nbsp;<span style="opacity:.6;font-weight:400">{{ anokii_brand_tag|default('Language Workspace') }}</span>
+{% endblock %}
+
+{% block content %}
+  <div class="anokii-lede">
+    <h1>Anokii — Language Workspace</h1>
+    <p>The home for transcribing, ingesting, and curating Anishinaabemowin from the community corpus. Tools arrive here as they land.</p>
+  </div>
+
+  <div class="anokii-soon">
+    <div class="card"><b>Transcribe</b><small>Whiteboard cards → entries. Coming soon.</small></div>
+    <div class="card"><b>Ingest</b><small>Pull new reels into the corpus. Coming soon.</small></div>
+    <div class="card"><b>Curate</b><small>Promote utterances into lessons. Coming soon.</small></div>
+  </div>
+{% endblock %}

--- a/tests/App/Integration/Http/Admin/AnokiiShellTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiShellTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * The Anokii shell at /admin/anokii (#851):
+ *   - role-gated to admin / elder_coordinator (denied for anonymous),
+ *   - renders the Anokii package shell, NOT the admin-surface Vue SPA
+ *     (i.e. its priority-100 routes win over the admin_spa /admin/{path} catch-all).
+ */
+#[CoversNothing]
+final class AnokiiShellTest extends HttpKernelTestCase
+{
+    private static int $adminUid = 0;
+    private static int $coordinatorUid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('user');
+
+        $admin = $storage->create([
+            'name' => 'Anokii Admin',
+            'mail' => 'anokii-admin@example.test',
+            'status' => true,
+            'created' => time(),
+            'roles' => ['admin'],
+            'permissions' => [],
+        ]);
+        $storage->save($admin);
+        self::$adminUid = (int) $admin->id();
+
+        $coordinator = $storage->create([
+            'name' => 'Elder Coordinator',
+            'mail' => 'anokii-coordinator@example.test',
+            'status' => true,
+            'created' => time(),
+            'roles' => ['elder_coordinator'],
+            'permissions' => [],
+        ]);
+        $storage->save($coordinator);
+        self::$coordinatorUid = (int) $coordinator->id();
+    }
+
+    #[Test]
+    public function anonymous_is_denied_and_does_not_get_the_spa(): void
+    {
+        $response = $this->send('GET', '/admin/anokii');
+        $code = $response->getStatusCode();
+        $body = (string) $response->getContent();
+
+        self::assertContains(
+            $code,
+            [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND, Response::HTTP_UNAUTHORIZED],
+            'Anonymous /admin/anokii must be denied, not served.',
+        );
+        self::assertNotSame(Response::HTTP_OK, $code);
+        self::assertStringNotContainsString('/_nuxt/', $body, 'Denied response must not be the admin SPA shell.');
+        self::assertStringNotContainsString('anokii-app', $body, 'Anonymous must not see the workspace chrome.');
+    }
+
+    #[Test]
+    public function admin_sees_the_anokii_shell_not_the_spa(): void
+    {
+        $response = $this->sendAs(self::$adminUid, 'GET', '/admin/anokii');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        // Anokii package shell markers (proves it rendered the shell, not the SPA).
+        self::assertStringContainsString('anokii-app', $body);
+        self::assertStringContainsString('anokii-nav', $body);
+        self::assertStringNotContainsString('/_nuxt/', $body, '/admin/anokii must not fall through to the Vue admin SPA.');
+
+        // Minoo landing content + placeholder tabs.
+        self::assertStringContainsString('Anokii — Language Workspace', $body);
+        self::assertStringContainsString('Transcribe', $body);
+        self::assertStringContainsString('Curate', $body);
+    }
+
+    #[Test]
+    public function elder_coordinator_is_also_allowed(): void
+    {
+        $response = $this->sendAs(self::$coordinatorUid, 'GET', '/admin/anokii');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('anokii-app', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function seeded_admin_user_actually_has_the_admin_role(): void
+    {
+        // Guards the auth-helper assumption: if seeding/roles silently broke,
+        // the 200s above would be false negatives.
+        $user = self::$kernel->getEntityTypeManager()->getStorage('user')->load(self::$adminUid);
+        self::assertInstanceOf(EntityInterface::class, $user);
+        self::assertContains('admin', $user->getRoles());
+    }
+
+    /**
+     * Drive a request as an authenticated user by seeding the session UID the
+     * way AuthManager does ($_SESSION['waaseyaa_uid']). The base send() clears
+     * the session, so this is a parallel helper that does not.
+     *
+     * Ensuring the session is active BEFORE setting the UID keeps SessionMiddleware
+     * from re-running session_start() and wiping it.
+     */
+    private function sendAs(int $uid, string $method, string $uri): Response
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = $uid;
+
+        return self::$kernel->handle();
+    }
+}


### PR DESCRIPTION
Mounts an empty, role-gated, themed **Anokii admin shell** at `/admin/anokii`. No transcriber yet — just the mounted chrome that #853–#855 build on. Closes the first build step of milestone #62.

## What landed
**Tier 3-lite embed** — require the package, but do **not** register `Anokii\Provider\CoIntelligenceServiceProvider`. That keeps Anokii's graph entity types (incl. a `community` type that would collide with Minoo's), its keyword-RAG chat routes, and its single-admin auth out of the build. Minoo keeps its own auth + entities.

- **`App\Provider\AnokiiServiceProvider`** (composer-registered) — exposes the package templates under the `@anokii` Twig namespace and applies Minoo theming by overriding the shell's `--color-*` tokens (language teal `#2a9d8f`, light/dark aware) + brand globals. No routes, entities, chat, or auth.
- **`App\Provider\Routing\AnokiiRouteProvider`** — `GET /admin/anokii` and `/admin/anokii/{sub}` at **priority 100**, `requireRole('admin,elder_coordinator')` (Minoo's `/staff/*` idiom, not Anokii's `DashboardGate`). Merged **before** `AdminRouteProvider` so it wins over the priority-0 `admin_spa` `/admin/{path}` SPA catch-all.
- **`App\Http\Controller\Anokii\AnokiiAdminController`** + **`templates/pages/anokii/index.html.twig`** — landing that `{% extends "@anokii/_shell.html.twig" %}` (never forks the shell), with placeholder **Transcribe / Ingest / Curate** tabs marked "Soon".

## Dependency delta (spike #850)
`composer require waaseyaa/anokii:^0.1.0-alpha.10` → **8 installs, 0 updates, 0 removals**: anokii `alpha.10` + `full`/`core`/`ai-pipeline`/`attachment`/`cms`/`structured-import`/`error-handler` at `alpha.248`. No existing `waaseyaa/*` moved; `bimaaji`'s exact `0.1.0-alpha.248` pin undisturbed.

## Verification
- `./vendor/bin/phpunit` — **green, 477 tests** (+4 new, 2 pre-existing skips).
- `composer phpstan` — **No errors** (level 5).
- `composer cs-fixer` — clean (new files).
- `ComposerProviderParityTest` — green with the new provider entry.
- **Live curl (cli-server):**
  - `GET /admin/anokii` (unauth) → **403** Minoo error page, 10410 bytes, no `/_nuxt/`, no shell — gated route wins over `admin_spa`.
  - `GET /admin/` → **200** with `/_nuxt/` — SPA intact (collision resolved).
  - `GET /admin/anokii` (admin session) → **200, 7052 bytes**, `anokii-app`/`anokii-nav` markers, landing H1, teal `#2a9d8f` applied, `<title>Minoo — Language Workspace</title>`, no `/_nuxt/`.

## Out of scope (future)
`oral_history` re-introduction and Anokii keyword RAG chat remain out of scope (#853–#855).

Refs #851