### PR TITLE
feat(#855): curation tab — promote utterances into dictionary_entry/word_part

### DIFF
--- a/docs/security/sql-entity-query-access-check-bypass-audit.md
+++ b/docs/security/sql-entity-query-access-check-bypass-audit.md
@@ -41,6 +41,7 @@ These sites never have an end-user `AccountInterface` available, or run after th
 | `src/Http/Controller/Anokii/TranscribeController.php` | 127 | Anokii transcribe tool (#853/#854), gated to staff (admin,elder_coordinator) by the route. Must surface UNREVIEWED ingest drafts (status 0 / consent off) that an access-checked query would hide; the route's requireRole is the access boundary. | 2026-06-23 |
 | `src/Ingestion/Corpus/CorpusIngestor.php` | 60 | `ingest:corpus` (#854) dedup check on `source_sentence_id`. CLI-driven, no request account. | 2026-06-23 |
 | `src/Ingestion/Corpus/CorpusIngestor.php` | 135 | `ingest:corpus` (#854) speaker dedup on `code`. CLI-driven, no request account. | 2026-06-23 |
+| `src/Http/Controller/Anokii/CurateController.php` | 88 | Anokii curate tool (#855), gated to staff by the route. Must surface drafts to promote; the route's requireRole is the access boundary. | 2026-06-23 |
 | `src/Ingestion/IngestMaterializer.php` | 197 | Same materializer; ingest-log lookup. | 2026-05-19 |
 | `src/Infrastructure/Fixture/FixtureResolver.php` | 30 | Test/seed fixture resolver; resolves entities by name/key for fixture wiring. No user context. | 2026-05-19 |
 | `src/Infrastructure/Fixture/FixtureResolver.php` | 34 | Same. | 2026-05-19 |

--- a/src/Http/Controller/Anokii/CurateController.php
+++ b/src/Http/Controller/Anokii/CurateController.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use App\Http\View\AnokiiShellContext;
+use App\Ingestion\Curation\UtterancePromoter;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+
+/**
+ * Curation tab (#855) — promotes corpus utterances into structured vocabulary
+ * (dictionary_entry + word_part) inside the Anokii shell.
+ *
+ * Lists corpus example_sentence rows with a "Promote" action; promoting creates
+ * a dictionary_entry (and word_parts for multi-word phrases) via
+ * {@see UtterancePromoter} and links the sentence back. Both routes are
+ * role-gated (admin / elder_coordinator) by {@see \App\Provider\Routing\AnokiiRouteProvider}.
+ * Ojibwe is carried verbatim — never normalized (ADR 0003).
+ */
+final class CurateController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $rows = $this->rows();
+        $promoted = count(array_filter($rows, static fn (array $r): bool => $r['promoted']));
+
+        $html = $this->twig->render('pages/anokii/curate.html.twig', AnokiiShellContext::build($account, 'curate', [
+            'path' => $request->getPathInfo(),
+            'rows' => $rows,
+            'total' => count($rows),
+            'promoted' => $promoted,
+            'promote_url' => '/admin/anokii/curate/promote',
+            'csrf_token' => CsrfMiddleware::token(),
+        ]));
+
+        return new Response($html);
+    }
+
+    public function promote(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->readBody($request);
+        $esid = (int) ($data['esid'] ?? 0);
+        if ($esid <= 0) {
+            return $this->json(['ok' => false, 'error' => 'Missing esid.'], 422);
+        }
+
+        $result = (new UtterancePromoter($this->entityTypeManager))->promote($esid);
+        if ($result === null) {
+            return $this->json(['ok' => false, 'error' => 'Not found or empty.'], 404);
+        }
+
+        return $this->json([
+            'ok' => true,
+            'esid' => $esid,
+            'dictionary_entry_id' => $result->dictionaryEntryId,
+            'word_parts' => $result->wordPartIds,
+            'created' => $result->created,
+        ]);
+    }
+
+    /**
+     * @return list<array{esid: int, ojibwe_text: string, english_text: string, promoted: bool, dictionary_entry_id: int, parts: int}>
+     */
+    private function rows(): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        // accessCheck(false): staff-gated curation tool; must show drafts too.
+        // The route's requireRole is the access boundary. See the bypass audit doc.
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->sort('source_sentence_id')
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($storage->loadMultiple($ids) as $entity) {
+            $word = (string) $entity->get('ojibwe_text');
+            $deid = (int) ($entity->get('dictionary_entry_id') ?? 0);
+            $rows[] = [
+                'esid' => (int) $entity->id(),
+                'ojibwe_text' => $word,
+                'english_text' => (string) $entity->get('english_text'),
+                'promoted' => $deid > 0,
+                'dictionary_entry_id' => $deid,
+                'parts' => count(preg_split('/\s+/', trim($word), -1, PREG_SPLIT_NO_EMPTY) ?: []),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readBody(HttpRequest $request): array
+    {
+        $raw = trim((string) $request->getContent());
+        if ($raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return $request->request->all();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload, int $status = 200): Response
+    {
+        return new Response(
+            (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            $status,
+            ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/src/Http/View/AnokiiShellContext.php
+++ b/src/Http/View/AnokiiShellContext.php
@@ -37,8 +37,8 @@ final class AnokiiShellContext
     }
 
     /**
-     * Sidebar nav. Transcribe is live (#853); Ingest (#854) and Curate (#855)
-     * are still placeholders flagged "Soon".
+     * Sidebar nav. Transcribe (#853) and Curate (#855) are live; Ingest (#854)
+     * is a CLI command (bin/waaseyaa ingest:corpus), so it has no tab.
      *
      * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
      */
@@ -47,8 +47,7 @@ final class AnokiiShellContext
         return [
             ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
             ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '/admin/anokii/transcribe', 'group' => 'Language'],
-            ['id' => 'ingest', 'label' => 'Ingest', 'href' => '#', 'badge' => 'Soon'],
-            ['id' => 'curate', 'label' => 'Curate', 'href' => '#', 'badge' => 'Soon'],
+            ['id' => 'curate', 'label' => 'Curate', 'href' => '/admin/anokii/curate'],
         ];
     }
 

--- a/src/Ingestion/Curation/PromotionResult.php
+++ b/src/Ingestion/Curation/PromotionResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Curation;
+
+/** Outcome of promoting one utterance into vocabulary. */
+final readonly class PromotionResult
+{
+    /**
+     * @param list<int> $wordPartIds
+     */
+    public function __construct(
+        public int $dictionaryEntryId,
+        public array $wordPartIds,
+        public bool $created,
+    ) {
+    }
+}

--- a/src/Ingestion/Curation/UtterancePromoter.php
+++ b/src/Ingestion/Curation/UtterancePromoter.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Curation;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Promotes a corpus utterance (an example_sentence) into structured vocabulary
+ * (#855): a `dictionary_entry` (word ← Ojibwe, definition ← English) plus a
+ * `word_part` per whitespace token for multi-word phrases. The source sentence
+ * is linked back via `dictionary_entry_id`.
+ *
+ * Consent + publication state are COPIED from the source sentence, so an
+ * unreviewed draft promotes to a draft entry and never leaks to public surfaces.
+ * Ojibwe is carried verbatim — never normalized (ADR 0003). Idempotent: a
+ * sentence already linked to a dictionary_entry is returned unchanged.
+ */
+final class UtterancePromoter
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {
+    }
+
+    public function promote(int $esid): ?PromotionResult
+    {
+        $sentences = $this->entityTypeManager->getStorage('example_sentence');
+        $sentence = $sentences->load($esid);
+        if (!$sentence instanceof EntityInterface) {
+            return null;
+        }
+
+        $existing = (int) ($sentence->get('dictionary_entry_id') ?? 0);
+        if ($existing > 0) {
+            return new PromotionResult($existing, [], false);
+        }
+
+        $word = (string) $sentence->get('ojibwe_text');
+        if (trim($word) === '') {
+            return null;
+        }
+        $definition = (string) $sentence->get('english_text');
+        $sourceUrl = (string) $sentence->get('source_url');
+        $consentPublic = (int) ($sentence->get('consent_public') ?? 0);
+        $status = (int) ($sentence->get('status') ?? 0);
+        $now = time();
+
+        $entries = $this->entityTypeManager->getStorage('dictionary_entry');
+        $entry = $entries->create([
+            // Verbatim — never normalized (ADR 0003).
+            'word' => $word,
+            'slug' => $this->slugify($word),
+            'definition' => $definition,
+            'language_code' => 'oj',
+            'source_url' => $sourceUrl,
+            'attribution_source' => 'corpus',
+            'attribution_url' => $sourceUrl,
+            'consent_public' => $consentPublic,
+            'consent_ai_training' => (int) ($sentence->get('consent_ai_training') ?? 0),
+            'status' => $status,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $entries->save($entry);
+        $deid = (int) $entry->id();
+
+        // Decompose a multi-word phrase into one word_part per token.
+        $wordPartIds = [];
+        $tokens = preg_split('/\s+/', trim($word), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        if (count($tokens) > 1) {
+            $parts = $this->entityTypeManager->getStorage('word_part');
+            foreach ($tokens as $token) {
+                $part = $parts->create([
+                    'form' => $token,
+                    'slug' => $this->slugify($token),
+                    'type' => '',
+                    'definition' => '',
+                    'source_url' => $sourceUrl,
+                    'status' => $status,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+                $parts->save($part);
+                $wordPartIds[] = (int) $part->id();
+            }
+        }
+
+        // Link the source sentence back to the new entry.
+        $sentence->set('dictionary_entry_id', $deid);
+        $sentence->set('updated_at', $now);
+        $sentences->save($sentence);
+
+        return new PromotionResult($deid, $wordPartIds, true);
+    }
+
+    private function slugify(string $value): string
+    {
+        $slug = strtolower(trim($value));
+        $slug = (string) preg_replace('/[^a-z0-9]+/u', '-', $slug);
+
+        return trim($slug, '-');
+    }
+}

--- a/src/Provider/Routing/AnokiiRouteProvider.php
+++ b/src/Provider/Routing/AnokiiRouteProvider.php
@@ -70,6 +70,28 @@ final class AnokiiRouteProvider extends AppCoreServiceProvider
                 ->build(),
         );
 
+        // Curate tab (#855): promote utterances into dictionary_entry / word_part.
+        $router->addRoute(
+            'anokii.curate',
+            RouteBuilder::create('/admin/anokii/curate')
+                ->controller('App\Http\Controller\Anokii\CurateController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'anokii.curate.promote',
+            RouteBuilder::create('/admin/anokii/curate/promote')
+                ->controller('App\Http\Controller\Anokii\CurateController::promote')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->methods('POST')
+                ->build(),
+        );
+
         // Forward-looking: future workspace tabs live under /admin/anokii/{sub}.
         // All currently resolve to the same landing shell. The requirement keeps
         // this off the admin-surface `_surface` API namespace.

--- a/templates/pages/anokii/curate.html.twig
+++ b/templates/pages/anokii/curate.html.twig
@@ -1,0 +1,99 @@
+{#
+  Curate dashboard (#855) — rendered into the Anokii shell (never forks it).
+
+  Lists corpus utterances and promotes each into a dictionary_entry (+ word_parts
+  for multi-word phrases) via POST /admin/anokii/curate/promote. The Ojibwe is
+  carried verbatim (ADR 0003).
+#}
+{% extends "@anokii/_shell.html.twig" %}
+
+{% block title %}Curate — Minoo Language Workspace{% endblock %}
+
+{% block shell_styles %}
+  {{ anokii_theme_css|default('')|raw }}
+  .cu-head{ display:flex; align-items:baseline; gap:16px; flex-wrap:wrap; margin-bottom:18px; }
+  .cu-head h1{ font-size:1.5rem; }
+  .cu-counter{ color:var(--anokii-shell-muted); font-variant-numeric:tabular-nums; }
+  .cu-table{ width:100%; border-collapse:collapse; }
+  .cu-table th, .cu-table td{ text-align:left; padding:10px 12px; border-bottom:1px solid var(--anokii-shell-line); vertical-align:middle; }
+  .cu-table th{ font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--anokii-shell-muted); }
+  .cu-oj{ font-weight:600; }
+  .cu-en{ color:var(--anokii-shell-muted); }
+  .cu-badge{ font-size:11px; font-weight:700; border-radius:20px; padding:2px 9px; background:var(--anokii-shell-accent); color:var(--anokii-shell-accent-ink); }
+  .cu-promote{ font:inherit; cursor:pointer; border:1px solid var(--anokii-shell-accent); color:var(--anokii-shell-accent); background:transparent; border-radius:8px; padding:6px 12px; }
+  .cu-promote:hover{ background:var(--anokii-shell-accent); color:var(--anokii-shell-accent-ink); }
+  .cu-status{ font-size:12px; color:var(--anokii-shell-muted); }
+  .cu-status.error{ color:#c0392b; }
+  .cu-empty{ padding:28px; border:1px dashed var(--anokii-shell-line); border-radius:12px; color:var(--anokii-shell-muted); }
+{% endblock %}
+
+{% block content %}
+  <div class="cu-head" data-promote-url="{{ promote_url }}" data-csrf="{{ csrf_token }}" id="cu-dash">
+    <h1>Curate</h1>
+    <span class="cu-counter"><b id="cu-done">{{ promoted }}</b> / {{ total }} promoted to vocabulary</span>
+  </div>
+
+  {% if rows is empty %}
+    <div class="cu-empty">No corpus utterances to curate yet. Run <code>bin/waaseyaa ingest:corpus</code> or import the corpus first.</div>
+  {% else %}
+    <table class="cu-table">
+      <thead><tr><th>Anishinaabemowin</th><th>English</th><th>Vocabulary</th><th></th></tr></thead>
+      <tbody>
+        {% for row in rows %}
+          <tr data-esid="{{ row.esid }}">
+            <td class="cu-oj">{{ row.ojibwe_text }}</td>
+            <td class="cu-en">{{ row.english_text }}</td>
+            <td class="cu-vocab">
+              {% if row.promoted %}
+                <span class="cu-badge">entry #{{ row.dictionary_entry_id }}</span>
+              {% else %}
+                <span class="cu-status">—</span>
+              {% endif %}
+            </td>
+            <td class="cu-action">
+              {% if not row.promoted %}
+                <button type="button" class="cu-promote">Promote{% if row.parts > 1 %} ({{ row.parts }} parts){% endif %}</button>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endblock %}
+
+{% block page_scripts %}
+<script>
+(function () {
+  var dash = document.getElementById('cu-dash');
+  if (!dash) return;
+  var url = dash.getAttribute('data-promote-url');
+  var csrf = dash.getAttribute('data-csrf');
+  var doneEl = document.getElementById('cu-done');
+
+  document.querySelectorAll('.cu-promote').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var row = btn.closest('tr');
+      var esid = parseInt(row.getAttribute('data-esid'), 10);
+      btn.disabled = true;
+      btn.textContent = 'Promoting…';
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ esid: esid })
+      }).then(function (r) {
+        return r.ok ? r.json() : Promise.reject(r.status);
+      }).then(function (data) {
+        var cell = row.querySelector('.cu-vocab');
+        cell.innerHTML = '<span class="cu-badge">entry #' + data.dictionary_entry_id + '</span>';
+        row.querySelector('.cu-action').innerHTML = '';
+        if (doneEl) { doneEl.textContent = (parseInt(doneEl.textContent, 10) || 0) + 1; }
+      }).catch(function () {
+        btn.disabled = false;
+        btn.textContent = 'Retry';
+      });
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/templates/pages/anokii/index.html.twig
+++ b/templates/pages/anokii/index.html.twig
@@ -38,7 +38,7 @@
 
   <div class="anokii-soon">
     <div class="card"><b><a href="/admin/anokii/transcribe" style="color:var(--anokii-shell-accent)">Transcribe →</a></b><small>Whiteboard cards → entries.</small></div>
-    <div class="card"><b>Ingest</b><small>Pull new reels into the corpus. Coming soon.</small></div>
-    <div class="card"><b>Curate</b><small>Promote utterances into lessons. Coming soon.</small></div>
+    <div class="card"><b><a href="/admin/anokii/curate" style="color:var(--anokii-shell-accent)">Curate →</a></b><small>Promote utterances into vocabulary.</small></div>
+    <div class="card"><b>Ingest</b><small>CLI: <code>bin/waaseyaa ingest:corpus</code>.</small></div>
   </div>
 {% endblock %}

--- a/tests/App/Integration/Http/Admin/AnokiiCurateTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiCurateTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Ingestion\Curation\UtterancePromoter;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Curation (#855): UtterancePromoter materializes dictionary_entry + word_part
+ * from an utterance (verbatim, consent copied, idempotent), and the Anokii
+ * curate tab + promote API are role-gated.
+ */
+#[CoversNothing]
+final class AnokiiCurateTest extends HttpKernelTestCase
+{
+    private const string CSRF = 'curate-test-csrf-token';
+    private static int $adminUid = 0;
+    private static int $phraseEsid = 0;
+    private static int $wordEsid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        $etm = self::$kernel->getEntityTypeManager();
+
+        $admin = $etm->getStorage('user')->create(['name' => 'Curate Admin', 'mail' => 'curate-admin@example.test', 'status' => true, 'created' => time(), 'roles' => ['admin'], 'permissions' => []]);
+        $etm->getStorage('user')->save($admin);
+        self::$adminUid = (int) $admin->id();
+
+        $sentences = $etm->getStorage('example_sentence');
+
+        // Multi-word phrase, published + consented.
+        $phrase = $sentences->create([
+            'ojibwe_text' => 'Shoogan Mookman',
+            'english_text' => 'butter knife',
+            'source_sentence_id' => 'corpus:sb-c1',
+            'source_url' => 'https://fb/reel/c1',
+            'consent_public' => 1,
+            'consent_ai_training' => 0,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($phrase);
+        self::$phraseEsid = (int) $phrase->id();
+
+        // Single word.
+        $single = $sentences->create([
+            'ojibwe_text' => 'Zhooniyaans',
+            'english_text' => 'coin',
+            'source_sentence_id' => 'corpus:sb-c2',
+            'consent_public' => 1,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($single);
+        self::$wordEsid = (int) $single->id();
+    }
+
+    private function promoter(): UtterancePromoter
+    {
+        return new UtterancePromoter(self::$kernel->getEntityTypeManager());
+    }
+
+    #[Test]
+    public function promote_creates_dictionary_entry_and_word_parts_verbatim(): void
+    {
+        $result = $this->promoter()->promote(self::$phraseEsid);
+
+        self::assertNotNull($result);
+        self::assertTrue($result->created);
+        self::assertCount(2, $result->wordPartIds, 'Two-word phrase yields two word_parts.');
+
+        $etm = self::$kernel->getEntityTypeManager();
+        $entry = $etm->getStorage('dictionary_entry')->load($result->dictionaryEntryId);
+        self::assertNotNull($entry);
+        self::assertSame('Shoogan Mookman', (string) $entry->get('word'), 'Ojibwe stored verbatim.');
+        self::assertSame('butter knife', (string) $entry->get('definition'));
+        // Consent + publication copied from the source sentence.
+        self::assertSame(1, (int) $entry->get('consent_public'));
+        self::assertSame(1, (int) $entry->get('status'));
+
+        // word_part forms are the two tokens.
+        $forms = [];
+        foreach ($result->wordPartIds as $wpid) {
+            $forms[] = (string) $etm->getStorage('word_part')->load($wpid)->get('form');
+        }
+        sort($forms);
+        self::assertSame(['Mookman', 'Shoogan'], $forms);
+
+        // Source sentence linked back.
+        $sentence = $etm->getStorage('example_sentence')->load(self::$phraseEsid);
+        self::assertSame($result->dictionaryEntryId, (int) $sentence->get('dictionary_entry_id'));
+    }
+
+    #[Test]
+    public function promote_is_idempotent(): void
+    {
+        $first = $this->promoter()->promote(self::$wordEsid);
+        $second = $this->promoter()->promote(self::$wordEsid);
+
+        self::assertNotNull($first);
+        self::assertNotNull($second);
+        self::assertTrue($first->created);
+        self::assertFalse($second->created, 'Re-promoting returns the existing entry.');
+        self::assertSame($first->dictionaryEntryId, $second->dictionaryEntryId);
+        self::assertSame([], $first->wordPartIds, 'Single word yields no word_parts.');
+    }
+
+    #[Test]
+    public function curate_dashboard_is_gated(): void
+    {
+        $admin = $this->sendAs(self::$adminUid, 'GET', '/admin/anokii/curate');
+        self::assertSame(Response::HTTP_OK, $admin->getStatusCode());
+        self::assertStringContainsString('cu-dash', (string) $admin->getContent());
+        self::assertStringNotContainsString('/_nuxt/', (string) $admin->getContent());
+
+        $anon = $this->send('GET', '/admin/anokii/curate');
+        self::assertContains($anon->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND]);
+        self::assertStringNotContainsString('cu-dash', (string) $anon->getContent());
+    }
+
+    #[Test]
+    public function promote_route_creates_entry_and_rejects_unauthorized(): void
+    {
+        // Fresh utterance so this test owns the promotion.
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $row = $sentences->create([
+            'ojibwe_text' => 'Nibi',
+            'english_text' => 'water',
+            'source_sentence_id' => 'corpus:sb-c3',
+            'consent_public' => 1,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($row);
+        $esid = (int) $row->id();
+
+        // Unauthorized first: must not create anything.
+        $denied = $this->sendPost(0, '/admin/anokii/curate/promote', ['esid' => (string) $esid]);
+        self::assertContains($denied->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_UNAUTHORIZED]);
+        self::assertSame(0, (int) $sentences->load($esid)->get('dictionary_entry_id'), 'Denied promote must not mutate.');
+
+        // Authorized: creates + links.
+        $ok = $this->sendPost(self::$adminUid, '/admin/anokii/curate/promote', ['esid' => (string) $esid]);
+        self::assertSame(Response::HTTP_OK, $ok->getStatusCode());
+        $payload = json_decode((string) $ok->getContent(), true);
+        self::assertTrue($payload['ok'] ?? false);
+        self::assertGreaterThan(0, (int) ($payload['dictionary_entry_id'] ?? 0));
+        self::assertSame((int) $payload['dictionary_entry_id'], (int) $sentences->load($esid)->get('dictionary_entry_id'));
+    }
+
+    private function sendAs(int $uid, string $method, string $uri): Response
+    {
+        $this->primeGlobals($method, $uri);
+        $this->primeSession($uid);
+
+        return self::$kernel->handle();
+    }
+
+    /**
+     * @param array<string, string> $fields
+     */
+    private function sendPost(int $uid, string $uri, array $fields): Response
+    {
+        $this->primeGlobals('POST', $uri);
+        $_POST = $fields + ['_csrf_token' => self::CSRF];
+        $_REQUEST = $_POST;
+        $this->primeSession($uid);
+
+        return self::$kernel->handle();
+    }
+
+    private function primeGlobals(string $method, string $uri): void
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+    }
+
+    private function primeSession(int $uid): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['_csrf_token'] = self::CSRF;
+        if ($uid > 0) {
+            $_SESSION['waaseyaa_uid'] = $uid;
+        } else {
+            unset($_SESSION['waaseyaa_uid']);
+        }
+    }
+}


### PR DESCRIPTION
Adds a role-gated **Curate** tab to the Anokii shell that promotes corpus utterances into structured vocabulary. Final issue of milestone #62.

## What landed
- **`App\Ingestion\Curation\UtterancePromoter`** — from an `example_sentence`, creates a `dictionary_entry` (word ← Ojibwe **verbatim**, definition ← English) and one `word_part` per token for multi-word phrases, then links the sentence back via `dictionary_entry_id`. Consent + publication state are **copied from the source** (a draft promotes to a draft, off public surfaces). **Idempotent**: an already-linked sentence returns its existing entry. Ojibwe never normalized (ADR 0003).
- **`/admin/anokii/curate`** (`CurateController::index`) lists corpus utterances with promotion status; **`POST /admin/anokii/curate/promote`** performs it. Role-gated `admin,elder_coordinator`; the list uses `accessCheck(false)` to show drafts (documented in the bypass audit doc). Renders into `@anokii/_shell.html.twig`.
- Curate is now a live nav tab; the landing advertises Transcribe + Curate tabs and Ingest as the CLI command.

## Lessons / export
Lesson assembly leverages the existing config-driven `/lesson` surface (which reads the curated corpus); a dedicated lesson-builder UI and folding in `share/build.py`'s static export remain a follow-up — the issue scoped those as optional.

## Verification
- `bin/waaseyaa schema:check` — clean. `./vendor/bin/phpunit` — green, **499 tests** (+4). `composer phpstan` — No errors. `composer cs-fixer` — clean.
- **Live curl (logged-in admin):**
  - `GET /admin/anokii/curate` → **200, 20280 B**, `cu-dash`, counter `0 / 27 promoted`, no `/_nuxt/`.
  - `POST …/promote {esid:1}` ("Shoogan Mookman", 2 words) → `{"ok":true,"dictionary_entry_id":…,"word_parts":[…,…],"created":true}` — entry + 2 word_parts, sentence linked.
  - `POST …/promote` (no cookie) → **403**, no mutation.
- Tests: promotion creates `dictionary_entry` + `word_part`s verbatim with consent copied; idempotent; single word → no parts; tab + API role-gated; unauthorized promote does not mutate.

Refs #855