### PR TITLE
feat(#876): Anokii Overview as a live pipeline dashboard

### DIFF
--- a/src/Anokii/Pipeline/PipelineCounts.php
+++ b/src/Anokii/Pipeline/PipelineCounts.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Pipeline;
+
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Computes the live pipeline funnel for the Anokii overview (#876): how many
+ * corpus items sit at each {@see PipelineStage}, and which actionable stage has
+ * the most pending work (the "do next" CTA).
+ *
+ * Scope is the corpus (example_sentence rows whose source_sentence_id is
+ * `corpus:*`) — the same set the Transcribe/Curate tabs work on. Stage is taken
+ * from {@see PipelineStageResolver}, so legacy rows count correctly without a
+ * backfill.
+ */
+final class PipelineCounts
+{
+    /**
+     * Actionable stages, in the order a reviewer should clear them. The "do
+     * next" CTA picks the actionable stage with the most items.
+     */
+    private const array ACTIONABLE = [
+        PipelineStage::DRAFTED,
+        PipelineStage::TRANSCRIBED,
+        PipelineStage::INGESTED,
+    ];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly PipelineStageResolver $resolver = new PipelineStageResolver(),
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   counts: array<string, int>,
+     *   total: int,
+     *   do_next: array{stage: string, label: string, href: string, count: int}|null
+     * }
+     */
+    public function compute(): array
+    {
+        $counts = array_fill_keys(PipelineStage::ORDER, 0);
+
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            return ['counts' => $counts, 'total' => 0, 'do_next' => null];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        // accessCheck(false): staff-gated overview, must count UNREVIEWED drafts
+        // (status 0 / consent off) the same way the Transcribe/Curate tools show
+        // them. The route's requireRole is the access boundary. See the bypass
+        // audit doc.
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->execute();
+
+        if ($ids === []) {
+            return ['counts' => $counts, 'total' => 0, 'do_next' => null];
+        }
+
+        $total = 0;
+        foreach ($storage->loadMultiple($ids) as $sentence) {
+            $stage = $this->resolver->resolve($sentence);
+            $counts[$stage] = ($counts[$stage] ?? 0) + 1;
+            ++$total;
+        }
+
+        return ['counts' => $counts, 'total' => $total, 'do_next' => $this->doNext($counts)];
+    }
+
+    /**
+     * @param array<string, int> $counts
+     *
+     * @return array{stage: string, label: string, href: string, count: int}|null
+     */
+    private function doNext(array $counts): ?array
+    {
+        $best = null;
+        foreach (self::ACTIONABLE as $stage) {
+            $count = $counts[$stage] ?? 0;
+            if ($count > 0 && ($best === null || $count > $best['count'])) {
+                $best = ['stage' => $stage, 'label' => PipelineStage::label($stage), 'href' => PipelineStage::href($stage), 'count' => $count];
+            }
+        }
+
+        return $best;
+    }
+}

--- a/src/Anokii/Pipeline/PipelineStage.php
+++ b/src/Anokii/Pipeline/PipelineStage.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Pipeline;
+
+/**
+ * The Anokii corpus pipeline (#876). Every corpus item moves through these
+ * ordered stages, and the whole workspace UI is driven off them:
+ *
+ *   ingested   raw upload, no draft yet
+ *   drafted    vision/ASR filled, unreviewed
+ *   transcribed human-confirmed Ojibwe + English
+ *   curated    promoted to dictionary/lesson
+ *   published  live on public surfaces
+ *
+ * Stage is stored verbatim in example_sentence.pipeline_status; legacy rows are
+ * resolved on the fly by {@see PipelineStageResolver}. This class is the single
+ * source of truth for stage identity, ordering, labels, and where each stage's
+ * items live in the workspace.
+ */
+final class PipelineStage
+{
+    public const string INGESTED = 'ingested';
+    public const string DRAFTED = 'drafted';
+    public const string TRANSCRIBED = 'transcribed';
+    public const string CURATED = 'curated';
+    public const string PUBLISHED = 'published';
+
+    /** Stages in pipeline order. */
+    public const array ORDER = [
+        self::INGESTED,
+        self::DRAFTED,
+        self::TRANSCRIBED,
+        self::CURATED,
+        self::PUBLISHED,
+    ];
+
+    /** @var array<string, string> */
+    private const array LABELS = [
+        self::INGESTED => 'Ingested',
+        self::DRAFTED => 'Awaiting transcription',
+        self::TRANSCRIBED => 'Ready to curate',
+        self::CURATED => 'In lessons',
+        self::PUBLISHED => 'Published',
+    ];
+
+    /**
+     * Where the funnel sends a reviewer to act on a stage's items. Each carries a
+     * `?stage=` so the destination tab can filter to exactly those rows (#878).
+     *
+     * @var array<string, string>
+     */
+    private const array HREFS = [
+        self::INGESTED => '/admin/anokii/ingest?stage=ingested',
+        self::DRAFTED => '/admin/anokii/transcribe?stage=drafted',
+        self::TRANSCRIBED => '/admin/anokii/curate?stage=transcribed',
+        self::CURATED => '/admin/anokii/curate?stage=curated',
+        self::PUBLISHED => '/admin/anokii/curate?stage=published',
+    ];
+
+    public static function isValid(string $stage): bool
+    {
+        return in_array($stage, self::ORDER, true);
+    }
+
+    public static function label(string $stage): string
+    {
+        return self::LABELS[$stage] ?? ucfirst($stage);
+    }
+
+    public static function href(string $stage): string
+    {
+        return self::HREFS[$stage] ?? '/admin/anokii';
+    }
+}

--- a/src/Anokii/Pipeline/PipelineStageResolver.php
+++ b/src/Anokii/Pipeline/PipelineStageResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Pipeline;
+
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Resolves the effective {@see PipelineStage} of a corpus example_sentence (#876).
+ *
+ * An explicit `pipeline_status` value (set by the workspace transitions) always
+ * wins. For legacy rows — imported before the field existed — the stage is
+ * derived from the row's shape so the dashboard works without a backfill, and
+ * the backfill command ({@see \App\Console\AnokiiBackfillStatusHandler}) can
+ * persist what this derives.
+ */
+final class PipelineStageResolver
+{
+    public function resolve(EntityInterface $sentence): string
+    {
+        $explicit = trim((string) ($sentence->get('pipeline_status') ?? ''));
+        if ($explicit !== '' && PipelineStage::isValid($explicit)) {
+            return $explicit;
+        }
+
+        return $this->derive($sentence);
+    }
+
+    /**
+     * Best-effort stage for a legacy row with no explicit pipeline_status.
+     */
+    private function derive(EntityInterface $sentence): string
+    {
+        $status = (int) ($sentence->get('status') ?? 0);
+        $consentPublic = (int) ($sentence->get('consent_public') ?? 0);
+        $dictionaryEntryId = (int) ($sentence->get('dictionary_entry_id') ?? 0);
+        $ojibwe = trim((string) $sentence->get('ojibwe_text'));
+        $english = trim((string) $sentence->get('english_text'));
+
+        // Promoted to vocabulary: curated, or published once it is publicly live.
+        if ($dictionaryEntryId > 0) {
+            return ($status === 1 && $consentPublic === 1) ? PipelineStage::PUBLISHED : PipelineStage::CURATED;
+        }
+
+        // Both languages confirmed but not yet promoted: ready to curate.
+        if ($ojibwe !== '' && $english !== '') {
+            return PipelineStage::TRANSCRIBED;
+        }
+
+        // Some draft text or media exists but the transcription is incomplete.
+        $hasMedia = trim((string) $sentence->get('thumbnail_url')) !== ''
+            || trim((string) $sentence->get('audio_url')) !== ''
+            || trim((string) $sentence->get('video_url')) !== '';
+        if ($ojibwe !== '' || $english !== '' || $hasMedia) {
+            return PipelineStage::DRAFTED;
+        }
+
+        return PipelineStage::INGESTED;
+    }
+}

--- a/src/Console/AnokiiBackfillStatusHandler.php
+++ b/src/Console/AnokiiBackfillStatusHandler.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use App\Anokii\Pipeline\PipelineStageResolver;
+use Waaseyaa\CLI\Command\SymfonyCommandIO;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * `bin/waaseyaa anokii:backfill-status [--dry-run]` (#876).
+ *
+ * Persists `pipeline_status` on corpus example_sentence rows that predate the
+ * field, deriving each row's stage with {@see PipelineStageResolver}. Rows that
+ * already carry an explicit stage are left untouched, so re-running is safe and
+ * never clobbers a workspace transition. The dashboard already resolves stage on
+ * the fly; this just materializes it so future transitions start from a known
+ * value.
+ */
+final class AnokiiBackfillStatusHandler
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly PipelineStageResolver $resolver = new PipelineStageResolver(),
+    ) {
+    }
+
+    public function execute(SymfonyCommandIO $io): int
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            $io->error('example_sentence entity type is not registered.');
+            return 1;
+        }
+
+        $dryRun = (bool) $io->option('dry-run');
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->execute();
+
+        if ($ids === []) {
+            $io->writeln('No corpus rows found.');
+            return 0;
+        }
+
+        $updated = 0;
+        $skipped = 0;
+        foreach ($storage->loadMultiple($ids) as $sentence) {
+            $existing = trim((string) ($sentence->get('pipeline_status') ?? ''));
+            if ($existing !== '') {
+                ++$skipped;
+                continue;
+            }
+
+            $stage = $this->resolver->resolve($sentence);
+            $io->writeln(sprintf('%s #%s -> %s', $dryRun ? '[dry-run]' : '[set]', $sentence->id(), $stage));
+
+            if (!$dryRun) {
+                $sentence->set('pipeline_status', $stage);
+                $sentence->set('updated_at', time());
+                $storage->save($sentence);
+            }
+            ++$updated;
+        }
+
+        $io->writeln(sprintf("\nDone. %s=%d skipped(explicit)=%d", $dryRun ? 'would-update' : 'updated', $updated, $skipped));
+
+        return 0;
+    }
+}

