### PR TITLE
feat(#862): normalize game URLs to /games/{slug} canonical + 301 short links

### DIFF
--- a/src/Provider/Routing/StaticPagesRouteProvider.php
+++ b/src/Provider/Routing/StaticPagesRouteProvider.php
@@ -29,18 +29,19 @@ final class StaticPagesRouteProvider extends AppCoreServiceProvider
                 ->allowAll()->render()->methods('GET')->build(),
         );
 
+        // Short game links 301 to the canonical /games/{slug} (#862).
         $router->addRoute(
             'games.agim.short',
             RouteBuilder::create('/agim')
-                ->controller('App\Http\Controller\Games\AgimController::page')
-                ->allowAll()->render()->methods('GET')->build(),
+                ->controller(static fn (): Response => new RedirectResponse('/games/agim', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()->methods('GET')->build(),
         );
 
         $router->addRoute(
             'games.crossword.short',
             RouteBuilder::create('/crossword')
-                ->controller('App\Http\Controller\Games\CrosswordController::page')
-                ->allowAll()->render()->methods('GET')->build(),
+                ->controller(static fn (): Response => new RedirectResponse('/games/crossword', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()->methods('GET')->build(),
         );
 
         $router->addRoute(
@@ -90,8 +91,8 @@ final class StaticPagesRouteProvider extends AppCoreServiceProvider
         $router->addRoute(
             'static.matcher',
             RouteBuilder::create('/matcher')
-                ->controller('App\Http\Controller\Site\StaticPageController::matcher')
-                ->allowAll()->render()->methods('GET')->build(),
+                ->controller(static fn (): Response => new RedirectResponse('/games/matcher', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()->methods('GET')->build(),
         );
 
         $router->addRoute(
@@ -104,8 +105,8 @@ final class StaticPagesRouteProvider extends AppCoreServiceProvider
         $router->addRoute(
             'games.shkoda.short',
             RouteBuilder::create('/shkoda')
-                ->controller('App\Http\Controller\Games\ShkodaController::page')
-                ->allowAll()->render()->methods('GET')->build(),
+                ->controller(static fn (): Response => new RedirectResponse('/games/shkoda', Response::HTTP_MOVED_PERMANENTLY))
+                ->allowAll()->methods('GET')->build(),
         );
 
         $router->addRoute(

--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -33,7 +33,7 @@
     <a href="{{ lang_url('/games/shkoda') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/shkoda' %} sbx__item--active{% endif %}">
       <span>Shkoda</span>
     </a>
-    <a href="{{ lang_url('/matcher') }}" class="sbx__item{% if current_path is defined and current_path starts with '/matcher' %} sbx__item--active{% endif %}">
+    <a href="{{ lang_url('/games/matcher') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/matcher' %} sbx__item--active{% endif %}">
       <span>Matcher</span>
     </a>
     <a href="{{ lang_url('/games/agim') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/agim' %} sbx__item--active{% endif %}">

--- a/tests/App/Integration/Http/GameUrlRedirectTest.php
+++ b/tests/App/Integration/Http/GameUrlRedirectTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Game URL normalization (#862): /games/{slug} is canonical, and the short links
+ * 301 to it (no more duplicate-content 200s).
+ */
+final class GameUrlRedirectTest extends HttpKernelTestCase
+{
+    /** @return iterable<string, array{string, string}> */
+    public static function shortLinks(): iterable
+    {
+        yield 'matcher' => ['/matcher', '/games/matcher'];
+        yield 'agim' => ['/agim', '/games/agim'];
+        yield 'shkoda' => ['/shkoda', '/games/shkoda'];
+        yield 'crossword' => ['/crossword', '/games/crossword'];
+    }
+
+    #[Test]
+    #[DataProvider('shortLinks')]
+    public function short_link_301s_to_canonical(string $short, string $canonical): void
+    {
+        $response = $this->send('GET', $short);
+        self::assertSame(Response::HTTP_MOVED_PERMANENTLY, $response->getStatusCode(), "{$short} must 301");
+        self::assertSame($canonical, $response->headers->get('Location'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function canonicalLinks(): iterable
+    {
+        yield 'matcher' => ['/games/matcher'];
+        yield 'agim' => ['/games/agim'];
+        yield 'shkoda' => ['/games/shkoda'];
+        yield 'crossword' => ['/games/crossword'];
+        yield 'journey' => ['/games/journey'];
+    }
+
+    #[Test]
+    #[DataProvider('canonicalLinks')]
+    public function canonical_game_url_serves(string $canonical): void
+    {
+        self::assertSame(Response::HTTP_OK, $this->send('GET', $canonical)->getStatusCode(), "{$canonical} must 200");
+    }
+
+    #[Test]
+    public function legacy_ishkode_still_redirects_to_shkoda(): void
+    {
+        $response = $this->send('GET', '/games/ishkode');
+        self::assertContains($response->getStatusCode(), [Response::HTTP_MOVED_PERMANENTLY, Response::HTTP_PERMANENTLY_REDIRECT]);
+        self::assertStringContainsString('/games/shkoda', (string) $response->headers->get('Location'));
+    }
+}


### PR DESCRIPTION
The short game links `/matcher`, `/agim`, `/shkoda`, `/crossword` each served **200** (duplicate content, no canonical). They now **301** to the canonical `/games/{slug}`, and the nav points at the canonical path.

## What landed
- `StaticPagesRouteProvider`: the four short routes now return `301 → /games/{slug}` (RedirectResponse) instead of rendering. Canonical `/games/{slug}` routes (incl. `journey`) unchanged; legacy `/games/ishkode`→`/games/shkoda` preserved.
- `sidebar-nav`: the Matcher link + active-state use `/games/matcher` (was `/matcher`). The cards component already used canonical paths.

## Verification (local)
- `/matcher`→301 `/games/matcher`, `/agim`→301 `/games/agim`, `/shkoda`→301 `/games/shkoda`, `/crossword`→301 `/games/crossword`.
- `/games/{matcher,agim,shkoda,crossword}` still **200**.
- Nav HTML no longer contains `href="/matcher"` (now `/games/matcher`).
- `bin/waaseyaa schema:check` clean; `./vendor/bin/phpunit` green (**515**, +10); `composer phpstan` no errors; `composer cs-fixer` clean.
- Tests: `GameUrlRedirectTest` asserts each 301 + each canonical 200 + legacy ishkode redirect.

No visual change (nav labels identical; the change is the link target + redirects), so no screenshots.

Refs #862