### PR TITLE
feat(#853): SSR transcribe dashboard under the Anokii shell

### DIFF
--- a/src/Http/Controller/Anokii/AnokiiAdminController.php
+++ b/src/Http/Controller/Anokii/AnokiiAdminController.php
@@ -4,24 +4,22 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Anokii;
 
+use App\Http\View\AnokiiShellContext;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\SSR\Attribute\MapQuery;
 use Waaseyaa\SSR\Attribute\MapRoute;
-use Waaseyaa\User\User;
 
 /**
  * Anokii admin shell landing (#851).
  *
- * Renders the empty, themed Anokii workspace chrome at /admin/anokii. The route
- * is role-gated (admin / elder_coordinator) by {@see \App\Provider\Routing\AnokiiRouteProvider},
- * so by the time this runs the account is an authorised staff member.
- *
- * No tools are wired yet — the nav advertises the planned tabs (Transcribe,
- * Ingest, Curate) as "coming soon". The page extends the Anokii package shell
- * via the `@anokii` namespace; it never forks it.
+ * Renders the themed Anokii workspace chrome at /admin/anokii. The route is
+ * role-gated (admin / elder_coordinator) by {@see \App\Provider\Routing\AnokiiRouteProvider},
+ * so by the time this runs the account is an authorised staff member. The page
+ * extends the Anokii package shell via the `@anokii` namespace; it never forks it.
+ * Sidebar nav + user chip come from {@see AnokiiShellContext}.
  */
 final class AnokiiAdminController
 {
@@ -34,71 +32,10 @@ final class AnokiiAdminController
     {
         $active = (string) ($params['sub'] ?? 'home');
 
-        $html = $this->twig->render('pages/anokii/index.html.twig', [
+        $html = $this->twig->render('pages/anokii/index.html.twig', AnokiiShellContext::build($account, $active, [
             'path' => $request->getPathInfo(),
-            'nav' => $this->nav(),
-            'nav_active' => $active,
-            'home_path' => '/admin/anokii',
-            'logout_path' => '/logout',
-            'user_label' => $this->accountLabel($account),
-            'user_role' => $this->accountRole($account),
-            'user_initials' => $this->initials($this->accountLabel($account)),
-        ]);
+        ]));
 
         return new Response($html);
-    }
-
-    /**
-     * Sidebar nav. The workspace tabs are placeholders until their issues land
-     * (#853 transcribe, #854 ingest, #855 curate); each links nowhere yet and is
-     * flagged "Soon" so the chrome reads as intentionally empty.
-     *
-     * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
-     */
-    private function nav(): array
-    {
-        return [
-            ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
-            ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '#', 'group' => 'Language', 'badge' => 'Soon'],
-            ['id' => 'ingest', 'label' => 'Ingest', 'href' => '#', 'badge' => 'Soon'],
-            ['id' => 'curate', 'label' => 'Curate', 'href' => '#', 'badge' => 'Soon'],
-        ];
-    }
-
-    private function accountLabel(AccountInterface $account): string
-    {
-        if ($account instanceof User) {
-            $name = trim($account->getName());
-            if ($name !== '') {
-                return $name;
-            }
-            $email = trim($account->getEmail());
-            if ($email !== '') {
-                return $email;
-            }
-        }
-
-        return 'Staff';
-    }
-
-    private function accountRole(AccountInterface $account): string
-    {
-        $roles = $account->getRoles();
-
-        return $roles !== [] ? (string) reset($roles) : 'staff';
-    }
-
-    private function initials(string $label): string
-    {
-        $parts = preg_split('/[\s@._-]+/', $label, -1, PREG_SPLIT_NO_EMPTY) ?: [];
-        $initials = '';
-        foreach ($parts as $part) {
-            $initials .= strtoupper(substr($part, 0, 1));
-            if (strlen($initials) === 2) {
-                break;
-            }
-        }
-
-        return $initials !== '' ? $initials : '?';
     }
 }

