### PR TITLE
feat(#861): lessons as first-class — /lessons index, slugged URLs, nav + homepage surfacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ storage/exports/
 !/phpstan-dead-code-baseline.neon
 !/phpunit.xml.dist
 /tests/storage/
+/audit-screens/
+scripts/audit-screens.mjs
+scripts/shot.mjs

--- a/config/lesson1.php
+++ b/config/lesson1.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  */
 return [
     'title' => 'Lesson 1: Kitchen',
+    'slug' => 'the-kitchen',
     'groups' => [
         [
             'label' => 'Dishes and containers',

--- a/src/Http/Controller/Lesson/LessonController.php
+++ b/src/Http/Controller/Lesson/LessonController.php
@@ -41,26 +41,43 @@ final class LessonController
     ) {
     }
 
-    /** Landing: the list of available lessons (Lesson 1 for now). */
+    /** Landing: the list of available lessons. */
     public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        $def = $this->lessonDefinition();
+        $lessons = [];
+        foreach ($this->lessons() as $lesson) {
+            $def = $this->lessonDefinition($lesson['config']);
+            $lessons[] = [
+                'number' => $lesson['number'],
+                'title' => $def['title'],
+                'slug' => $lesson['slug'],
+                'url' => '/lessons/' . $lesson['slug'],
+                'count' => $this->lessonItemCount($def),
+            ];
+        }
 
         $html = $this->twig->render('pages/lesson/index.html.twig', LayoutTwigContext::withAccount($account, [
-            'path' => '/lesson',
-            'lessons' => [
-                ['number' => 1, 'title' => $def['title'], 'url' => '/lesson/1', 'count' => count($this->allowedIds())],
-            ],
+            'path' => '/lessons',
+            'lessons' => $lessons,
             'steven_url' => self::STEVEN_PROFILE_URL,
         ]));
 
         return new Response($html);
     }
 
-    /** Lesson 1: Kitchen, 16 cards grouped by section. */
-    public function lessonOne(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    /** A single lesson by slug: cards grouped by section. */
+    public function show(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        $def = $this->lessonDefinition();
+        $slug = (string) ($params['slug'] ?? '');
+        $lesson = $this->lessonBySlug($slug);
+        if ($lesson === null) {
+            return new Response(
+                $this->twig->render('404.html.twig', LayoutTwigContext::withAccount($account, ['path' => $request->getPathInfo()])),
+                404,
+            );
+        }
+
+        $def = $this->lessonDefinition($lesson['config']);
         $corpus = $this->corpusRowsBySourceId();
 
         $groups = [];
@@ -90,8 +107,9 @@ final class LessonController
         }
 
         $html = $this->twig->render('pages/lesson/lesson1.html.twig', LayoutTwigContext::withAccount($account, [
-            'path' => '/lesson/1',
+            'path' => '/lessons/' . $lesson['slug'],
             'lesson_title' => $def['title'],
+            'lesson_slug' => $lesson['slug'],
             'groups' => $groups,
             'total' => $total,
             'steven_url' => self::STEVEN_PROFILE_URL,
@@ -151,23 +169,63 @@ final class LessonController
     }
 
     /**
+     * The lesson registry. Each entry maps a stable slug + number to its
+     * curation config under config/. Add lessons here.
+     *
+     * @return list<array{number: int, slug: string, config: string}>
+     */
+    private function lessons(): array
+    {
+        return [
+            ['number' => 1, 'slug' => 'the-kitchen', 'config' => 'lesson1.php'],
+        ];
+    }
+
+    /** @return array{number: int, slug: string, config: string}|null */
+    private function lessonBySlug(string $slug): ?array
+    {
+        foreach ($this->lessons() as $lesson) {
+            if ($lesson['slug'] === $slug) {
+                return $lesson;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>} $def
+     */
+    private function lessonItemCount(array $def): int
+    {
+        $count = 0;
+        foreach ($def['groups'] as $group) {
+            $count += count($group['items']);
+        }
+
+        return $count;
+    }
+
+    /**
      * @return array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>}
      */
-    private function lessonDefinition(): array
+    private function lessonDefinition(string $configFile): array
     {
         /** @var array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>} $def */
-        $def = require dirname(__DIR__, 4) . '/config/lesson1.php';
+        $def = require dirname(__DIR__, 4) . '/config/' . $configFile;
 
         return $def;
     }
 
-    /** @return list<string> */
+    /** Every lesson item id across all lessons (the media route's allowlist). @return list<string> */
     private function allowedIds(): array
     {
         $ids = [];
-        foreach ($this->lessonDefinition()['groups'] as $group) {
-            foreach ($group['items'] as $item) {
-                $ids[] = $item['id'];
+        foreach ($this->lessons() as $lesson) {
+            foreach ($this->lessonDefinition($lesson['config'])['groups'] as $group) {
+                foreach ($group['items'] as $item) {
+                    $ids[] = $item['id'];
+                }
             }
         }
 

--- a/src/Provider/Routing/LessonRouteProvider.php
+++ b/src/Provider/Routing/LessonRouteProvider.php
@@ -5,15 +5,20 @@ declare(strict_types=1);
 namespace App\Provider\Routing;
 
 use App\Provider\AppCoreServiceProvider;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 /**
- * Lesson (course) surface routes.
+ * Lesson (course) surface routes (#861).
+ *
+ * Lessons are first-class: an index at /lessons and slugged lesson URLs at
+ * /lessons/{slug}. The legacy /lesson and /lesson/1 paths 301 to the new URLs.
  *
  * Public since Phase 4: written consent has been granted for the corpus, so the
- * lesson (and its media) are open. The Anishinaabemowin is read verbatim from
+ * lessons (and their media) are open. The Anishinaabemowin is read verbatim from
  * the community-controlled corpus directory at runtime and never committed.
  */
 final class LessonRouteProvider extends AppCoreServiceProvider
@@ -21,8 +26,8 @@ final class LessonRouteProvider extends AppCoreServiceProvider
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
     {
         $router->addRoute(
-            'lesson.index',
-            RouteBuilder::create('/lesson')
+            'lessons.index',
+            RouteBuilder::create('/lessons')
                 ->controller('App\\Http\\Controller\\Lesson\\LessonController::index')
                 ->allowAll()
                 ->render()
@@ -31,11 +36,31 @@ final class LessonRouteProvider extends AppCoreServiceProvider
         );
 
         $router->addRoute(
-            'lesson.one',
-            RouteBuilder::create('/lesson/1')
-                ->controller('App\\Http\\Controller\\Lesson\\LessonController::lessonOne')
+            'lessons.show',
+            RouteBuilder::create('/lessons/{slug}')
+                ->controller('App\\Http\\Controller\\Lesson\\LessonController::show')
                 ->allowAll()
                 ->render()
+                ->methods('GET')
+                ->requirement('slug', '[a-z][a-z0-9-]*')
+                ->build(),
+        );
+
+        // Legacy paths → the new slugged URLs (301).
+        $router->addRoute(
+            'lesson.legacy_index',
+            RouteBuilder::create('/lesson')
+                ->controller(static fn (): Response => new RedirectResponse('/lessons', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'lesson.legacy_one',
+            RouteBuilder::create('/lesson/1')
+                ->controller(static fn (): Response => new RedirectResponse('/lessons/the-kitchen', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()
                 ->methods('GET')
                 ->build(),
         );

--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -17,15 +17,13 @@
     </a>
   </div>
 
-  {% if account is defined and account.hasPermission('administer content') %}
   <div class="sbx__group">
     <span class="sbx__label">Learn</span>
-    <a href="{{ lang_url('/lesson/1') }}" class="sbx__item{% if current_path is defined and current_path starts with '/lesson' %} sbx__item--active{% endif %}">
+    <a href="{{ lang_url('/lessons') }}" class="sbx__item{% if current_path is defined and (current_path starts with '/lessons' or current_path starts with '/lesson') %} sbx__item--active{% endif %}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>
-      <span>Lesson 1: Kitchen</span>
+      <span>Lessons</span>
     </a>
   </div>
-  {% endif %}
 
   <div class="sbx__group">
     <span class="sbx__label">Games</span>

--- a/templates/layouts/base.html.twig
+++ b/templates/layouts/base.html.twig
@@ -71,6 +71,7 @@
           <div style="margin-top: 4px;">Built on Anishinaabe territory.</div>
         </div>
         <div>
+          <a href="{{ lang_url('/lessons') }}">Lessons</a>
           <a href="{{ lang_url('/about') }}">About</a>
           <a href="{{ lang_url('/data-sovereignty') }}">Data Sovereignty</a>
           <a href="{{ lang_url('/legal/privacy') }}">Privacy</a>

--- a/templates/pages/home/index.html.twig
+++ b/templates/pages/home/index.html.twig
@@ -15,8 +15,24 @@
         practice with daily games, and grow with the language.
       </p>
       <div class="hero__ctas">
-        <a href="{{ lang_url('/language') }}" class="btn btn--primary btn--lg">Explore the Dictionary</a>
+        <a href="{{ lang_url('/lessons') }}" class="btn btn--primary btn--lg">Start learning</a>
+        <a href="{{ lang_url('/language') }}" class="btn btn--secondary btn--lg">Explore the Dictionary</a>
         <a href="{{ lang_url('/games') }}" class="btn btn--secondary btn--lg">Play Word Games</a>
+      </div>
+    </section>
+
+    {# === Lessons (learn first) === #}
+    <section class="sec">
+      <div class="sec__head">
+        <h2>Lessons</h2>
+        <a href="{{ lang_url('/lessons') }}">View all &rarr;</a>
+      </div>
+      <div class="ds-grid">
+        <a href="{{ lang_url('/lessons/the-kitchen') }}" class="card">
+          <span class="card__eyebrow">Lesson 1</span>
+          <h3 class="card__title">The Kitchen</h3>
+          <p class="card__meta">Everyday objects in <em>Anishinaabemowin</em>, taught by Steven Bennett in his own voice.</p>
+        </a>
       </div>
     </section>
 
@@ -65,8 +81,11 @@
     {% if account is not defined or not account.isAuthenticated() %}
       <section class="sec" style="text-align: center; padding: var(--space-xl) 0;">
         <h2>Track Your Learning</h2>
-        <p style="color: var(--text-secondary); max-width: 50ch; margin: var(--space-sm) auto var(--space-md);">Create an account to keep your game streaks, save words to your own list, and pick up where you left off.</p>
-        <a href="{{ lang_url('/register') }}" class="btn btn--primary btn--lg">Create an Account</a>
+        <p style="color: var(--text-secondary); max-width: 50ch; margin: var(--space-sm) auto var(--space-md);">Start with a lesson, then create an account to keep your game streaks, save words to your own list, and pick up where you left off.</p>
+        <div class="hero__ctas" style="justify-content: center;">
+          <a href="{{ lang_url('/lessons') }}" class="btn btn--primary btn--lg">Start a lesson</a>
+          <a href="{{ lang_url('/register') }}" class="btn btn--secondary btn--lg">Create an Account</a>
+        </div>
       </section>
     {% endif %}
 

--- a/templates/pages/lesson/lesson1.html.twig
+++ b/templates/pages/lesson/lesson1.html.twig
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="lesson-page" id="lesson">
   <header class="lesson-hero">
+    <p class="lesson-hero__eyebrow"><a href="{{ lang_url('/lessons') }}">&larr; Lessons</a></p>
     <p class="lesson-hero__eyebrow">Lesson 1 of the Anishinaabemowin corpus</p>
     <h1>The kitchen, in <em>Anishinaabemowin</em></h1>
     <p class="lesson-hero__lede">

--- a/tests/App/Integration/Http/LessonRoutesTest.php
+++ b/tests/App/Integration/Http/LessonRoutesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Lessons as first-class (#861): /lessons index + slugged /lessons/{slug},
+ * unknown slug 404s, and the legacy /lesson and /lesson/1 paths 301 to the new
+ * URLs.
+ */
+#[CoversNothing]
+final class LessonRoutesTest extends HttpKernelTestCase
+{
+    #[Test]
+    public function lessons_index_lists_the_kitchen(): void
+    {
+        $response = $this->send('GET', '/lessons');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('/lessons/the-kitchen', $body);
+    }
+
+    #[Test]
+    public function slugged_lesson_renders(): void
+    {
+        $response = $this->send('GET', '/lessons/the-kitchen');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('lesson-page', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function unknown_lesson_slug_is_404(): void
+    {
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->send('GET', '/lessons/no-such-lesson')->getStatusCode());
+    }
+
+    #[Test]
+    public function legacy_lesson_index_redirects(): void
+    {
+        $response = $this->send('GET', '/lesson');
+        self::assertSame(Response::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
+        self::assertSame('/lessons', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function legacy_lesson_one_redirects_to_slug(): void
+    {
+        $response = $this->send('GET', '/lesson/1');
+        self::assertSame(Response::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
+        self::assertSame('/lessons/the-kitchen', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function lesson_media_route_still_exists(): void
+    {
+        // Unknown id → 404 from the controller allowlist (not an admin_spa 404).
+        $response = $this->send('GET', '/lesson/media/thumb/sb-001');
+        self::assertContains($response->getStatusCode(), [Response::HTTP_OK, Response::HTTP_NOT_FOUND]);
+    }
+}


### PR DESCRIPTION
Makes the learning experience first-class and discoverable. Previously `/lesson/1` was number-only and the only nav entry was gated behind `administer content` (invisible to the public).

## What landed
- **Routes**: `/lessons` (index) + `/lessons/{slug}` via a slug-keyed lesson registry in `LessonController`. **301** `/lesson`→`/lessons` and `/lesson/1`→`/lessons/the-kitchen`; unknown slug → 404; `/lesson/media/{kind}/{id}` unchanged. `config/lesson1.php` gains a stable `slug: the-kitchen`.
- **Nav**: the "Learn" group is **ungated** and links **Lessons** → `/lessons`.
- **Homepage**: hero **"Start learning"** primary CTA → `/lessons`; a **Lessons section** (The Kitchen card) near the top; "Track Your Learning" now leads with a Start-a-lesson CTA. **Footer** Lessons link.
- Orthography untouched (ADR 0003). No CSS changed (no `?v` bump).

## Verification
- `bin/waaseyaa schema:check` clean; `./vendor/bin/phpunit` green (**505**, +6); `composer phpstan` no errors; `composer cs-fixer` clean.
- Local curls: `/lessons` 200, `/lessons/the-kitchen` 200, `/lessons/bogus` 404, `/lesson` 301→`/lessons`, `/lesson/1` 301→`/lessons/the-kitchen`; homepage has Start-learning CTA + Lessons section + ungated nav Lessons.
- Tests: `LessonRoutesTest` covers index/show/404/301s; existing media-allowlist unit tests still pass.

## Screenshots (local, after)
- **Mobile home (375px):** hero now leads with "Start learning"; a Lessons section with The Kitchen card sits above Games.
- **Desktop /lessons (1280px):** LEARN → Lessons nav group is visible/ungated; "Lessons" index lists "Lesson 1: Kitchen · 16 words"; footer has Lessons.
(Before: lessons absent from nav/home; `/lesson/1` number-only.)

## Note
Lesson card media 404s on production (corpus media isn't deployed — lives only at `MINOO_CORPUS_PATH`). IA surfacing is the goal here; shipping the consented media to the Pi is a separate ops task.

Refs #861