### PR TITLE
feat(#865): SEO pass — canonical, per-page + per-lesson meta/OG, JSON-LD, sitemap, hreflang

### DIFF
--- a/src/Http/Controller/Site/SitemapController.php
+++ b/src/Http/Controller/Site/SitemapController.php
@@ -33,8 +33,10 @@ final class SitemapController
     /** @param array<string, mixed> $params @param array<string, mixed> $query */
     public function xml(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
+        // /language/search is intentionally excluded (it is noindex). Lessons
+        // are indexable learning surfaces (#865).
         $paths = [
-            '/', '/language', '/language/search', '/communities', '/games',
+            '/', '/lessons', '/lessons/the-kitchen', '/language', '/communities', '/games',
             '/games/shkoda', '/games/matcher', '/games/crossword', '/games/agim', '/games/journey',
             '/about', '/data-sovereignty', '/legal/privacy',
         ];

--- a/templates/components/seo/breadcrumb.html.twig
+++ b/templates/components/seo/breadcrumb.html.twig
@@ -1,0 +1,10 @@
+{#
+  Reusable BreadcrumbList JSON-LD (#865).
+  Usage: {% include "components/seo/breadcrumb.html.twig" with { crumbs: [
+            { name: 'Lessons', url: '/lessons' },
+            { name: 'The Kitchen', url: '/lessons/the-kitchen' },
+          ] } %}
+  A leading Home crumb is prepended automatically. URLs are absolute-ised with
+  site_base_url + lang_url so they match the page's locale.
+#}
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"{{ site_base_url }}{{ lang_url('/') }}"}{% for c in crumbs %},{"@type":"ListItem","position":{{ loop.index + 1 }},"name":{{ c.name|json_encode|raw }},"item":"{{ site_base_url }}{{ lang_url(c.url) }}"}{% endfor %}]}</script>

--- a/templates/layouts/base.html.twig
+++ b/templates/layouts/base.html.twig
@@ -5,12 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preload" href="/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/fonts/dm-sans-variable.woff2" as="font" type="font/woff2" crossorigin>
+  {# SEO (#865): un-prefixed logical path for canonical + hreflang. #}
+  {% set seo_path = path is defined ? path : (request_path is defined ? request_path : '/') %}
   <title>{% block title %}Minoo{% endblock %}</title>
   <meta name="description" content="{% block meta_description %}{{ trans('og.default_description') }}{% endblock %}">
+  <meta name="robots" content="{% block robots %}index, follow{% endblock %}">
+  <link rel="canonical" href="{% block canonical %}{{ site_base_url }}{{ lang_url(seo_path) }}{% endblock %}">
+  {% for lang in available_languages() %}
+  <link rel="alternate" hreflang="{{ lang.id }}" href="{{ site_base_url }}{{ lang_switch_url(lang.id, seo_path) }}">
+  {% endfor %}
+  <link rel="alternate" hreflang="x-default" href="{{ site_base_url }}{{ seo_path }}">
   <meta property="og:title" content="{% block og_title %}{{ block('title') }}{% endblock %}">
   <meta property="og:description" content="{% block og_description %}{{ trans('og.default_description') }}{% endblock %}">
   <meta property="og:image" content="{% block og_image %}{{ site_base_url }}/img/og-default.png{% endblock %}">
-  <meta property="og:url" content="{{ site_base_url }}{{ path is defined ? lang_url(path) : lang_url('/') }}">
+  <meta property="og:url" content="{{ site_base_url }}{{ lang_url(seo_path) }}">
   <meta property="og:type" content="{% block og_type %}website{% endblock %}">
   <meta property="og:site_name" content="Minoo">
   <meta name="twitter:card" content="summary_large_image">

--- a/templates/pages/community/show.html.twig
+++ b/templates/pages/community/show.html.twig
@@ -5,6 +5,13 @@
   {%- if nation -%}{{ nation.name }}: {{ nation.reserve }}, {{ nation.treaty }}, a member of Mamaweswen, The North Shore Tribal Council.{%- else -%}Community not found.{%- endif -%}
 {% endblock %}
 
+{% block structured_data %}
+  {{ parent() }}
+  {% if nation %}
+    {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: 'Communities', url: '/communities' }, { name: nation.name, url: '/communities/' ~ nation.slug }] } %}
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   {% if nation %}
     <div class="flow-lg detail">

--- a/templates/pages/games/agim.html.twig
+++ b/templates/pages/games/agim.html.twig
@@ -2,6 +2,13 @@
 
 {% block title %}Minoo | {{ trans('games.agim_title') }}{% endblock %}
 
