### PR TITLE
feat(#854): bin/waaseyaa ingest:corpus — port ingest.py to write entities directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ storage/exports/
 !/phpstan-dead-code.neon
 !/phpstan-dead-code-baseline.neon
 !/phpunit.xml.dist
+/tests/storage/

--- a/docs/security/sql-entity-query-access-check-bypass-audit.md
+++ b/docs/security/sql-entity-query-access-check-bypass-audit.md
@@ -38,6 +38,9 @@ These sites never have an end-user `AccountInterface` available, or run after th
 | `src/Console/MessageDigestCommand.php` | 37 | Digest job runs from cron/queue; aggregates participants across all threads to build per-user summaries. Per-user filtering happens at digest-render time, not query time. | 2026-05-19 |
 | `src/Console/MessageDigestCommand.php` | 79 | Same digest aggregation — unread-message count per thread. | 2026-05-19 |
 | `src/Ingestion/IngestMaterializer.php` | 177 | NorthCloud ingest materializer dedupes existing entities across all communities. CLI-driven; no per-user view restriction makes sense. | 2026-05-19 |
+| `src/Http/Controller/Anokii/TranscribeController.php` | 127 | Anokii transcribe tool (#853/#854), gated to staff (admin,elder_coordinator) by the route. Must surface UNREVIEWED ingest drafts (status 0 / consent off) that an access-checked query would hide; the route's requireRole is the access boundary. | 2026-06-23 |
+| `src/Ingestion/Corpus/CorpusIngestor.php` | 60 | `ingest:corpus` (#854) dedup check on `source_sentence_id`. CLI-driven, no request account. | 2026-06-23 |
+| `src/Ingestion/Corpus/CorpusIngestor.php` | 135 | `ingest:corpus` (#854) speaker dedup on `code`. CLI-driven, no request account. | 2026-06-23 |
 | `src/Ingestion/IngestMaterializer.php` | 197 | Same materializer; ingest-log lookup. | 2026-05-19 |
 | `src/Infrastructure/Fixture/FixtureResolver.php` | 30 | Test/seed fixture resolver; resolves entities by name/key for fixture wiring. No user context. | 2026-05-19 |
 | `src/Infrastructure/Fixture/FixtureResolver.php` | 34 | Same. | 2026-05-19 |

--- a/src/Console/IngestCorpusHandler.php
+++ b/src/Console/IngestCorpusHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use App\Ingestion\Corpus\CorpusIngestor;
+use App\Ingestion\Corpus\IngestedReel;
+use Waaseyaa\CLI\Command\SymfonyCommandIO;
+
+/**
+ * `bin/waaseyaa ingest:corpus <manifest>` (#854).
+ *
+ * Reads a manifest of reels and ingests each into Minoo entities directly via
+ * {@see CorpusIngestor} — the PHP port of code/ingest/ingest.py. Entities are the
+ * system of record; no items/*.json is written.
+ *
+ * Manifest: one reel per line, `id,url[,YYYY-MM-DD]`; blank lines and `#`
+ * comments ignored. Example:
+ *   sb-034,https://www.facebook.com/reel/123,2026-06-20
+ *
+ * Prerequisite for the (non --dry-run, non --skip-vision) path: the muxed source
+ * video for each id must be at `<MINOO_CORPUS_PATH>/source-videos/<id>.mp4`
+ * (the Facebook pull drives a real browser and is run separately), and an LLM
+ * provider must be configured (ANTHROPIC_API_KEY) for the vision draft.
+ */
+final class IngestCorpusHandler
+{
+    public function __construct(
+        private readonly CorpusIngestor $ingestor,
+    ) {
+    }
+
+    public function execute(SymfonyCommandIO $io): int
+    {
+        $manifestPath = (string) $io->argument('manifest');
+        if (!is_file($manifestPath)) {
+            $io->error("Manifest not found: {$manifestPath}");
+            return 1;
+        }
+
+        $reels = $this->parseManifest((string) file_get_contents($manifestPath));
+        if ($reels === []) {
+            $io->error('Manifest has no reels (expected lines: id,url[,date]).');
+            return 1;
+        }
+
+        $dryRun = (bool) $io->option('dry-run');
+        $skipVision = (bool) $io->option('skip-vision');
+        $limitOpt = $io->option('limit');
+        $limit = is_numeric($limitOpt) ? max(1, (int) $limitOpt) : null;
+
+        if ($dryRun) {
+            $io->writeln('Dry run — no media fetched, no entities written.');
+        }
+
+        $result = $this->ingestor->ingest(
+            $reels,
+            $dryRun,
+            $skipVision,
+            $limit,
+            static function (string $line) use ($io): void {
+                $io->writeln($line);
+            },
+        );
+
+        $io->writeln(sprintf(
+            "\nDone. created=%d skipped=%d failed=%d",
+            $result->created,
+            $result->skipped,
+            $result->failed,
+        ));
+
+        return $result->failed > 0 ? 1 : 0;
+    }
+
+    /**
+     * @return list<IngestedReel>
+     */
+    private function parseManifest(string $raw): array
+    {
+        $reels = [];
+        foreach (preg_split('/\R/', $raw) ?: [] as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $parts = array_map('trim', explode(',', $line));
+            $id = $parts[0];
+            $url = $parts[1] ?? '';
+            if ($id === '' || $url === '') {
+                continue;
+            }
+
+            $reels[] = new IngestedReel(
+                id: $id,
+                url: $url,
+                sourceDate: $parts[2] ?? '',
+            );
+        }
+
+        return $reels;
+    }
+}

--- a/src/Http/Controller/Anokii/TranscribeController.php
+++ b/src/Http/Controller/Anokii/TranscribeController.php
@@ -44,7 +44,7 @@ final class TranscribeController
     {
         $showAll = ($request->query->get('filter') === 'all');
 
-        $rows = $this->corpusRows($account);
+        $rows = $this->corpusRows();
         $total = count($rows);
         $done = count(array_filter($rows, static fn (array $r): bool => $r['ojibwe_text'] !== '' && $r['english_text'] !== ''));
 
@@ -112,15 +112,19 @@ final class TranscribeController
      *
      * @return list<array{esid: int, ojibwe_text: string, english_text: string, notes: string, thumb_url: string, audio_url: string, source_url: string, corpus_id: string}>
      */
-    private function corpusRows(AccountInterface $account): array
+    private function corpusRows(): array
     {
         if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
             return [];
         }
 
         $storage = $this->entityTypeManager->getStorage('example_sentence');
+        // accessCheck(false): this is the transcribe tool, gated to staff by the
+        // route. It must surface UNREVIEWED drafts (status 0 / consent off) from
+        // ingest:corpus (#854) — which an access-checked query would hide. The
+        // route's requireRole is the access boundary. See the bypass audit doc.
         $ids = $storage->getQuery()
-            ->setAccount($account)
+            ->accessCheck(false)
             ->condition('source_sentence_id', 'corpus:%', 'LIKE')
             ->sort('source_sentence_id')
             ->execute();

--- a/src/Ingestion/Corpus/CorpusIngestor.php
+++ b/src/Ingestion/Corpus/CorpusIngestor.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Corpus ingest orchestration (#854) — the PHP port of code/ingest/ingest.py's
+ * per-reel pipeline, writing Minoo entities directly instead of JSON files.
+ *
+ * For each reel: fetch media (keyframe + opus) via {@see ReelFetcherInterface},
+ * draft the gloss via {@see WhiteboardReaderInterface} (unless --skip-vision),
+ * then materialize a `speaker` (deduped) and an `example_sentence` directly into
+ * entity storage. Entities are the system of record — no items/*.json is written.
+ *
+ * Newly ingested rows are unreviewed DRAFTS: status 0 and consent OFF, so they
+ * never reach public surfaces (which gate on status 1 + consent) until a
+ * reviewer transcribes/publishes them via the Anokii transcribe dashboard (#853).
+ *
+ * Idempotent: a reel whose `corpus:<id>` example_sentence already exists is
+ * skipped. The Ojibwe is stored EXACTLY as read — never normalized (ADR 0003).
+ */
+final class CorpusIngestor
+{
+    /** Credit: Steven Bennett's public profile, the source of every corpus reel. */
+    private const string STEVEN_PROFILE_URL = 'https://www.facebook.com/profile.php?id=61582894730998';
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly ReelFetcherInterface $fetcher,
+        private readonly WhiteboardReaderInterface $reader,
+    ) {
+    }
+
+    /**
+     * @param list<IngestedReel> $reels
+     * @param callable(string): void $log
+     */
+    public function ingest(array $reels, bool $dryRun, bool $skipVision, ?int $limit, callable $log): IngestResult
+    {
+        $sentences = $this->entityTypeManager->getStorage('example_sentence');
+        $speakers = $this->entityTypeManager->getStorage('speaker');
+
+        $created = 0;
+        $skipped = 0;
+        $failed = 0;
+        $processed = 0;
+
+        foreach ($reels as $reel) {
+            if ($limit !== null && $processed >= $limit) {
+                break;
+            }
+            ++$processed;
+
+            $sourceId = 'corpus:' . $reel->id;
+
+            $existing = $sentences->getQuery()->accessCheck(false)
+                ->condition('source_sentence_id', $sourceId)
+                ->range(0, 1)
+                ->execute();
+            if ($existing !== []) {
+                $log("[skip] {$reel->id} already ingested");
+                ++$skipped;
+                continue;
+            }
+
+            if ($dryRun) {
+                $log("[dry-run] would ingest {$reel->id} from {$reel->url}");
+                continue;
+            }
+
+            try {
+                $media = $this->fetcher->fetch($reel->url, $reel->id);
+
+                $draft = $skipVision
+                    ? ['ojibwe' => '', 'english' => '', 'notes' => 'skip_vision']
+                    : $this->reader->read($media['keyframe']);
+
+                $speakerId = $this->resolveSpeaker($speakers, $reel->contributor);
+
+                $entity = $sentences->create([
+                    // Stored verbatim — orthography is never normalized (ADR 0003).
+                    'ojibwe_text' => $draft['ojibwe'],
+                    'english_text' => $draft['english'],
+                    'notes' => $draft['notes'],
+                    'speaker_id' => $speakerId,
+                    'audio_url' => '/media/corpus/audio/' . $reel->id,
+                    'thumbnail_url' => '/media/corpus/thumb/' . $reel->id,
+                    'source_sentence_id' => $sourceId,
+                    'source_url' => $reel->url,
+                    'source_date' => $reel->sourceDate,
+                    'provenance' => (string) json_encode([
+                        'id' => $reel->id,
+                        'source_url' => $reel->url,
+                        'source_date' => $reel->sourceDate,
+                        'contributor' => $reel->contributor,
+                        'audio_path' => $media['audio'],
+                        'thumbnail_path' => $media['keyframe'],
+                        'vision_notes' => $draft['notes'],
+                    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+                    'language_code' => 'oj',
+                    // Unreviewed draft: off all public surfaces until published.
+                    'consent_public' => 0,
+                    'consent_ai_training' => 0,
+                    'status' => 0,
+                    'created_at' => time(),
+                    'updated_at' => time(),
+                ]);
+                $sentences->save($entity);
+                $log("[ingest] {$reel->id} -> example_sentence " . $entity->id() . ' (draft)');
+                ++$created;
+            } catch (\Throwable $e) {
+                $log("[fail] {$reel->id}: " . $e->getMessage());
+                ++$failed;
+            }
+        }
+
+        return new IngestResult($created, $skipped, $failed);
+    }
+
+    /**
+     * Find or create the speaker for a contributor name (deduped on initials),
+     * mirroring scripts/import-corpus.php.
+     */
+    private function resolveSpeaker(object $speakers, string $name): ?int
+    {
+        $code = strtolower(implode('', array_map(
+            static fn (string $part): string => mb_substr(trim($part), 0, 1),
+            array_filter(explode(' ', $name)),
+        )));
+
+        $ids = $speakers->getQuery()->accessCheck(false)->condition('code', $code)->range(0, 1)->execute();
+        if ($ids !== []) {
+            return (int) reset($ids);
+        }
+
+        $speaker = $speakers->create([
+            'name' => $name,
+            'code' => $code,
+            'slug' => strtolower(str_replace(' ', '-', trim($name))),
+            'bio' => sprintf('%s contributed this Anishinaabemowin corpus from public videos. Credit and source: %s', $name, self::STEVEN_PROFILE_URL),
+            'consent_public_display' => 1,
+            'consent_ai_training' => 1,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $speakers->save($speaker);
+
+        return $speaker instanceof EntityInterface ? (int) $speaker->id() : null;
+    }
+}

--- a/src/Ingestion/Corpus/FfmpegReelFetcher.php
+++ b/src/Ingestion/Corpus/FfmpegReelFetcher.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/**
+ * Produces a whiteboard keyframe + opus audio from a reel's source video using
+ * ffmpeg, mirroring code/ingest/ingest.py's extract_keyframe / extract_audio.
+ *
+ * The Facebook download itself (the Python tool drives a real Playwright browser
+ * because FB's page structure churns) stays an OPERATOR PREREQUISITE: place the
+ * muxed reel at `<corpus>/source-videos/<id>.mp4` first. This fetcher then does
+ * the deterministic ffmpeg stage. Nothing is committed to the repo — all media
+ * lives under MINOO_CORPUS_PATH.
+ */
+final class FfmpegReelFetcher implements ReelFetcherInterface
+{
+    public function __construct(
+        private readonly string $corpusPath,
+        private readonly string $ffmpegBinary = 'ffmpeg',
+        private readonly float $keyframeSeconds = 1.0,
+    ) {
+    }
+
+    public function fetch(string $reelUrl, string $itemId): array
+    {
+        $video = $this->corpusPath . '/source-videos/' . $itemId . '.mp4';
+        if (!is_file($video)) {
+            throw new ReelFetchException(sprintf(
+                'Source video not found: %s. Download the reel (%s) first — see the ingest:corpus help.',
+                $video,
+                $reelUrl,
+            ));
+        }
+
+        $thumb = $this->corpusPath . '/thumbs/' . $itemId . '.jpg';
+        $audio = $this->corpusPath . '/audio/' . $itemId . '.opus';
+        $this->ensureDir(dirname($thumb));
+        $this->ensureDir(dirname($audio));
+
+        // Keyframe a second in (skips the intro fade), then opus audio at 64k.
+        $this->run([$this->ffmpegBinary, '-y', '-ss', (string) $this->keyframeSeconds, '-i', $video, '-frames:v', '1', '-q:v', '3', $thumb]);
+        $this->run([$this->ffmpegBinary, '-y', '-i', $video, '-vn', '-c:a', 'libopus', '-b:a', '64k', $audio]);
+
+        if (!is_file($thumb) || !is_file($audio)) {
+            throw new ReelFetchException("ffmpeg did not produce media for {$itemId}.");
+        }
+
+        return ['keyframe' => $thumb, 'audio' => $audio];
+    }
+
+    private function ensureDir(string $dir): void
+    {
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw new ReelFetchException("Could not create directory: {$dir}");
+        }
+    }
+
+    /**
+     * @param list<string> $cmd
+     */
+    private function run(array $cmd): void
+    {
+        $command = implode(' ', array_map('escapeshellarg', $cmd)) . ' 2>&1';
+        exec($command, $output, $code);
+        if ($code !== 0) {
+            throw new ReelFetchException('ffmpeg failed: ' . implode("\n", $output));
+        }
+    }
+}

--- a/src/Ingestion/Corpus/IngestResult.php
+++ b/src/Ingestion/Corpus/IngestResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/** Tally of a corpus ingest run. */
+final readonly class IngestResult
+{
+    public function __construct(
+        public int $created,
+        public int $skipped,
+        public int $failed,
+    ) {
+    }
+}

--- a/src/Ingestion/Corpus/IngestedReel.php
+++ b/src/Ingestion/Corpus/IngestedReel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/**
+ * One reel to ingest: a corpus id + its source video URL, plus optional
+ * provenance the manifest may carry. Produced by parsing the ingest manifest.
+ */
+final readonly class IngestedReel
+{
+    public function __construct(
+        public string $id,
+        public string $url,
+        public string $sourceDate = '',
+        public string $contributor = 'Steven Bennett',
+    ) {
+    }
+}

--- a/src/Ingestion/Corpus/LlmWhiteboardReader.php
+++ b/src/Ingestion/Corpus/LlmWhiteboardReader.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+use Waaseyaa\AI\Agent\Provider\MessageRequest;
+use Waaseyaa\AI\Agent\Provider\ProviderInterface;
+
+/**
+ * Drafts the gloss from a whiteboard keyframe via the framework AI provider
+ * (Anthropic vision when ANTHROPIC_API_KEY is set), mirroring
+ * code/ingest/ingest.py's read_whiteboard.
+ *
+ * Degrades safely: if no real provider is configured (NullLlmProvider) or the
+ * response is not the expected JSON, it returns a blank draft with a note rather
+ * than throwing — the row is created as a draft for a human to complete (#853).
+ */
+final class LlmWhiteboardReader implements WhiteboardReaderInterface
+{
+    private const string PROMPT = <<<'TXT'
+        You're looking at a still frame from a teaching video. The whiteboard in the
+        frame should contain a single word or short phrase written in two languages:
+        English and Anishinaabemowin (Ojibwe).
+
+        Read the whiteboard. Return JSON with exactly these keys:
+          - "ojibwe": the Anishinaabemowin text, exactly as written
+          - "english": the English text, exactly as written
+          - "confidence": "high" | "medium" | "low"
+          - "notes": short note about anything unusual or empty string
+
+        Respond with ONLY the JSON object, no prose.
+        TXT;
+
+    public function __construct(
+        private readonly ProviderInterface $provider,
+    ) {
+    }
+
+    public function read(string $keyframePath): array
+    {
+        $blank = ['ojibwe' => '', 'english' => '', 'notes' => 'vision_unavailable'];
+
+        if (!is_file($keyframePath)) {
+            return $blank;
+        }
+
+        $imageB64 = base64_encode((string) file_get_contents($keyframePath));
+
+        try {
+            $response = $this->provider->sendMessage(new MessageRequest(
+                messages: [[
+                    'role' => 'user',
+                    'content' => [
+                        ['type' => 'image', 'source' => ['type' => 'base64', 'media_type' => 'image/jpeg', 'data' => $imageB64]],
+                        ['type' => 'text', 'text' => self::PROMPT],
+                    ],
+                ]],
+                maxTokens: 400,
+            ));
+
+            $parsed = $this->decode($response->getText());
+            if ($parsed === null) {
+                return $blank;
+            }
+
+            return [
+                // Verbatim — never normalized (ADR 0003).
+                'ojibwe' => (string) ($parsed['ojibwe'] ?? ''),
+                'english' => (string) ($parsed['english'] ?? ''),
+                'notes' => (string) ($parsed['notes'] ?? ''),
+            ];
+        } catch (\Throwable) {
+            return $blank;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decode(string $text): ?array
+    {
+        $text = trim($text);
+        // Strip a ```json fenced block if the model added one.
+        if (str_starts_with($text, '```')) {
+            $text = (string) preg_replace('/^```[a-z]*\n?|\n?```$/i', '', $text);
+            $text = trim($text);
+        }
+
+        $decoded = json_decode($text, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/src/Ingestion/Corpus/ReelFetchException.php
+++ b/src/Ingestion/Corpus/ReelFetchException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/** Raised when a reel's media cannot be produced (download or ffmpeg failure). */
+final class ReelFetchException extends \RuntimeException
+{
+}

--- a/src/Ingestion/Corpus/ReelFetcherInterface.php
+++ b/src/Ingestion/Corpus/ReelFetcherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/**
+ * Fetches a reel's media into the corpus directory: a whiteboard keyframe and an
+ * audio clip. The Facebook download + ffmpeg muxing live behind this seam so the
+ * ingest orchestration ({@see CorpusIngestor}) can be tested without network or
+ * system tools.
+ */
+interface ReelFetcherInterface
+{
+    /**
+     * @return array{keyframe: string, audio: string} absolute paths under the corpus dir
+     *
+     * @throws ReelFetchException when the media could not be produced
+     */
+    public function fetch(string $reelUrl, string $itemId): array;
+}

--- a/src/Ingestion/Corpus/WhiteboardReaderInterface.php
+++ b/src/Ingestion/Corpus/WhiteboardReaderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/**
+ * Drafts the Ojibwe + English gloss from a whiteboard keyframe via a vision LLM.
+ * Behind a seam so ingest can run (and be tested) without an LLM provider.
+ */
+interface WhiteboardReaderInterface
+{
+    /**
+     * @return array{ojibwe: string, english: string, notes: string}
+     *         Best-effort draft; blank strings when the reader cannot determine a value.
+     *         The Ojibwe is returned exactly as read — never normalized (ADR 0003).
+     */
+    public function read(string $keyframePath): array;
+}

--- a/src/Provider/AppCommandServiceProvider.php
+++ b/src/Provider/AppCommandServiceProvider.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
+use App\Console\IngestCorpusHandler;
 use App\Console\MailTestHandler;
+use App\Ingestion\Corpus\CorpusIngestor;
+use App\Ingestion\Corpus\FfmpegReelFetcher;
+use App\Ingestion\Corpus\LlmWhiteboardReader;
+use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\CLI\Command\HandlerArgument;
 use Waaseyaa\CLI\Command\HandlerArgumentMode;
 use Waaseyaa\CLI\Command\HandlerCommand;
+use Waaseyaa\CLI\Command\HandlerOption;
+use Waaseyaa\CLI\Command\HandlerOptionMode;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\Capability\ProvidesConsoleCommandsInterface;
 use Waaseyaa\Mail\MailerInterface;
 
@@ -29,6 +37,17 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                 $fromAddress,
             );
         });
+
+        $this->singleton(IngestCorpusHandler::class, function (): IngestCorpusHandler {
+            $corpusPath = $this->corpusPath();
+            return new IngestCorpusHandler(
+                new CorpusIngestor(
+                    $this->resolve(EntityTypeManager::class),
+                    new FfmpegReelFetcher($corpusPath),
+                    new LlmWhiteboardReader($this->resolve(ProviderInterface::class)),
+                ),
+            );
+        });
     }
 
     public function consoleCommands(): iterable
@@ -45,6 +64,36 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                 ),
             ],
         );
+
+        yield new HandlerCommand(
+            name: 'ingest:corpus',
+            description: 'Ingest reels from a manifest into example_sentence + speaker entities (port of code/ingest/ingest.py)',
+            handler: [IngestCorpusHandler::class, 'execute'],
+            arguments: [
+                new HandlerArgument(
+                    name: 'manifest',
+                    mode: HandlerArgumentMode::Required,
+                    description: 'Path to the reel manifest (lines: id,url[,YYYY-MM-DD])',
+                ),
+            ],
+            options: [
+                new HandlerOption(
+                    name: 'dry-run',
+                    mode: HandlerOptionMode::None,
+                    description: 'Preview without fetching media or writing entities',
+                ),
+                new HandlerOption(
+                    name: 'skip-vision',
+                    mode: HandlerOptionMode::None,
+                    description: 'Do not call the vision LLM; leave Ojibwe/English blank for manual transcription',
+                ),
+                new HandlerOption(
+                    name: 'limit',
+                    mode: HandlerOptionMode::Required,
+                    description: 'Ingest at most N reels',
+                ),
+            ],
+        );
     }
 
     /**
@@ -58,5 +107,19 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
             && $fromAddress !== '';
 
         return [$configured, $fromAddress];
+    }
+
+    /**
+     * Community-controlled corpus directory (never committed). Override with
+     * MINOO_CORPUS_PATH; mirrors the controllers' default.
+     */
+    private function corpusPath(): string
+    {
+        $env = getenv('MINOO_CORPUS_PATH');
+        if (is_string($env) && $env !== '') {
+            return rtrim($env, '/\\');
+        }
+
+        return 'C:/Users/jones/Projects/LLC/anishinaabemowin/content/corpus';
     }
 }

--- a/tests/App/Integration/Console/IngestCorpusTest.php
+++ b/tests/App/Integration/Console/IngestCorpusTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Console;
+
+use App\Ingestion\Corpus\CorpusIngestor;
+use App\Ingestion\Corpus\IngestedReel;
+use App\Ingestion\Corpus\ReelFetcherInterface;
+use App\Ingestion\Corpus\ReelFetchException;
+use App\Ingestion\Corpus\WhiteboardReaderInterface;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * `ingest:corpus` core (#854): the orchestration writes example_sentence +
+ * speaker entities directly (network + LLM mocked), as unreviewed drafts;
+ * --dry-run writes nothing; --skip-vision leaves the gloss blank; re-runs dedup.
+ *
+ * The live Facebook pull + vision LLM are NOT exercised here (no creds/network);
+ * the ReelFetcher and WhiteboardReader are faked behind their interfaces. Boots a
+ * real kernel (in-memory SQLite) for genuine entity storage.
+ */
+#[CoversClass(CorpusIngestor::class)]
+final class IngestCorpusTest extends HttpKernelTestCase
+{
+    private function etm(): EntityTypeManager
+    {
+        return self::$kernel->getEntityTypeManager();
+    }
+
+    private function ingestor(ReelFetcherInterface $fetcher, WhiteboardReaderInterface $reader): CorpusIngestor
+    {
+        return new CorpusIngestor($this->etm(), $fetcher, $reader);
+    }
+
+    private function noop(): callable
+    {
+        return static function (string $line): void {
+        };
+    }
+
+    /** @return list<int> example_sentence ids matching the given corpus ids */
+    private function sentenceIds(string $likeId): array
+    {
+        return $this->etm()->getStorage('example_sentence')->getQuery()->accessCheck(false)
+            ->condition('source_sentence_id', $likeId, 'LIKE')
+            ->execute();
+    }
+
+    #[Test]
+    public function ingest_writes_draft_entities_with_mocked_pipeline(): void
+    {
+        $fetcher = new FakeReelFetcher();
+        $reader = new FakeWhiteboardReader(['ojibwe' => 'Zhooniyaans', 'english' => 'coin', 'notes' => 'high']);
+
+        $result = $this->ingestor($fetcher, $reader)->ingest(
+            [new IngestedReel('sb-901', 'https://fb/reel/901', '2026-06-20'), new IngestedReel('sb-902', 'https://fb/reel/902')],
+            dryRun: false,
+            skipVision: false,
+            limit: null,
+            log: $this->noop(),
+        );
+
+        self::assertSame(2, $result->created);
+        self::assertSame(0, $result->failed);
+
+        $ids = $this->sentenceIds('corpus:sb-90%');
+        self::assertCount(2, $ids);
+
+        $entity = $this->etm()->getStorage('example_sentence')->load(reset($ids));
+        self::assertSame('Zhooniyaans', (string) $entity->get('ojibwe_text'));
+        self::assertSame('coin', (string) $entity->get('english_text'));
+        self::assertSame('/media/corpus/audio/sb-901', (string) $entity->get('audio_url'));
+        self::assertSame('/media/corpus/thumb/sb-901', (string) $entity->get('thumbnail_url'));
+        self::assertSame('https://fb/reel/901', (string) $entity->get('source_url'));
+        // Unreviewed draft: off public surfaces.
+        self::assertSame(0, (int) $entity->get('status'));
+        self::assertSame(0, (int) $entity->get('consent_public'));
+
+        // Exactly one speaker (Steven Bennett, deduped) across both rows.
+        $speakers = $this->etm()->getStorage('speaker')->getQuery()->accessCheck(false)->condition('code', 'sb')->execute();
+        self::assertCount(1, $speakers);
+    }
+
+    #[Test]
+    public function dry_run_writes_nothing(): void
+    {
+        $result = $this->ingestor(new FakeReelFetcher(), new FakeWhiteboardReader([]))->ingest(
+            [new IngestedReel('sb-911', 'https://fb/reel/911')],
+            dryRun: true,
+            skipVision: false,
+            limit: null,
+            log: $this->noop(),
+        );
+
+        self::assertSame(0, $result->created);
+        self::assertSame([], $this->sentenceIds('corpus:sb-911'));
+    }
+
+    #[Test]
+    public function skip_vision_leaves_the_gloss_blank(): void
+    {
+        // Reader would return text, but --skip-vision must bypass it entirely.
+        $result = $this->ingestor(new FakeReelFetcher(), new FakeWhiteboardReader(['ojibwe' => 'X', 'english' => 'Y']))->ingest(
+            [new IngestedReel('sb-921', 'https://fb/reel/921')],
+            dryRun: false,
+            skipVision: true,
+            limit: null,
+            log: $this->noop(),
+        );
+
+        self::assertSame(1, $result->created);
+        $ids = $this->sentenceIds('corpus:sb-921');
+        $entity = $this->etm()->getStorage('example_sentence')->load(reset($ids));
+        self::assertSame('', (string) $entity->get('ojibwe_text'));
+        self::assertSame('', (string) $entity->get('english_text'));
+        self::assertSame('skip_vision', (string) $entity->get('notes'));
+    }
+
+    #[Test]
+    public function re_running_dedups_on_source_sentence_id(): void
+    {
+        $reels = [new IngestedReel('sb-931', 'https://fb/reel/931')];
+        $first = $this->ingestor(new FakeReelFetcher(), new FakeWhiteboardReader(['ojibwe' => 'a', 'english' => 'b']))->ingest($reels, false, false, null, $this->noop());
+        $second = $this->ingestor(new FakeReelFetcher(), new FakeWhiteboardReader(['ojibwe' => 'a', 'english' => 'b']))->ingest($reels, false, false, null, $this->noop());
+
+        self::assertSame(1, $first->created);
+        self::assertSame(0, $second->created);
+        self::assertSame(1, $second->skipped);
+        self::assertCount(1, $this->sentenceIds('corpus:sb-931'));
+    }
+
+    #[Test]
+    public function a_fetch_failure_is_counted_and_does_not_abort_the_run(): void
+    {
+        $fetcher = new FakeReelFetcher(failIds: ['sb-941']);
+        $result = $this->ingestor($fetcher, new FakeWhiteboardReader(['ojibwe' => 'ok', 'english' => 'ok']))->ingest(
+            [new IngestedReel('sb-941', 'https://fb/reel/941'), new IngestedReel('sb-942', 'https://fb/reel/942')],
+            dryRun: false,
+            skipVision: false,
+            limit: null,
+            log: $this->noop(),
+        );
+
+        self::assertSame(1, $result->created);
+        self::assertSame(1, $result->failed);
+        self::assertSame([], $this->sentenceIds('corpus:sb-941'));
+        self::assertCount(1, $this->sentenceIds('corpus:sb-942'));
+    }
+}
+
+/** Fake fetcher: writes throwaway media to a temp dir, or throws for designated ids. */
+final class FakeReelFetcher implements ReelFetcherInterface
+{
+    /** @param list<string> $failIds */
+    public function __construct(private readonly array $failIds = [])
+    {
+    }
+
+    public function fetch(string $reelUrl, string $itemId): array
+    {
+        if (in_array($itemId, $this->failIds, true)) {
+            throw new ReelFetchException("mock fetch failure for {$itemId}");
+        }
+
+        $dir = sys_get_temp_dir() . '/minoo_ingest_test';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+        $keyframe = $dir . '/' . $itemId . '.jpg';
+        $audio = $dir . '/' . $itemId . '.opus';
+        file_put_contents($keyframe, 'jpg');
+        file_put_contents($audio, 'opus');
+
+        return ['keyframe' => $keyframe, 'audio' => $audio];
+    }
+}
+
+/** Fake reader: returns a fixed draft (no LLM). */
+final class FakeWhiteboardReader implements WhiteboardReaderInterface
+{
+    /** @param array<string, string> $draft */
+    public function __construct(private readonly array $draft)
+    {
+    }
+
+    public function read(string $keyframePath): array
+    {
+        return [
+            'ojibwe' => $this->draft['ojibwe'] ?? '',
+            'english' => $this->draft['english'] ?? '',
+            'notes' => $this->draft['notes'] ?? '',
+        ];
+    }
+}


### PR DESCRIPTION
Ports `code/ingest/ingest.py`'s per-reel pipeline (FB reel → ffmpeg keyframe + `.opus` → vision-LLM gloss draft) into a native CLI command that materializes `example_sentence` + `speaker` entities **directly** — entities are the system of record, no `items/*.json` is written. Builds on #852/#853.

## What landed
- **`bin/waaseyaa ingest:corpus <manifest> [--dry-run] [--skip-vision] [--limit=N]`** — manifest is `id,url[,YYYY-MM-DD]` per line.
- **`App\Ingestion\Corpus\CorpusIngestor`** — orchestration: per reel, fetch media → draft gloss → write a deduped `speaker` + an `example_sentence` as an **unreviewed DRAFT** (status 0, consent off) so it stays off public surfaces until a reviewer transcribes/publishes it (#853). Ojibwe stored verbatim (ADR 0003). Idempotent on `source_sentence_id`.
- **Seams** (testable, no network/LLM in CI):
  - `ReelFetcherInterface` → `FfmpegReelFetcher` shells ffmpeg over a pre-downloaded source video. The Facebook browser-pull stays an **operator prerequisite**, exactly as the Python tool (which drives a real browser because FB churns).
  - `WhiteboardReaderInterface` → `LlmWhiteboardReader` uses the framework AI `ProviderInterface` (Anthropic vision); degrades to a blank draft when no provider is configured.
- **`TranscribeController`** now queries `accessCheck(false)` (staff-gated tool) so ingest **drafts** surface for review — documented in the bypass audit doc.

## Honest scope
Live scraping + the vision LLM were **not** run here (no creds/network). The command is unit-tested with the fetcher/reader faked and the entity-write path fully asserted; `--dry-run` was verified live to parse the manifest and write nothing.

## Verification
- `bin/waaseyaa schema:check` — clean. `./vendor/bin/phpunit` — green, **495 tests** (+5). `composer phpstan` — No errors. `composer cs-fixer` — clean.
- `bin/waaseyaa ingest:corpus` registered and listed.
- **Live `--dry-run`:** parsed a 2-reel manifest, reported `would ingest` for each, `created=0`; 0 rows written (verified in DB).
- Tests: creates draft entities (mocked pipeline); `--dry-run` writes nothing; `--skip-vision` leaves the gloss blank; re-run dedups; a fetch failure is counted without aborting.

Refs #854