--- a/src/Http/Controller/Anokii/AnokiiAdminController.php
+++ b/src/Http/Controller/Anokii/AnokiiAdminController.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Anokii;
 
+use App\Anokii\Pipeline\PipelineCounts;
 use App\Http\View\AnokiiShellContext;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\Attribute\MapQuery;
 use Waaseyaa\SSR\Attribute\MapRoute;
 
@@ -24,16 +26,23 @@ use Waaseyaa\SSR\Attribute\MapRoute;
 final class AnokiiAdminController
 {
     public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
         private readonly Environment $twig,
     ) {
     }
 
     public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
-        $active = (string) ($params['sub'] ?? 'home');
+        // The Overview is the workspace home; any unknown /admin/anokii/{sub}
+        // falls through here too, so keep it the live pipeline dashboard.
+        $snapshot = (new PipelineCounts($this->entityTypeManager))->compute();
 
-        $html = $this->twig->render('pages/anokii/index.html.twig', AnokiiShellContext::build($account, $active, [
+        $html = $this->twig->render('pages/anokii/index.html.twig', AnokiiShellContext::build($account, 'home', [
             'path' => $request->getPathInfo(),
+            'pipeline' => $snapshot,
+            'counts' => $snapshot['counts'],
+            'total' => $snapshot['total'],
+            'do_next' => $snapshot['do_next'],
         ]));
 
         return new Response($html);

--- a/src/Http/Controller/Anokii/CurateController.php
+++ b/src/Http/Controller/Anokii/CurateController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Anokii;
 
+use App\Anokii\Pipeline\PipelineCounts;
 use App\Http\View\AnokiiShellContext;
 use App\Ingestion\Curation\UtterancePromoter;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -45,6 +46,8 @@ final class CurateController
             'promoted' => $promoted,
             'promote_url' => '/admin/anokii/curate/promote',
             'csrf_token' => CsrfMiddleware::token(),
+            'pipeline' => (new PipelineCounts($this->entityTypeManager))->compute(),
+            'pipeline_active' => 'transcribed',
         ]));
 
         return new Response($html);