+{% block meta_description %}{{ trans('games.agim_title') }} — a free Anishinaabemowin number game on Minoo. Practice counting in the language.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: trans('games.title'), url: '/games' }, { name: trans('games.agim_title'), url: '/games/agim' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="agim" id="agim-game" data-api-base="/api/games/agim">
     <div class="game-header">

--- a/templates/pages/games/crossword.html.twig
+++ b/templates/pages/games/crossword.html.twig
@@ -2,6 +2,13 @@
 
 {% block title %}Minoo | {{ trans('games.crossword_title') }}{% endblock %}
 
+{% block meta_description %}{{ trans('games.crossword_title') }} — a free Anishinaabemowin word game on Minoo. Practice the language with daily challenges.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: trans('games.title'), url: '/games' }, { name: trans('games.crossword_title'), url: '/games/crossword' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="crossword" data-game="crossword">
     {# Compact header: breadcrumb + title + tabs on one row #}

--- a/templates/pages/games/index.html.twig
+++ b/templates/pages/games/index.html.twig
@@ -2,6 +2,14 @@
 
 {% block title %}Minoo | {{ trans('games.title') }}{% endblock %}
 
+{% block meta_description %}Free Anishinaabemowin word games on Minoo — Shkoda, Crossword, Matcher, Agim, and Journey. Practice the language with daily challenges.{% endblock %}
+{% block og_description %}Free Anishinaabemowin word games on Minoo — Shkoda, Crossword, Matcher, Agim, and Journey. Practice the language with daily challenges.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: trans('games.title'), url: '/games' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="games-hub content-max">
     <header class="games-hub__header">

--- a/templates/pages/games/shkoda.html.twig
+++ b/templates/pages/games/shkoda.html.twig
@@ -2,6 +2,13 @@
 
 {% block title %}Minoo | {{ trans('games.shkoda_title') }}{% endblock %}
 
+{% block meta_description %}{{ trans('games.shkoda_title') }} — a free Anishinaabemowin word game on Minoo. Practice the language with daily challenges.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: trans('games.title'), url: '/games' }, { name: trans('games.shkoda_title'), url: '/games/shkoda' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="shkoda" id="shkoda-game" data-api-base="/api/games/shkoda">
     {# Compact header: breadcrumb + title + tabs on one row #}

--- a/templates/pages/language/search.html.twig
+++ b/templates/pages/language/search.html.twig
@@ -2,6 +2,9 @@
 
 {% block title %}Minoo | {{ trans('language.search_results_title') }}{% endblock %}
 
+{# Search results are not canonical content. #}
+{% block robots %}noindex, follow{% endblock %}
+
 {% block content %}
   <div class="flow-lg">
     <h1>{{ trans('language.search_results_title') }}</h1>

--- a/templates/pages/lesson/index.html.twig
+++ b/templates/pages/lesson/index.html.twig
@@ -2,6 +2,14 @@
 
 {% block title %}Lessons · Anishinaabemowin{% endblock %}
 
+{% block meta_description %}Free Anishinaabemowin lessons built from the words Knowledge Keepers share — start with the kitchen, taught by Steven Bennett with audio.{% endblock %}
+{% block og_description %}Free Anishinaabemowin lessons built from the words Knowledge Keepers share — start with the kitchen, taught by Steven Bennett with audio.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: 'Lessons', url: '/lessons' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="lesson-page">
   <header class="lesson-hero">

--- a/templates/pages/lesson/lesson1.html.twig
+++ b/templates/pages/lesson/lesson1.html.twig
@@ -2,6 +2,15 @@
 
 {% block title %}{{ lesson_title }} · Anishinaabemowin{% endblock %}
 
+{% block meta_description %}{{ lesson_title }} — learn {{ total }} everyday Anishinaabemowin words with audio, taught by Steven Bennett. A free language lesson on Minoo.{% endblock %}
+{% block og_description %}{{ lesson_title }} — {{ total }} Anishinaabemowin words with audio, taught by Steven Bennett. Free to learn on Minoo.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":["Course","LearningResource"],"name":{{ lesson_title|json_encode|raw }},"description":{{ (lesson_title ~ ': ' ~ total ~ ' everyday Anishinaabemowin words with audio, taught by Steven Bennett.')|json_encode|raw }},"url":"{{ site_base_url }}{{ lang_url('/lessons/' ~ (lesson_slug|default(''))) }}","inLanguage":["oj","en"],"isAccessibleForFree":true,"educationalLevel":"beginner","learningResourceType":"lesson","teaches":"Anishinaabemowin vocabulary","provider":{"@type":"Organization","name":"Minoo","url":"{{ site_base_url }}"}}</script>
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: 'Lessons', url: '/lessons' }, { name: lesson_title, url: '/lessons/' ~ (lesson_slug|default('')) }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="lesson-page" id="lesson">
   <header class="lesson-hero">

--- a/templates/pages/static/matcher.html.twig
+++ b/templates/pages/static/matcher.html.twig
@@ -2,6 +2,13 @@
 
 {% block title %}Minoo | {{ trans('games.matcher_title') }}{% endblock %}
 
+{% block meta_description %}{{ trans('games.matcher_title') }} — a free Anishinaabemowin matching game on Minoo. Match words to their meanings.{% endblock %}
+
+{% block structured_data %}
+  {{ parent() }}
+  {% include "components/seo/breadcrumb.html.twig" with { crumbs: [{ name: trans('games.title'), url: '/games' }, { name: trans('games.matcher_title'), url: '/games/matcher' }] } %}
+{% endblock %}
+
 {% block content %}
 <div class="matcher" data-game="matcher"
      data-label-ojibwe="{{ trans('games.ojibwe') }}"

--- a/tests/App/Integration/Http/SeoMetaTest.php
+++ b/tests/App/Integration/Http/SeoMetaTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * SEO head (#865): self-referential canonical + hreflang alternates + robots on
+ * every page; search results are noindex; lessons carry Course/LearningResource
+ * JSON-LD and a BreadcrumbList.
+ */
+#[CoversNothing]
+final class SeoMetaTest extends HttpKernelTestCase
+{
+    #[Test]
+    public function homepage_has_canonical_hreflang_and_indexable_robots(): void
+    {
+        $body = (string) $this->send('GET', '/')->getContent();
+
+        self::assertStringContainsString('<link rel="canonical" href="', $body);
+        self::assertMatchesRegularExpression('/<link rel="canonical" href="https?:\/\/[^"]+\/"/', $body);
+        self::assertStringContainsString('rel="alternate" hreflang="oj"', $body);
+        self::assertStringContainsString('rel="alternate" hreflang="x-default"', $body);
+        self::assertStringContainsString('name="robots" content="index, follow"', $body);
+    }
+
+    #[Test]
+    public function search_results_are_noindex(): void
+    {
+        $body = (string) $this->send('GET', '/language/search', ['q' => 'nibi'])->getContent();
+        self::assertStringContainsString('name="robots" content="noindex, follow"', $body);
+    }
+
+    #[Test]
+    public function lesson_has_course_jsonld_and_breadcrumb_and_canonical(): void
+    {
+        $response = $this->send('GET', '/lessons/the-kitchen');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = (string) $response->getContent();
+
+        self::assertStringContainsString('"@type":["Course","LearningResource"]', $body);
+        self::assertStringContainsString('"@type":"BreadcrumbList"', $body);
+        self::assertStringContainsString('/lessons/the-kitchen"', $body);
+    }
+
+    #[Test]
+    public function games_index_has_breadcrumb_jsonld(): void
+    {
+        $body = (string) $this->send('GET', '/games')->getContent();
+        self::assertStringContainsString('"@type":"BreadcrumbList"', $body);
+        self::assertStringContainsString('name="robots" content="index, follow"', $body);
+    }
+}

--- a/tests/App/Unit/Http/Controller/Site/SitemapControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Site/SitemapControllerTest.php
@@ -54,8 +54,12 @@ final class SitemapControllerTest extends TestCase
 
         $body = $response->getContent();
         $this->assertStringContainsString('https://minoo.live/', $body);
+        $this->assertStringContainsString('https://minoo.live/lessons', $body);
+        $this->assertStringContainsString('https://minoo.live/lessons/the-kitchen', $body);
         $this->assertStringContainsString('https://minoo.live/communities/sagamok-anishnawbek', $body);
         $this->assertStringContainsString('https://minoo.live/language/makwa', $body);
+        // Search results are noindex, so they must not be in the sitemap.
+        $this->assertStringNotContainsString('/language/search', $body);
 
         // Well-formed XML.
         $doc = new \DOMDocument();


### PR DESCRIPTION
Site-wide SEO pass over the final URLs from #861/#862/#863.

## What landed
- **Canonical**: self-referential, absolute, **locale-aware** `<link rel="canonical">` on every page (via an un-prefixed `seo_path`). Verified `/oj/` → canonical `…/oj/`.
- **hreflang**: `en` / `oj` / `x-default` alternates on every page.
- **robots**: a `robots` meta (default `index, follow`, overridable per page). `/language/search` → **`noindex, follow`** and removed from the sitemap.
- **Lessons**: per-lesson meta + og description, **`Course`/`LearningResource`** JSON-LD, and a `BreadcrumbList`; the lessons index gets its own description + breadcrumb.
- **Games**: index + each game (shkoda, crossword, agim, matcher) get a meta description + `BreadcrumbList`. **Community detail** gets a `BreadcrumbList`.
- Reusable `components/seo/breadcrumb.html.twig` (Home prepended, absolute locale-aware URLs).
- **Sitemap** now lists `/lessons` + `/lessons/the-kitchen` alongside games, communities, dictionary landing, and static pages.
- No CSS changed (no `?v` bump).

## Verification (live + tests)
- `/` → `robots index, follow`, `canonical https://minoo.live/`, hreflang en/oj/x-default. `/oj/` → `canonical https://minoo.live/oj/`.
- `/language/search` → `robots noindex, follow`.
- `/lessons/the-kitchen` → `"@type":["Course","LearningResource"]` + `BreadcrumbList`.
- `bin/waaseyaa schema:check` clean; `./vendor/bin/phpunit` green (**519**, +4); `composer phpstan` no errors; `composer cs-fixer` clean.
- Tests: `SeoMetaTest` (canonical/hreflang/robots/noindex/Course/breadcrumb); `SitemapControllerTest` now asserts `/lessons` in and `/language/search` out.

Refs #865