--- a/src/Http/Controller/Anokii/TranscribeController.php
+++ b/src/Http/Controller/Anokii/TranscribeController.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use App\Http\View\AnokiiShellContext;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+
+/**
+ * Transcribe dashboard (#853) — replaces the standalone Python prototype
+ * (code/transcribe/transcribe.py, in a separate repo) with an SSR tab inside
+ * the Anokii shell.
+ *
+ * Lists corpus example_sentence rows (default-filtered to untranscribed: those
+ * missing the Ojibwe or English text), each with the whiteboard thumbnail and
+ * audio (#852/#822 consent-gated routes) plus editable Ojibwe / English / notes.
+ * Edits autosave to the entity via {@see self::save()}.
+ *
+ * Both routes are role-gated (admin / elder_coordinator) by
+ * {@see \App\Provider\Routing\AnokiiRouteProvider}. The page renders into the
+ * Anokii package shell via the `@anokii` namespace; it never forks it.
+ *
+ * HARD REQUIREMENT: the Ojibwe is stored EXACTLY as entered — never normalize
+ * the speaker's orthography (ADR 0003).
+ */
+final class TranscribeController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $showAll = ($request->query->get('filter') === 'all');
+
+        $rows = $this->corpusRows($account);
+        $total = count($rows);
+        $done = count(array_filter($rows, static fn (array $r): bool => $r['ojibwe_text'] !== '' && $r['english_text'] !== ''));
+
+        $visible = $showAll
+            ? $rows
+            : array_values(array_filter($rows, static fn (array $r): bool => $r['ojibwe_text'] === '' || $r['english_text'] === ''));
+
+        $html = $this->twig->render('pages/anokii/transcribe.html.twig', AnokiiShellContext::build($account, 'transcribe', [
+            'path' => $request->getPathInfo(),
+            'rows' => $visible,
+            'total' => $total,
+            'done' => $done,
+            'show_all' => $showAll,
+            'save_url' => '/admin/anokii/transcribe/save',
+            'csrf_token' => CsrfMiddleware::token(),
+        ]));
+
+        return new Response($html);
+    }
+
+    /**
+     * Autosave a single row. Accepts a JSON body (the dashboard's fetch) or form
+     * fields (test/no-JS fallback). CSRF is enforced by the framework middleware
+     * (X-CSRF-Token header or _csrf_token field); the route enforces the role.
+     */
+    public function save(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->readBody($request);
+
+        $esid = (int) ($data['esid'] ?? 0);
+        if ($esid <= 0) {
+            return $this->json(['ok' => false, 'error' => 'Missing esid.'], 422);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $entity = $storage->load($esid);
+        if (!$entity instanceof EntityInterface) {
+            return $this->json(['ok' => false, 'error' => 'Not found.'], 404);
+        }
+
+        // Stored verbatim — the Ojibwe orthography is never normalized (ADR 0003).
+        if (array_key_exists('ojibwe_text', $data)) {
+            $entity->set('ojibwe_text', (string) $data['ojibwe_text']);
+        }
+        if (array_key_exists('english_text', $data)) {
+            $entity->set('english_text', (string) $data['english_text']);
+        }
+        if (array_key_exists('notes', $data)) {
+            $entity->set('notes', (string) $data['notes']);
+        }
+        $entity->set('updated_at', time());
+        $storage->save($entity);
+
+        return $this->json([
+            'ok' => true,
+            'esid' => $esid,
+            'transcribed' => (string) $entity->get('ojibwe_text') !== '' && (string) $entity->get('english_text') !== '',
+        ]);
+    }
+
+    /**
+     * Corpus rows as flat arrays for the template. Admin-gated route, so the
+     * account is bound for the access check; all imported corpus rows are
+     * consent-public, so they all surface.
+     *
+     * @return list<array{esid: int, ojibwe_text: string, english_text: string, notes: string, thumb_url: string, audio_url: string, source_url: string, corpus_id: string}>
+     */
+    private function corpusRows(AccountInterface $account): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $ids = $storage->getQuery()
+            ->setAccount($account)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->sort('source_sentence_id')
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($storage->loadMultiple($ids) as $entity) {
+            $corpusId = str_replace('corpus:', '', (string) $entity->get('source_sentence_id'));
+            $rows[] = [
+                'esid' => (int) $entity->id(),
+                'ojibwe_text' => (string) $entity->get('ojibwe_text'),
+                'english_text' => (string) $entity->get('english_text'),
+                'notes' => (string) ($entity->get('notes') ?? ''),
+                'thumb_url' => (string) ($entity->get('thumbnail_url') ?: ($corpusId !== '' ? '/media/corpus/thumb/' . $corpusId : '')),
+                'audio_url' => (string) ($entity->get('audio_url') ?: ($corpusId !== '' ? '/media/corpus/audio/' . $corpusId : '')),
+                'source_url' => (string) $entity->get('source_url'),
+                'corpus_id' => $corpusId,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readBody(HttpRequest $request): array
+    {
+        $raw = trim((string) $request->getContent());
+        if ($raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return $request->request->all();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload, int $status = 200): Response
+    {
+        return new Response(
+            (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            $status,
+            ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/src/Http/View/AnokiiShellContext.php
+++ b/src/Http/View/AnokiiShellContext.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\View;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\User\User;
+
+/**
+ * Shared Twig context for pages rendered into the Anokii shell (#851, #853).
+ *
+ * Centralises the sidebar nav and the user-chip fields so every workspace tab
+ * (Overview, Transcribe, …) renders identical chrome. Tabs pass their own
+ * `nav_active` id and merge page-specific keys via $extra.
+ */
+final class AnokiiShellContext
+{
+    /**
+     * @param array<string, mixed> $extra
+     *
+     * @return array<string, mixed>
+     */
+    public static function build(AccountInterface $account, string $active, array $extra = []): array
+    {
+        $label = self::accountLabel($account);
+
+        return $extra + [
+            'nav' => self::nav(),
+            'nav_active' => $active,
+            'home_path' => '/admin/anokii',
+            'logout_path' => '/logout',
+            'user_label' => $label,
+            'user_role' => self::accountRole($account),
+            'user_initials' => self::initials($label),
+        ];
+    }
+
+    /**
+     * Sidebar nav. Transcribe is live (#853); Ingest (#854) and Curate (#855)
+     * are still placeholders flagged "Soon".
+     *
+     * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
+     */
+    private static function nav(): array
+    {
+        return [
+            ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
+            ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '/admin/anokii/transcribe', 'group' => 'Language'],
+            ['id' => 'ingest', 'label' => 'Ingest', 'href' => '#', 'badge' => 'Soon'],
+            ['id' => 'curate', 'label' => 'Curate', 'href' => '#', 'badge' => 'Soon'],
+        ];
+    }
+
+    private static function accountLabel(AccountInterface $account): string
+    {
+        if ($account instanceof User) {
+            $name = trim($account->getName());
+            if ($name !== '') {
+                return $name;
+            }
+            $email = trim($account->getEmail());
+            if ($email !== '') {
+                return $email;
+            }
+        }
+
+        return 'Staff';
+    }
+
+    private static function accountRole(AccountInterface $account): string
+    {
+        $roles = $account->getRoles();
+
+        return $roles !== [] ? (string) reset($roles) : 'staff';
+    }
+
+    private static function initials(string $label): string
+    {
+        $parts = preg_split('/[\s@._-]+/', $label, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $initials = '';
+        foreach ($parts as $part) {
+            $initials .= strtoupper(substr($part, 0, 1));
+            if (strlen($initials) === 2) {
+                break;
+            }
+        }
+
+        return $initials !== '' ? $initials : '?';
+    }
+}

--- a/src/Provider/Entity/EntityFoundationProvider.php
+++ b/src/Provider/Entity/EntityFoundationProvider.php
@@ -107,6 +107,7 @@ final class EntityFoundationProvider extends AppCoreServiceProvider
             _fieldDefinitions: [
                 'ojibwe_text' => ['type' => 'string', 'label' => 'Ojibwe Text', 'weight' => 0],
                 'english_text' => ['type' => 'string', 'label' => 'English Translation', 'weight' => 5],
+                'notes' => ['type' => 'text', 'label' => 'Notes', 'description' => 'Transcriber notes (not displayed publicly).', 'weight' => 6],
                 'dictionary_entry_id' => ['type' => 'entity_reference', 'label' => 'Dictionary Entry', 'settings' => ['target_type' => 'dictionary_entry'], 'weight' => 10],
                 'contributor_id' => ['type' => 'entity_reference', 'label' => 'Contributor', 'settings' => ['target_type' => 'contributor'], 'weight' => 15],
                 'speaker_id' => ['type' => 'entity_reference', 'label' => 'Speaker', 'settings' => ['target_type' => 'speaker'], 'weight' => 16],

--- a/src/Provider/Routing/AnokiiRouteProvider.php
+++ b/src/Provider/Routing/AnokiiRouteProvider.php
@@ -28,6 +28,9 @@ final class AnokiiRouteProvider extends AppCoreServiceProvider
     /** Beats the priority-0 admin_spa /admin/{path} catch-all. */
     private const int ROUTE_PRIORITY = 100;
 
+    /** Above ROUTE_PRIORITY so literal tab routes win over the /{sub} catch-all. */
+    private const int TAB_PRIORITY = 110;
+
     /** Roles permitted into the Anokii workspace (Minoo staff roles). */
     private const string STAFF_ROLES = 'admin,elder_coordinator';
 
@@ -41,6 +44,29 @@ final class AnokiiRouteProvider extends AppCoreServiceProvider
                 ->priority(self::ROUTE_PRIORITY)
                 ->render()
                 ->methods('GET')
+                ->build(),
+        );
+
+        // Transcribe tab (#853): dashboard + autosave API. Higher priority than
+        // the /{sub} catch-all below so these literal paths win.
+        $router->addRoute(
+            'anokii.transcribe',
+            RouteBuilder::create('/admin/anokii/transcribe')
+                ->controller('App\Http\Controller\Anokii\TranscribeController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'anokii.transcribe.save',
+            RouteBuilder::create('/admin/anokii/transcribe/save')
+                ->controller('App\Http\Controller\Anokii\TranscribeController::save')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->methods('POST')
                 ->build(),
         );
 

--- a/templates/pages/anokii/index.html.twig
+++ b/templates/pages/anokii/index.html.twig
@@ -37,7 +37,7 @@
   </div>
 
   <div class="anokii-soon">
-    <div class="card"><b>Transcribe</b><small>Whiteboard cards → entries. Coming soon.</small></div>
+    <div class="card"><b><a href="/admin/anokii/transcribe" style="color:var(--anokii-shell-accent)">Transcribe →</a></b><small>Whiteboard cards → entries.</small></div>
     <div class="card"><b>Ingest</b><small>Pull new reels into the corpus. Coming soon.</small></div>
     <div class="card"><b>Curate</b><small>Promote utterances into lessons. Coming soon.</small></div>
   </div>

--- a/templates/pages/anokii/transcribe.html.twig
+++ b/templates/pages/anokii/transcribe.html.twig
@@ -1,0 +1,125 @@
+{#
+  Transcribe dashboard (#853) — rendered into the Anokii shell (never forks it).
+
+  Lists corpus example_sentence rows with thumbnail + audio + editable Ojibwe /
+  English / notes. Edits autosave to /admin/anokii/transcribe/save via fetch with
+  the CSRF token. The Ojibwe is never normalized (ADR 0003).
+#}
+{% extends "@anokii/_shell.html.twig" %}
+
+{% block title %}Transcribe — Minoo Language Workspace{% endblock %}
+
+{% block shell_styles %}
+  {{ anokii_theme_css|default('')|raw }}
+  .tx-head{ display:flex; align-items:baseline; gap:16px; flex-wrap:wrap; margin-bottom:18px; }
+  .tx-head h1{ font-size:1.5rem; }
+  .tx-counter{ color:var(--anokii-shell-muted); font-variant-numeric:tabular-nums; }
+  .tx-filter{ margin-left:auto; font-size:13.5px; }
+  .tx-filter a{ color:var(--anokii-shell-accent); }
+  .tx-empty{ padding:28px; border:1px dashed var(--anokii-shell-line); border-radius:12px; color:var(--anokii-shell-muted); }
+  .tx-row{ display:grid; grid-template-columns:140px 1fr; gap:16px; background:var(--anokii-shell-card); border:1px solid var(--anokii-shell-line); border-radius:12px; padding:14px; margin-bottom:14px; }
+  .tx-media img{ width:140px; height:auto; border-radius:8px; display:block; background:#0001; }
+  .tx-media audio{ width:140px; margin-top:8px; }
+  .tx-media a{ font-size:12px; color:var(--anokii-shell-muted); display:inline-block; margin-top:6px; }
+  .tx-fields{ display:grid; gap:8px; min-width:0; }
+  .tx-fields label{ font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--anokii-shell-muted); }
+  .tx-fields input, .tx-fields textarea{ width:100%; font:inherit; padding:8px 10px; border:1px solid var(--anokii-shell-line); border-radius:8px; background:var(--anokii-shell-bg); color:var(--anokii-shell-ink); }
+  .tx-fields textarea{ min-height:48px; resize:vertical; }
+  .tx-status{ font-size:12px; min-height:16px; }
+  .tx-status.saved{ color:var(--anokii-shell-accent); }
+  .tx-status.error{ color:#c0392b; }
+  @media(max-width:620px){ .tx-row{ grid-template-columns:1fr; } .tx-media img,.tx-media audio{ width:100%; } }
+{% endblock %}
+
+{% block content %}
+  <div class="tx-head" data-save-url="{{ save_url }}" data-csrf="{{ csrf_token }}" id="tx-dash">
+    <h1>Transcribe</h1>
+    <span class="tx-counter"><b id="tx-done">{{ done }}</b> / {{ total }} transcribed</span>
+    <span class="tx-filter">
+      {% if show_all %}
+        <a href="/admin/anokii/transcribe">Show untranscribed only</a>
+      {% else %}
+        <a href="/admin/anokii/transcribe?filter=all">Show all</a>
+      {% endif %}
+    </span>
+  </div>
+
+  {% if rows is empty %}
+    <div class="tx-empty">
+      {% if show_all %}No corpus rows found.{% else %}Nothing left to transcribe — every corpus row has Ojibwe and English. <a href="/admin/anokii/transcribe?filter=all">Show all</a>.{% endif %}
+    </div>
+  {% else %}
+    {% for row in rows %}
+      <div class="tx-row" data-esid="{{ row.esid }}">
+        <div class="tx-media">
+          {% if row.thumb_url %}<img src="{{ row.thumb_url }}" alt="Whiteboard for {{ row.corpus_id }}" loading="lazy">{% endif %}
+          {% if row.audio_url %}<audio controls preload="none" src="{{ row.audio_url }}"></audio>{% endif %}
+          {% if row.source_url %}<a href="{{ row.source_url }}" target="_blank" rel="noopener">Source ↗</a>{% endif %}
+        </div>
+        <div class="tx-fields">
+          <div>
+            <label for="oj-{{ row.esid }}">Anishinaabemowin</label>
+            <input id="oj-{{ row.esid }}" type="text" data-field="ojibwe_text" value="{{ row.ojibwe_text }}" spellcheck="false" autocomplete="off">
+          </div>
+          <div>
+            <label for="en-{{ row.esid }}">English</label>
+            <input id="en-{{ row.esid }}" type="text" data-field="english_text" value="{{ row.english_text }}" autocomplete="off">
+          </div>
+          <div>
+            <label for="nt-{{ row.esid }}">Notes</label>
+            <textarea id="nt-{{ row.esid }}" data-field="notes">{{ row.notes }}</textarea>
+          </div>
+          <div class="tx-status" id="st-{{ row.esid }}"></div>
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endblock %}
+
+{% block page_scripts %}
+<script>
+(function () {
+  var dash = document.getElementById('tx-dash');
+  if (!dash) return;
+  var saveUrl = dash.getAttribute('data-save-url');
+  var csrf = dash.getAttribute('data-csrf');
+  var doneEl = document.getElementById('tx-done');
+
+  function rowPayload(rowEl) {
+    var payload = { esid: parseInt(rowEl.getAttribute('data-esid'), 10) };
+    rowEl.querySelectorAll('[data-field]').forEach(function (el) {
+      payload[el.getAttribute('data-field')] = el.value;
+    });
+    return payload;
+  }
+
+  function save(rowEl) {
+    var statusEl = rowEl.querySelector('.tx-status');
+    statusEl.textContent = 'Saving…';
+    statusEl.className = 'tx-status';
+    fetch(saveUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+      body: JSON.stringify(rowPayload(rowEl))
+    }).then(function (r) {
+      return r.ok ? r.json() : Promise.reject(r.status);
+    }).then(function (data) {
+      statusEl.textContent = 'Saved';
+      statusEl.className = 'tx-status saved';
+      if (doneEl && typeof data.done === 'number') { doneEl.textContent = data.done; }
+    }).catch(function () {
+      statusEl.textContent = 'Save failed';
+      statusEl.className = 'tx-status error';
+    });
+  }
+
+  // Autosave on blur, and recompute the done counter client-side as a hint.
+  document.querySelectorAll('.tx-row [data-field]').forEach(function (el) {
+    el.addEventListener('blur', function () { save(el.closest('.tx-row')); });
+    el.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); save(el.closest('.tx-row')); }
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/tests/App/Integration/Http/Admin/AnokiiTranscribeTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiTranscribeTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Transcribe dashboard (#853): the tab renders into the Anokii shell for staff
+ * (admin / elder_coordinator) and is denied for anonymous; the autosave API
+ * updates the entity verbatim and rejects unauthorized writes.
+ */
+#[CoversNothing]
+final class AnokiiTranscribeTest extends HttpKernelTestCase
+{
+    private const string CSRF = 'transcribe-test-csrf-token';
+    private static int $adminUid = 0;
+    private static int $coordinatorUid = 0;
+    private static int $esid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+
+        $admin = $users->create(['name' => 'Tx Admin', 'mail' => 'tx-admin@example.test', 'status' => true, 'created' => time(), 'roles' => ['admin'], 'permissions' => []]);
+        $users->save($admin);
+        self::$adminUid = (int) $admin->id();
+
+        $coord = $users->create(['name' => 'Tx Coordinator', 'mail' => 'tx-coord@example.test', 'status' => true, 'created' => time(), 'roles' => ['elder_coordinator'], 'permissions' => []]);
+        $users->save($coord);
+        self::$coordinatorUid = (int) $coord->id();
+
+        // One untranscribed corpus row (English missing).
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $row = $sentences->create([
+            'ojibwe_text' => 'Shoogan Mookman',
+            'english_text' => '',
+            'source_sentence_id' => 'corpus:sb-t1',
+            'thumbnail_url' => '/media/corpus/thumb/sb-t1',
+            'audio_url' => '/media/corpus/audio/sb-t1',
+            'consent_public' => 1,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($row);
+        self::$esid = (int) $row->id();
+    }
+
+    #[Test]
+    public function admin_sees_the_dashboard_in_the_anokii_shell(): void
+    {
+        $response = $this->sendAs(self::$adminUid, 'GET', '/admin/anokii/transcribe');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('anokii-app', $body);
+        self::assertStringContainsString('Transcribe', $body);
+        self::assertStringContainsString('tx-row', $body);
+        self::assertStringContainsString('data-esid="' . self::$esid . '"', $body);
+        self::assertStringNotContainsString('/_nuxt/', $body);
+    }
+
+    #[Test]
+    public function elder_coordinator_is_also_allowed(): void
+    {
+        $response = $this->sendAs(self::$coordinatorUid, 'GET', '/admin/anokii/transcribe');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('tx-row', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function anonymous_is_denied(): void
+    {
+        $response = $this->send('GET', '/admin/anokii/transcribe');
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND]);
+        self::assertStringNotContainsString('tx-row', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function save_updates_the_entity_verbatim(): void
+    {
+        // Includes orthography that must NOT be normalized (ADR 0003).
+        $ojibwe = '  Zhooniyaans  '; // leading/trailing spaces preserved
+        $response = $this->sendPost(self::$adminUid, '/admin/anokii/transcribe/save', [
+            'esid' => (string) self::$esid,
+            'ojibwe_text' => $ojibwe,
+            'english_text' => 'butter knife',
+            'notes' => 'reviewed',
+        ]);
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertTrue($payload['ok'] ?? false);
+
+        $entity = self::$kernel->getEntityTypeManager()->getStorage('example_sentence')->load(self::$esid);
+        self::assertNotNull($entity);
+        self::assertSame($ojibwe, (string) $entity->get('ojibwe_text'), 'Ojibwe orthography must be stored verbatim.');
+        self::assertSame('butter knife', (string) $entity->get('english_text'));
+        self::assertSame('reviewed', (string) $entity->get('notes'));
+    }
+
+    #[Test]
+    public function unauthorized_write_is_rejected_and_does_not_mutate(): void
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $before = (string) $storage->load(self::$esid)->get('english_text');
+
+        // Anonymous (no role) but with a valid CSRF token: the role gate must reject.
+        $response = $this->sendPost(0, '/admin/anokii/transcribe/save', [
+            'esid' => (string) self::$esid,
+            'english_text' => 'HACKED',
+        ]);
+
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_UNAUTHORIZED]);
+        $after = (string) $storage->load(self::$esid)->get('english_text');
+        self::assertSame($before, $after, 'Denied write must not mutate the entity.');
+    }
+
+    private function sendAs(int $uid, string $method, string $uri): Response
+    {
+        $this->primeGlobals($method, $uri);
+        $this->primeSession($uid);
+
+        return self::$kernel->handle();
+    }
+
+    /**
+     * @param array<string, string> $fields
+     */
+    private function sendPost(int $uid, string $uri, array $fields): Response
+    {
+        $this->primeGlobals('POST', $uri);
+        $_POST = $fields + ['_csrf_token' => self::CSRF];
+        $_REQUEST = $_POST;
+        $this->primeSession($uid);
+
+        return self::$kernel->handle();
+    }
+
+    private function primeGlobals(string $method, string $uri): void
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+    }
+
+    private function primeSession(int $uid): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        // Valid CSRF token in session so the middleware accepts the matching field.
+        $_SESSION['_csrf_token'] = self::CSRF;
+        if ($uid > 0) {
+            $_SESSION['waaseyaa_uid'] = $uid;
+        } else {
+            unset($_SESSION['waaseyaa_uid']);
+        }
+    }
+}


### PR DESCRIPTION
Replaces the standalone Python prototype (`code/transcribe/transcribe.py`, in a separate repo) with a role-gated transcribe tab inside the Anokii shell, operating over real `example_sentence` entities. Builds on #852.

## What landed
- **`/admin/anokii/transcribe`** (`TranscribeController::index`): lists corpus `example_sentence` rows, default-filtered to **untranscribed** (missing Ojibwe or English), each with the #852 whiteboard thumbnail + #822 audio and editable **Ojibwe / English / notes**, a **done/total** counter, and a "show all" toggle. Renders into `@anokii/_shell.html.twig` (never forks it).
- **`POST /admin/anokii/transcribe/save`** (`TranscribeController::save`): autosave JSON API (fetch on blur / Ctrl-Enter) writing the three fields back to the entity. **The Ojibwe is stored exactly as entered — never normalized (ADR 0003).**
- `example_sentence` gains a **`notes`** field (in `_data`; `schema:check` clean).
- Routes at **priority 110** (above the `/{sub}` catch-all). Nav + user chip extracted to `App\Http\View\AnokiiShellContext`, shared by the landing and the dashboard; Transcribe is now a live tab.

## Auth
Role-gated `requireRole('admin,elder_coordinator')` (Minoo roles, not Anokii's). Write authorization is the role gate — unauthenticated writes → 403. JSON bodies are framework-CSRF-exempt (not form-sendable cross-origin); the dashboard still sends `X-CSRF-Token` as defense-in-depth.

## Verification
- `bin/waaseyaa schema:check` — clean. `./vendor/bin/phpunit` — green, **490 tests** (+5). `composer phpstan` — No errors. `composer cs-fixer` — clean.
- **Live curl (logged-in admin):**
  - `GET /admin/anokii/transcribe?filter=all` → **200, 37242 B, 27 rows**, counter `25 / 27 transcribed`, no `/_nuxt/`.
  - `POST …/save` (authed, JSON) → `{"ok":true,"esid":1,"transcribed":true}`; write persisted (verified in DB).
  - `POST …/save` (no cookie) → **403**, no write.

Refs #853