### PR TITLE
feat(#863): IA/homepage reorg — learn→practice→belong nav groups + replace Featured placeholder

### DIFF
--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -1,19 +1,11 @@
 {# Required: —
    Optional: account, active #}
-{# Sidebar navigation - language-platform groups (2026-06 slimming) #}
+{# Sidebar navigation — learn → practice → belong (#863). #}
 <nav aria-label="{{ trans('sidebar.navigate') }}">
   <div class="sbx__group">
     <a href="{{ lang_url('/') }}" class="sbx__item{% if current_path is defined and current_path == '/' %} sbx__item--active{% endif %}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
       <span>{{ trans('sidebar.home') }}</span>
-    </a>
-    <a href="{{ lang_url('/language') }}" class="sbx__item{% if current_path is defined and current_path starts with '/language' %} sbx__item--active{% endif %}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
-      <span>Dictionary</span>
-    </a>
-    <a href="{{ lang_url('/language/search') }}" class="sbx__item">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-      <span>{{ trans('nav.search') }}</span>
     </a>
   </div>
 
@@ -23,15 +15,26 @@
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>
       <span>Lessons</span>
     </a>
+    <a href="{{ lang_url('/language') }}" class="sbx__item{% if current_path is defined and current_path starts with '/language' and current_path != '/language/search' %} sbx__item--active{% endif %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+      <span>Dictionary</span>
+    </a>
+    <a href="{{ lang_url('/language/search') }}" class="sbx__item{% if current_path is defined and current_path == '/language/search' %} sbx__item--active{% endif %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>{{ trans('nav.search') }}</span>
+    </a>
   </div>
 
   <div class="sbx__group">
-    <span class="sbx__label">Games</span>
+    <span class="sbx__label">Practice</span>
     <a href="{{ lang_url('/games') }}" class="sbx__item{% if current_path is defined and current_path == '/games' %} sbx__item--active{% endif %}">
       <span>All Games</span>
     </a>
     <a href="{{ lang_url('/games/shkoda') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/shkoda' %} sbx__item--active{% endif %}">
       <span>Shkoda</span>
+    </a>
+    <a href="{{ lang_url('/games/crossword') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/crossword' %} sbx__item--active{% endif %}">
+      <span>Crossword</span>
     </a>
     <a href="{{ lang_url('/games/matcher') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/matcher' %} sbx__item--active{% endif %}">
       <span>Matcher</span>
@@ -39,16 +42,13 @@
     <a href="{{ lang_url('/games/agim') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/agim' %} sbx__item--active{% endif %}">
       <span>Agim</span>
     </a>
-    <a href="{{ lang_url('/games/crossword') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/crossword' %} sbx__item--active{% endif %}">
-      <span>Crossword</span>
-    </a>
     <a href="{{ lang_url('/games/journey') }}" class="sbx__item{% if current_path is defined and current_path starts with '/games/journey' %} sbx__item--active{% endif %}">
       <span>Journey</span>
     </a>
   </div>
 
   <div class="sbx__group">
-    <span class="sbx__label">Community</span>
+    <span class="sbx__label">Belong</span>
     <a href="{{ lang_url('/communities') }}" class="sbx__item{% if current_path is defined and current_path starts with '/communities' %} sbx__item--active{% endif %}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
       <span>Communities</span>
@@ -56,7 +56,7 @@
   </div>
 
   <div class="sbx__group">
-    <span class="sbx__label">Minoo</span>
+    <span class="sbx__label">About</span>
     <a href="{{ lang_url('/about') }}" class="sbx__item{% if current_path is defined and current_path == '/about' %} sbx__item--active{% endif %}">
       <span>About</span>
     </a>

--- a/templates/pages/home/index.html.twig
+++ b/templates/pages/home/index.html.twig
@@ -21,11 +21,11 @@
       </div>
     </section>
 
-    {# === Lessons (learn first) === #}
+    {# === Learn (lessons + dictionary) === #}
     <section class="sec">
       <div class="sec__head">
-        <h2>Lessons</h2>
-        <a href="{{ lang_url('/lessons') }}">View all &rarr;</a>
+        <h2>Learn</h2>
+        <a href="{{ lang_url('/lessons') }}">All lessons &rarr;</a>
       </div>
       <div class="ds-grid">
         <a href="{{ lang_url('/lessons/the-kitchen') }}" class="card">
@@ -33,33 +33,22 @@
           <h3 class="card__title">The Kitchen</h3>
           <p class="card__meta">Everyday objects in <em>Anishinaabemowin</em>, taught by Steven Bennett in his own voice.</p>
         </a>
+        <a href="{{ lang_url('/language') }}" class="card">
+          <span class="card__eyebrow">Dictionary</span>
+          <h3 class="card__title">Look up a word</h3>
+          <p class="card__meta">{% if entry_count is defined and entry_count > 0 %}{{ entry_count|number_format }} words{% else %}A growing community dictionary{% endif %} of Anishinaabemowin, with audio and examples.</p>
+        </a>
       </div>
     </section>
 
-    {# === Featured Items === #}
-    {% if featured is defined and featured|length > 0 %}
-      <section class="sec">
-        <div class="sec__head">
-          <h2>Featured</h2>
-        </div>
-        <div class="ds-grid">
-          {% for item in featured %}
-            <a href="{{ item.url }}" class="card card--{{ item.entity_type }}">
-              <span class="card__eyebrow">{{ item.entity_type|replace({'_': ' '})|capitalize }}</span>
-              <h3 class="card__title">{{ item.headline }}</h3>
-              {% if item.subheadline is defined and item.subheadline %}
-                <p class="card__meta">{{ item.subheadline }}</p>
-              {% endif %}
-            </a>
-          {% endfor %}
-        </div>
-      </section>
-    {% endif %}
+    {# Featured-item pipeline (featured_item) stays available but is no longer
+       surfaced as a generic homepage card; the homepage leads with the real
+       learn → practice → belong pillars (#863). #}
 
-    {# === Games === #}
+    {# === Practice (games) === #}
     <section class="sec">
       <div class="sec__head">
-        <h2>Games</h2>
+        <h2>Practice</h2>
         <a href="{{ lang_url('/games') }}">View all &rarr;</a>
       </div>
       <div class="games-hub__featured">
@@ -67,7 +56,7 @@
       </div>
     </section>
 
-    {# === Community (the second truth: language lives in the land and people) === #}
+    {# === Belong (community) === #}
     <section class="sec">
       <div class="sec__head">
         <h2>Rooted in community</h2>


### PR DESCRIPTION
Reorganizes the primary nav and homepage toward a clear **learn → practice → belong** flow, and removes the weak generic "Featured" placeholder. Builds on #861 (lessons) and #862 (canonical games).

## What landed
- **Nav** (`sidebar-nav`): regrouped into **Home** / **Learn** (Lessons, Dictionary, Search) / **Practice** (All Games + the five games) / **Belong** (Communities) / **About** (renamed from the unclear "Minoo" label; About + Data Sovereignty).
- **Homepage**: a **Learn** section with real pillars — the **The Kitchen** lesson card + a **Dictionary** "Look up a word" card (uses the live word count) — then **Practice** (games), then the **Rooted in community** belong section. The generic Featured card is **no longer surfaced**; the `featured_item` pipeline stays available for a future curated surface (`HomeController` unchanged, so its test stays green).
- No CSS changed (reuses `sec`/`card`/`ds-grid`) — no `?v` bump.

## Verification
- Homepage: Learn + Practice sections present, Dictionary card present, **no Featured block**; nav shows Learn/Practice/Belong/About (no Minoo/Games/Community labels).
- `bin/waaseyaa schema:check` clean; `./vendor/bin/phpunit` green (**515**); `composer phpstan` no errors; `composer cs-fixer` clean.

## Screenshots (after)
- **Desktop home (1280px):** nav = Home / LEARN / PRACTICE / BELONG / ABOUT; a Learn section with The Kitchen + "Look up a word" cards replaces the old "Welcome to Minoo" Featured card; Games section now headed "Practice".
(Before: nav ended with a "Minoo" group; homepage showed a generic "Welcome to Minoo" Featured placeholder and no Dictionary pillar.)

Refs #863