--- a/src/Http/Controller/Anokii/TranscribeController.php
+++ b/src/Http/Controller/Anokii/TranscribeController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Anokii;
 
+use App\Anokii\Pipeline\PipelineCounts;
 use App\Http\View\AnokiiShellContext;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -60,6 +61,8 @@ final class TranscribeController
             'show_all' => $showAll,
             'save_url' => '/admin/anokii/transcribe/save',
             'csrf_token' => CsrfMiddleware::token(),
+            'pipeline' => (new PipelineCounts($this->entityTypeManager))->compute(),
+            'pipeline_active' => 'drafted',
         ]));
 
         return new Response($html);

--- a/src/Http/View/AnokiiShellContext.php
+++ b/src/Http/View/AnokiiShellContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\View;
 
+use App\Anokii\Pipeline\PipelineStage;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\User\User;
 
@@ -25,6 +26,16 @@ final class AnokiiShellContext
     {
         $label = self::accountLabel($account);
 
+        // When a controller passes a `pipeline` snapshot (App\Anokii\Pipeline\
+        // PipelineCounts::compute()), expand it into a thin breadcrumb/progress
+        // bar shown across every tab so the workspace reads as one flow (#876).
+        if (isset($extra['pipeline']) && is_array($extra['pipeline'])) {
+            $extra['pipeline_bar'] = self::pipelineBar(
+                $extra['pipeline']['counts'] ?? [],
+                (string) ($extra['pipeline_active'] ?? ''),
+            );
+        }
+
         return $extra + [
             'nav' => self::nav(),
             'nav_active' => $active,
@@ -37,8 +48,8 @@ final class AnokiiShellContext
     }
 
     /**
-     * Sidebar nav. Transcribe (#853) and Curate (#855) are live; Ingest (#854)
-     * is a CLI command (bin/waaseyaa ingest:corpus), so it has no tab.
+     * Sidebar nav in pipeline flow order (#876): Ingest -> Transcribe -> Curate
+     * -> Lessons. The Overview funnel is the workspace home.
      *
      * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
      */
@@ -46,9 +57,35 @@ final class AnokiiShellContext
     {
         return [
             ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
-            ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '/admin/anokii/transcribe', 'group' => 'Language'],
+            ['id' => 'ingest', 'label' => 'Ingest', 'href' => '/admin/anokii/ingest', 'group' => 'Pipeline'],
+            ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '/admin/anokii/transcribe'],
             ['id' => 'curate', 'label' => 'Curate', 'href' => '/admin/anokii/curate'],
+            ['id' => 'lessons', 'label' => 'Lessons', 'href' => '/lessons', 'group' => 'Publish'],
         ];
+    }
+
+    /**
+     * The cross-tab pipeline breadcrumb: one chip per stage with its live count,
+     * the current stage highlighted.
+     *
+     * @param array<string, int> $counts
+     *
+     * @return list<array{id: string, label: string, count: int, href: string, active: bool}>
+     */
+    private static function pipelineBar(array $counts, string $active): array
+    {
+        $bar = [];
+        foreach (PipelineStage::ORDER as $stage) {
+            $bar[] = [
+                'id' => $stage,
+                'label' => PipelineStage::label($stage),
+                'count' => (int) ($counts[$stage] ?? 0),
+                'href' => PipelineStage::href($stage),
+                'active' => $stage === $active,
+            ];
+        }
+
+        return $bar;
     }
 
     private static function accountLabel(AccountInterface $account): string

