### PR TITLE
fix(#864): update stale lesson consent copy — corpus is consented (Phase 4)

### DIFF
--- a/templates/pages/lesson/lesson1.html.twig
+++ b/templates/pages/lesson/lesson1.html.twig
@@ -50,7 +50,7 @@
   <footer class="lesson-footer">
     <p>Source. Each card is a real reel from <a href="{{ steven_url }}" target="_blank" rel="noopener">Steven Bennett's Facebook</a>. The audio is his unmodified voice.</p>
     <p>Orthography. Spellings are transcribed from the whiteboards exactly as written. Steven's local spelling may differ from standard double-vowel; we record what the Elder writes, we do not normalize it.</p>
-    <p>Consent. This lesson is a review surface. The corpus behind it is not yet published; it stays private until written consent records exist.</p>
+    <p>Consent. Taught by <a href="{{ steven_url }}" target="_blank" rel="noopener">Steven Bennett</a> and shared with his consent &mdash; for public display, publication, search, and language learning. Miigwech.</p>
   </footer>
 </div>
 


### PR DESCRIPTION
The lesson footer wrongly claimed the corpus *"is not yet published; it stays private until written consent records exist."* Steven Bennett's corpus **is** consented (public display, publication, search, AI grounding, and training — Phase 4).

## What changed
One line in `templates/pages/lesson/lesson1.html.twig`:
- **Before:** "Consent. This lesson is a review surface. The corpus behind it is not yet published; it stays private until written consent records exist."
- **After:** "Consent. Taught by Steven Bennett and shared with his consent — for public display, publication, search, and language learning. Miigwech."

Nothing is gated or hidden. The Source + Orthography notes (ADR 0003 — spellings recorded exactly as written) are unchanged.

## Verification
- Rendered `/lessons/the-kitchen`: old "not yet published" copy gone; new consent note present.
- `bin/waaseyaa schema:check` clean; `./vendor/bin/phpunit` green (**515**); `composer phpstan` no errors. No CSS changed.

Refs #864