--- a/src/Ingestion/Corpus/CorpusIngestor.php
+++ b/src/Ingestion/Corpus/CorpusIngestor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Corpus;
 
+use App\Anokii\Pipeline\PipelineStage;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
@@ -102,6 +103,9 @@ final class CorpusIngestor
                         'vision_notes' => $draft['notes'],
                     ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
                     'language_code' => 'oj',
+                    // Pipeline stage (#876): a vision draft lands as `drafted`;
+                    // --skip-vision leaves it `ingested` for manual transcription.
+                    'pipeline_status' => $skipVision ? PipelineStage::INGESTED : PipelineStage::DRAFTED,
                     // Unreviewed draft: off all public surfaces until published.
                     'consent_public' => 0,
                     'consent_ai_training' => 0,

--- a/src/Provider/AppCommandServiceProvider.php
+++ b/src/Provider/AppCommandServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
+use App\Console\AnokiiBackfillStatusHandler;
 use App\Console\IngestCorpusHandler;
 use App\Console\MailTestHandler;
 use App\Ingestion\Corpus\CorpusIngestor;
@@ -38,6 +39,10 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
             );
         });
 
+        $this->singleton(AnokiiBackfillStatusHandler::class, function (): AnokiiBackfillStatusHandler {
+            return new AnokiiBackfillStatusHandler($this->resolve(EntityTypeManager::class));
+        });
+
         $this->singleton(IngestCorpusHandler::class, function (): IngestCorpusHandler {
             $corpusPath = $this->corpusPath();
             return new IngestCorpusHandler(
@@ -52,6 +57,19 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
 
     public function consoleCommands(): iterable
     {
+        yield new HandlerCommand(
+            name: 'anokii:backfill-status',
+            description: 'Persist pipeline_status on legacy corpus example_sentence rows (#876)',
+            handler: [AnokiiBackfillStatusHandler::class, 'execute'],
+            options: [
+                new HandlerOption(
+                    name: 'dry-run',
+                    mode: HandlerOptionMode::None,
+                    description: 'Report what would be set without writing entities',
+                ),
+            ],
+        );
+
         yield new HandlerCommand(
             name: 'mail:test',
             description: 'Send a test email to verify SendGrid configuration',

--- a/src/Provider/Entity/EntityFoundationProvider.php
+++ b/src/Provider/Entity/EntityFoundationProvider.php
@@ -126,6 +126,11 @@ final class EntityFoundationProvider extends AppCoreServiceProvider
                 'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this sentence may be shown on public pages.', 'weight' => 28, 'default' => 1],
                 'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'description' => 'Whether this sentence may be used for AI training. Default: no.', 'weight' => 29, 'default' => 0],
                 'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
+                // Anokii workspace pipeline stage (#876). Drives the workspace UI:
+                // ingested -> drafted -> transcribed -> curated -> published. Stored
+                // in the _data JSON blob (no migration); legacy rows are resolved
+                // on the fly by App\Anokii\Pipeline\PipelineStageResolver.
+                'pipeline_status' => ['type' => 'string', 'label' => 'Pipeline Stage', 'description' => 'Anokii workspace stage: ingested|drafted|transcribed|curated|published.', 'weight' => 31],
                 'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
                 'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
             ],

--- a/templates/components/anokii/pipeline-bar.html.twig
+++ b/templates/components/anokii/pipeline-bar.html.twig
@@ -1,0 +1,33 @@
+{#
+  Anokii cross-tab pipeline breadcrumb (#876).
+
+  A thin, persistent progress bar shown on every workspace tab so the pages read
+  as one flow: ingested → drafted → transcribed → curated → published, each chip
+  carrying its live count and linking to where those items are worked. The
+  current stage is highlighted. Renders nothing when `pipeline_bar` is absent.
+
+  Styles are scoped here so any tab can `{% include %}` it inside the shell's
+  `topbar` block without duplicating CSS. The Anokii shell is fully inline-styled
+  (no external stylesheet), so there is no ?v= cache-bust to maintain here.
+#}
+{% if pipeline_bar is defined and pipeline_bar %}
+<style>
+  .anokii-pipeline{ display:flex; align-items:stretch; gap:0; flex-wrap:wrap; padding:10px 30px; border-bottom:1px solid var(--anokii-shell-line); background:var(--anokii-shell-card); }
+  .anokii-pipeline .pl-step{ display:flex; align-items:center; gap:8px; padding:4px 14px 4px 10px; color:var(--anokii-shell-muted); font-size:13px; position:relative; }
+  .anokii-pipeline .pl-step:not(:last-child)::after{ content:'→'; margin-left:14px; opacity:.4; }
+  .anokii-pipeline .pl-step.on{ color:var(--anokii-shell-ink); font-weight:600; }
+  .anokii-pipeline .pl-count{ display:inline-grid; place-items:center; min-width:22px; height:22px; padding:0 6px; border-radius:11px; background:var(--anokii-shell-bg); border:1px solid var(--anokii-shell-line); font-variant-numeric:tabular-nums; font-size:12.5px; }
+  .anokii-pipeline .pl-step.on .pl-count{ background:var(--anokii-shell-accent); color:var(--anokii-shell-accent-ink); border-color:transparent; }
+  .anokii-pipeline a.pl-step:hover{ color:var(--anokii-shell-ink); }
+  .anokii-pipeline a.pl-step:hover .pl-count{ border-color:var(--anokii-shell-accent); }
+  @media(max-width:620px){ .anokii-pipeline{ padding:8px 16px; font-size:12px; } .anokii-pipeline .pl-step:not(:last-child)::after{ margin-left:8px; } }
+</style>
+<nav class="anokii-pipeline" aria-label="Corpus pipeline progress">
+  {% for step in pipeline_bar %}
+    <a class="pl-step{{ step.active ? ' on' : '' }}" href="{{ step.href }}"{{ step.active ? ' aria-current="step"' : '' }}>
+      <span class="pl-label">{{ step.label }}</span>
+      <span class="pl-count">{{ step.count }}</span>
+    </a>
+  {% endfor %}
+</nav>
+{% endif %}

--- a/templates/pages/anokii/curate.html.twig
+++ b/templates/pages/anokii/curate.html.twig
@@ -27,6 +27,8 @@
   .cu-empty{ padding:28px; border:1px dashed var(--anokii-shell-line); border-radius:12px; color:var(--anokii-shell-muted); }
 {% endblock %}
 
+{% block topbar %}{% include "components/anokii/pipeline-bar.html.twig" %}{% endblock %}
+
 {% block content %}
   <div class="cu-head" data-promote-url="{{ promote_url }}" data-csrf="{{ csrf_token }}" id="cu-dash">
     <h1>Curate</h1>

--- a/templates/pages/anokii/index.html.twig
+++ b/templates/pages/anokii/index.html.twig
@@ -1,44 +1,78 @@
 {#
-  Anokii admin shell landing (#851).
+  Anokii Overview — the live pipeline dashboard (#876).
 
-  Extends the Anokii package shell via the @anokii namespace (registered by
-  App\Provider\AnokiiServiceProvider) — never forked. Theming is applied by
-  overriding the shell's --color-* tokens in the shell_styles block, using the
-  Minoo palette supplied as the `anokii_theme_css` global. Brand identity comes
-  from the `anokii_brand_*` globals. Nav + user-chip context come from
-  AnokiiAdminController.
-
-  Empty by design: the workspace tabs (Transcribe / Ingest / Curate) are
-  advertised as "Soon" until their issues land (#853, #854, #855).
+  Replaces the old static landing. Shows the corpus funnel (a count per stage,
+  each a button that jumps to where those items are worked) and one primary
+  "do next" CTA = the actionable stage with the most pending work. Extends the
+  Anokii package shell via @anokii (never forked); the cross-tab pipeline
+  breadcrumb is shared via components/anokii/pipeline-bar.html.twig.
 #}
 {% extends "@anokii/_shell.html.twig" %}
 
-{% block title %}{{ anokii_brand_title|default('Minoo') }} — {{ anokii_brand_tag|default('Language Workspace') }}{% endblock %}
+{% block title %}Overview — {{ anokii_brand_title|default('Minoo') }} {{ anokii_brand_tag|default('Language Workspace') }}{% endblock %}
 
 {% block shell_styles %}
   {{ anokii_theme_css|default('')|raw }}
-  .anokii-lede{ max-width: 56ch; }
-  .anokii-lede h1{ font-size: 1.6rem; line-height: 1.2; margin-bottom: .5rem; }
-  .anokii-lede p{ color: var(--anokii-shell-muted); }
-  .anokii-soon{ margin-top: 1.75rem; display: grid; gap: .75rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
-  .anokii-soon .card{ background: var(--anokii-shell-card); border: 1px solid var(--anokii-shell-line); border-radius: 12px; padding: 14px 16px; }
-  .anokii-soon .card b{ display: block; }
-  .anokii-soon .card small{ color: var(--anokii-shell-muted); }
+  .ov-head{ max-width:64ch; margin-bottom:22px; }
+  .ov-head h1{ font-size:1.6rem; line-height:1.2; margin-bottom:.4rem; }
+  .ov-head p{ color:var(--anokii-shell-muted); }
+  .ov-cta{ display:flex; align-items:center; gap:14px; flex-wrap:wrap; background:var(--anokii-shell-card); border:1px solid var(--anokii-shell-line); border-left:4px solid var(--anokii-shell-accent); border-radius:12px; padding:16px 18px; margin-bottom:24px; }
+  .ov-cta .ov-cta-text{ flex:1; min-width:200px; }
+  .ov-cta .ov-cta-text b{ display:block; font-size:1.05rem; }
+  .ov-cta .ov-cta-text small{ color:var(--anokii-shell-muted); }
+  .ov-btn{ display:inline-block; background:var(--anokii-shell-accent); color:var(--anokii-shell-accent-ink); border-radius:9px; padding:10px 18px; font-weight:600; font-size:14.5px; }
+  .ov-btn:hover{ filter:brightness(1.07); }
+  .ov-funnel{ display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(170px, 1fr)); }
+  .ov-stage{ display:block; background:var(--anokii-shell-card); border:1px solid var(--anokii-shell-line); border-radius:12px; padding:16px 18px; transition:border-color .12s, transform .12s; }
+  .ov-stage:hover{ border-color:var(--anokii-shell-accent); transform:translateY(-1px); }
+  .ov-stage .ov-n{ font-size:2rem; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; }
+  .ov-stage .ov-label{ display:block; margin-top:6px; color:var(--anokii-shell-muted); font-size:13.5px; }
+  .ov-stage .ov-go{ display:block; margin-top:10px; color:var(--anokii-shell-accent); font-size:13px; font-weight:600; }
+  .ov-empty{ padding:28px; border:1px dashed var(--anokii-shell-line); border-radius:12px; color:var(--anokii-shell-muted); }
 {% endblock %}
 
 {% block brand %}
   <b>{{ anokii_brand_title|default('Minoo') }}</b>&nbsp;<span style="opacity:.6;font-weight:400">{{ anokii_brand_tag|default('Language Workspace') }}</span>
 {% endblock %}
 
+{% block topbar %}{% include "components/anokii/pipeline-bar.html.twig" %}{% endblock %}
+
 {% block content %}
-  <div class="anokii-lede">
-    <h1>Anokii — Language Workspace</h1>
-    <p>The home for transcribing, ingesting, and curating Anishinaabemowin from the community corpus. Tools arrive here as they land.</p>
+  <div class="ov-head">
+    <h1>Overview</h1>
+    <p>Every reel from the community corpus moves through one flow: ingest it, transcribe the Anishinaabemowin and English, curate it into the dictionary and lessons, then publish. {{ total }} item{{ total == 1 ? '' : 's' }} in the pipeline.</p>
   </div>
 
-  <div class="anokii-soon">
-    <div class="card"><b><a href="/admin/anokii/transcribe" style="color:var(--anokii-shell-accent)">Transcribe →</a></b><small>Whiteboard cards → entries.</small></div>
-    <div class="card"><b><a href="/admin/anokii/curate" style="color:var(--anokii-shell-accent)">Curate →</a></b><small>Promote utterances into vocabulary.</small></div>
-    <div class="card"><b>Ingest</b><small>CLI: <code>bin/waaseyaa ingest:corpus</code>.</small></div>
+  {% if do_next %}
+    <div class="ov-cta">
+      <div class="ov-cta-text">
+        <b>
+          {%- if do_next.stage == 'drafted' -%}{{ do_next.count }} draft{{ do_next.count == 1 ? '' : 's' }} awaiting transcription
+          {%- elseif do_next.stage == 'transcribed' -%}{{ do_next.count }} item{{ do_next.count == 1 ? '' : 's' }} ready to curate
+          {%- elseif do_next.stage == 'ingested' -%}{{ do_next.count }} new upload{{ do_next.count == 1 ? '' : 's' }} to process
+          {%- else -%}{{ do_next.count }} item{{ do_next.count == 1 ? '' : 's' }} need attention
+          {%- endif -%}
+        </b>
+        <small>The stage with the most pending work. Start here.</small>
+      </div>
+      <a class="ov-btn" href="{{ do_next.href }}">
+        {%- if do_next.stage == 'drafted' -%}Transcribe →
+        {%- elseif do_next.stage == 'transcribed' -%}Curate →
+        {%- elseif do_next.stage == 'ingested' -%}Process →
+        {%- else -%}Open →{%- endif -%}
+      </a>
+    </div>
+  {% elseif total == 0 %}
+    <div class="ov-empty">No corpus items yet. Head to <a href="/admin/anokii/ingest" style="color:var(--anokii-shell-accent)">Ingest</a> to drop in reels.</div>
+  {% endif %}
+
+  <div class="ov-funnel">
+    {% for step in pipeline_bar %}
+      <a class="ov-stage" href="{{ step.href }}">
+        <span class="ov-n">{{ step.count }}</span>
+        <span class="ov-label">{{ step.label }}</span>
+        <span class="ov-go">View →</span>
+      </a>
+    {% endfor %}
   </div>
 {% endblock %}

--- a/templates/pages/anokii/transcribe.html.twig
+++ b/templates/pages/anokii/transcribe.html.twig
@@ -31,6 +31,8 @@
   @media(max-width:620px){ .tx-row{ grid-template-columns:1fr; } .tx-media img,.tx-media audio{ width:100%; } }
 {% endblock %}
 
+{% block topbar %}{% include "components/anokii/pipeline-bar.html.twig" %}{% endblock %}
+
 {% block content %}
   <div class="tx-head" data-save-url="{{ save_url }}" data-csrf="{{ csrf_token }}" id="tx-dash">
     <h1>Transcribe</h1>

--- a/tests/App/Integration/Http/Admin/AnokiiOverviewTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiOverviewTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Anokii Overview as the live pipeline dashboard (#876):
+ *   - role-gated (admin / elder_coordinator), denied for anonymous,
+ *   - renders a funnel with a live count per stage,
+ *   - surfaces a single "do next" CTA = the actionable stage with the most work,
+ *   - reorders the shell nav into flow order (Ingest before Transcribe),
+ *   - shows the persistent cross-tab pipeline breadcrumb.
+ *
+ * Counts are deterministic: per-class :memory: DB, seeded below.
+ */
+#[CoversNothing]
+final class AnokiiOverviewTest extends HttpKernelTestCase
+{
+    private static int $adminUid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $admin = $users->create(['name' => 'Ov Admin', 'mail' => 'ov-admin@example.test', 'status' => true, 'created' => time(), 'roles' => ['admin'], 'permissions' => []]);
+        $users->save($admin);
+        self::$adminUid = (int) $admin->id();
+
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $i = 0;
+        $seed = static function (array $values) use ($sentences, &$i): void {
+            ++$i;
+            $sentences->save($sentences->create($values + [
+                'source_sentence_id' => 'corpus:ov-' . $i,
+                'consent_public' => 0,
+                'status' => 0,
+                'created_at' => time(),
+                'updated_at' => time(),
+            ]));
+        };
+
+        // 2 ingested, 3 drafted (explicit), 1 transcribed (derived), 1 curated (explicit). Total 7.
+        $seed(['ojibwe_text' => '', 'english_text' => '', 'pipeline_status' => PipelineStage::INGESTED]);
+        $seed(['ojibwe_text' => '', 'english_text' => '', 'pipeline_status' => PipelineStage::INGESTED]);
+        $seed(['ojibwe_text' => 'a', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'b', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'c', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'Makwa', 'english_text' => 'bear']); // derived -> transcribed
+        $seed(['ojibwe_text' => 'Waaban', 'english_text' => 'dawn', 'pipeline_status' => PipelineStage::CURATED]);
+    }
+
+    #[Test]
+    public function admin_sees_the_funnel_with_live_counts(): void
+    {
+        $response = $this->sendAs(self::$adminUid, '/admin/anokii');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('anokii-app', $body);
+        self::assertStringContainsString('Overview', $body);
+        self::assertStringContainsString('ov-funnel', $body);
+        self::assertStringContainsString('7 items in the pipeline', $body);
+
+        // Funnel buttons jump to each stage, filtered.
+        self::assertStringContainsString('/admin/anokii/ingest?stage=ingested', $body);
+        self::assertStringContainsString('/admin/anokii/transcribe?stage=drafted', $body);
+        self::assertStringContainsString('/admin/anokii/curate?stage=transcribed', $body);
+    }
+
+    #[Test]
+    public function the_do_next_cta_points_at_the_busiest_actionable_stage(): void
+    {
+        // drafted=3 beats transcribed=1 and ingested=2 -> CTA is "Transcribe".
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii')->getContent();
+
+        self::assertStringContainsString('3 drafts awaiting transcription', $body);
+        self::assertStringContainsString('Transcribe →', $body);
+    }
+
+    #[Test]
+    public function the_persistent_pipeline_breadcrumb_renders(): void
+    {
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii')->getContent();
+
+        self::assertStringContainsString('anokii-pipeline', $body);
+        self::assertStringContainsString('Awaiting transcription', $body);
+        self::assertStringContainsString('Ready to curate', $body);
+    }
+
+    #[Test]
+    public function the_nav_is_in_pipeline_flow_order(): void
+    {
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii')->getContent();
+
+        $ingest = strpos($body, 'href="/admin/anokii/ingest"');
+        $transcribe = strpos($body, 'href="/admin/anokii/transcribe"');
+        $curate = strpos($body, 'href="/admin/anokii/curate"');
+
+        self::assertNotFalse($ingest, 'Ingest nav link is present.');
+        self::assertNotFalse($transcribe);
+        self::assertNotFalse($curate);
+        self::assertLessThan($transcribe, $ingest, 'Ingest must precede Transcribe in the nav.');
+        self::assertLessThan($curate, $transcribe, 'Transcribe must precede Curate in the nav.');
+    }
+
+    #[Test]
+    public function anonymous_is_denied(): void
+    {
+        $response = $this->send('GET', '/admin/anokii');
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND, Response::HTTP_UNAUTHORIZED]);
+        self::assertStringNotContainsString('ov-funnel', (string) $response->getContent());
+    }
+
+    private function sendAs(int $uid, string $uri): Response
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = $uid;
+
+        return self::$kernel->handle();
+    }
+}

--- a/tests/App/Integration/Http/Admin/AnokiiShellTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiShellTest.php
@@ -81,8 +81,10 @@ final class AnokiiShellTest extends HttpKernelTestCase
         self::assertStringContainsString('anokii-nav', $body);
         self::assertStringNotContainsString('/_nuxt/', $body, '/admin/anokii must not fall through to the Vue admin SPA.');
 
-        // Minoo landing content + placeholder tabs.
-        self::assertStringContainsString('Anokii — Language Workspace', $body);
+        // Overview pipeline dashboard (#876) + flow-order nav tabs.
+        self::assertStringContainsString('Overview', $body);
+        self::assertStringContainsString('ov-funnel', $body);
+        self::assertStringContainsString('Ingest', $body);
         self::assertStringContainsString('Transcribe', $body);
         self::assertStringContainsString('Curate', $body);
     }

--- a/tests/App/Unit/Anokii/PipelineStageResolverTest.php
+++ b/tests/App/Unit/Anokii/PipelineStageResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Anokii;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Anokii\Pipeline\PipelineStageResolver;
+use App\Entity\Language\ExampleSentence;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PipelineStageResolver::class)]
+#[CoversClass(PipelineStage::class)]
+final class PipelineStageResolverTest extends TestCase
+{
+    private PipelineStageResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new PipelineStageResolver();
+    }
+
+    #[Test]
+    public function explicit_pipeline_status_always_wins(): void
+    {
+        // A row that would derive to "curated" (it has a dictionary link) but
+        // carries an explicit stage must report the explicit stage verbatim.
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => 'Aaniin',
+            'english_text' => 'Hello',
+            'dictionary_entry_id' => 7,
+            'pipeline_status' => PipelineStage::TRANSCRIBED,
+        ]);
+
+        self::assertSame(PipelineStage::TRANSCRIBED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function invalid_explicit_value_falls_back_to_derivation(): void
+    {
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => 'Aaniin',
+            'english_text' => 'Hello',
+            'pipeline_status' => 'garbage',
+        ]);
+
+        self::assertSame(PipelineStage::TRANSCRIBED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function empty_row_derives_ingested(): void
+    {
+        $sentence = new ExampleSentence(['ojibwe_text' => '', 'english_text' => '']);
+
+        self::assertSame(PipelineStage::INGESTED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function row_with_media_but_no_translation_derives_drafted(): void
+    {
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => '',
+            'english_text' => '',
+            'thumbnail_url' => '/media/corpus/thumb/sb-1',
+        ]);
+
+        self::assertSame(PipelineStage::DRAFTED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function row_with_both_languages_derives_transcribed(): void
+    {
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => 'Mino-bimaadiziwin',
+            'english_text' => 'the good life',
+        ]);
+
+        self::assertSame(PipelineStage::TRANSCRIBED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function promoted_unpublished_row_derives_curated(): void
+    {
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => 'Makwa',
+            'english_text' => 'bear',
+            'dictionary_entry_id' => 12,
+            'status' => 0,
+            'consent_public' => 0,
+        ]);
+
+        self::assertSame(PipelineStage::CURATED, $this->resolver->resolve($sentence));
+    }
+
+    #[Test]
+    public function promoted_public_row_derives_published(): void
+    {
+        $sentence = new ExampleSentence([
+            'ojibwe_text' => 'Makwa',
+            'english_text' => 'bear',
+            'dictionary_entry_id' => 12,
+            'status' => 1,
+            'consent_public' => 1,
+        ]);
+
+        self::assertSame(PipelineStage::PUBLISHED, $this->resolver->resolve($sentence));
+    }
+}


### PR DESCRIPTION
Closes #876. First PR of the **Anokii Workspace v2** milestone.

## The status model
Every corpus item moves through ordered stages, and the whole workspace UI is driven off them:

`ingested → drafted → transcribed → curated → published`

A new `pipeline_status` string field on `example_sentence` carries the stage. It lives in the `_data` JSON blob, so **no migration** is needed and `schema:check` stays green. `status` (boolean) remains the public-publish gate. Legacy rows with no explicit stage are resolved on the fly by `PipelineStageResolver`, so the dashboard is correct without a backfill; `anokii:backfill-status` can persist it.

## What landed
- `App\Anokii\Pipeline\{PipelineStage, PipelineStageResolver, PipelineCounts}` — stage identity/order/labels, derivation, and the live funnel.
- **Overview** is now a funnel: a live count per stage, each a button that jumps to that stage filtered (`?stage=`), plus one "do next" CTA = the actionable stage with the most pending work.
- Shell nav reordered into flow order: **Ingest → Transcribe → Curate → Lessons**.
- Persistent cross-tab **pipeline breadcrumb** (`components/anokii/pipeline-bar.html.twig`) on Overview, Transcribe, and Curate.
- `anokii:backfill-status [--dry-run]` CLI.
- `CorpusIngestor` stamps `pipeline_status` (drafted, or ingested with `--skip-vision`).

## Constraints honored
- Role gating `admin,elder_coordinator` unchanged.
- ADR 0003 (never normalize Steven's orthography) unchanged; corpus stays fully consented (no new gating).
- Anokii shell uses inline CSS (no external stylesheet) — no `?v=` bump applies.

## Gates
- ✅ phpunit (538 tests, 2 known skips)
- ✅ phpstan level 5 (no errors)
- ✅ cs-fixer (0 to fix, LF)
- ✅ schema:check (no drift)

## Tests
- `PipelineStageResolverTest` — explicit precedence + derivation for each stage.
- `AnokiiOverviewTest` — live counts, do-next CTA selection, breadcrumb, nav flow order, anonymous gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)