### PR TITLE
feat(#877): drag-and-drop multi-reel ingestion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     libpng \
     libjpeg-turbo \
     ttf-dejavu \
+    ffmpeg \
     freetype-dev \
     libpng-dev \
     libjpeg-turbo-dev \

--- a/config/waaseyaa.php
+++ b/config/waaseyaa.php
@@ -90,6 +90,18 @@ return [
         'application/octet-stream',
     ],
 
+    // Anokii reel ingestion (#877): staff drop-zone video uploads are far larger
+    // than the generic media cap. The PHP (upload_max_filesize / post_max_size)
+    // and Caddy (request_body max_size) limits MUST be raised to match in the
+    // deployment image (see waaseyaa-infra) or large uploads are truncated at the
+    // web tier before reaching this validation.
+    'corpus_upload_max_bytes' => 120 * 1024 * 1024, // 120 MiB (~100 MB videos + headroom)
+    'corpus_upload_allowed_mime_types' => [
+        'video/mp4',
+        'video/quicktime', // .mov
+        'video/webm',
+    ],
+
     // Allowed CORS origins for the admin SPA.
     'cors_origins' => ['http://localhost:3000', 'http://127.0.0.1:3000'],
 

--- a/src/Console/ProcessReelsHandler.php
+++ b/src/Console/ProcessReelsHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Ingestion\Corpus\ReelProcessor;
+use Waaseyaa\CLI\Command\SymfonyCommandIO;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * `bin/waaseyaa anokii:process-reels [--limit=N] [--loop] [--sleep=N]` (#877).
+ *
+ * The async worker behind the Anokii drag-and-drop ingest. The upload endpoint
+ * only stages the file + creates an `ingested` draft and returns immediately;
+ * this command does the heavy lifting out-of-band: it finds `pipeline_status=
+ * ingested` example_sentence rows and runs each through {@see ReelProcessor}
+ * (ffmpeg keyframe + opus, then the vision draft), advancing it to `drafted`.
+ *
+ * On the Pi this runs as a long-lived service (`--loop`), which is the worker.
+ * Locally it can be run once to drain the queue. A row is a plain DI service
+ * call here (full container access), not a serialized framework Queue Job —
+ * deserialized jobs can't resolve EntityTypeManager at handle() time.
+ */
+final class ProcessReelsHandler
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly ReelProcessor $processor,
+    ) {
+    }
+
+    public function execute(SymfonyCommandIO $io): int
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            $io->error('example_sentence entity type is not registered.');
+            return 1;
+        }
+
+        $limitOpt = $io->option('limit');
+        $limit = is_numeric($limitOpt) ? max(1, (int) $limitOpt) : null;
+        $loop = (bool) $io->option('loop');
+        $sleepOpt = $io->option('sleep');
+        $sleep = is_numeric($sleepOpt) ? max(1, (int) $sleepOpt) : 5;
+
+        $skipVision = (bool) $io->option('skip-vision');
+
+        do {
+            $processed = $this->drain($limit, $skipVision, $io);
+            if ($loop && $processed === 0) {
+                sleep($sleep);
+            }
+        } while ($loop);
+
+        return 0;
+    }
+
+    private function drain(?int $limit, bool $skipVision, SymfonyCommandIO $io): int
+    {
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('pipeline_status', PipelineStage::INGESTED)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->sort('created_at', 'ASC')
+            ->execute();
+
+        if ($ids === []) {
+            return 0;
+        }
+
+        $processed = 0;
+        foreach ($ids as $id) {
+            if ($limit !== null && $processed >= $limit) {
+                break;
+            }
+            $result = $this->processor->process((int) $id, $skipVision);
+            if ($result['error'] !== null) {
+                $io->writeln(sprintf('[fail] #%d: %s', $result['esid'], $result['error']));
+            } else {
+                $io->writeln(sprintf('[ok] #%d -> %s', $result['esid'], $result['status']));
+            }
+            ++$processed;
+        }
+
+        return $processed;
+    }
+}

--- a/src/Http/Controller/Anokii/AnokiiMediaController.php
+++ b/src/Http/Controller/Anokii/AnokiiMediaController.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\SSR\Attribute\MapRoute;
+
+/**
+ * Staff-gated corpus media for the Anokii workspace (#877).
+ *
+ * The public corpus controllers (CorpusVideo/Image/AudioController) serve a clip
+ * ONLY when its example_sentence row is status=1 AND consent_public=1. Ingest
+ * drafts are status=0 by design, so staff could not see the reel they are about
+ * to transcribe through those routes. This controller serves the same files from
+ * MINOO_CORPUS_PATH WITHOUT the consent gate — the access boundary is instead the
+ * route's requireRole(admin,elder_coordinator). It never touches public surfaces.
+ *
+ *   video -> source-videos/<id>.mp4   (the uploaded original, with Range support)
+ *   thumb -> thumbs/<id>.jpg          (ffmpeg keyframe)
+ *   audio -> audio/<id>.opus          (ffmpeg opus track)
+ *
+ * Path traversal is impossible: kind is whitelisted and id is regex-validated.
+ */
+final class AnokiiMediaController
+{
+    private const string DEFAULT_CORPUS_PATH = 'C:/Users/jones/Projects/LLC/anishinaabemowin/content/corpus';
+
+    /** @var array<string, array{0: string, 1: string}> kind => [subdir/ext, content-type] */
+    private const array KINDS = [
+        'video' => ['source-videos|mp4', 'video/mp4'],
+        'thumb' => ['thumbs|jpg', 'image/jpeg'],
+        'audio' => ['audio|opus', 'audio/ogg'],
+    ];
+
+    /** @param array<string, mixed> $params */
+    public function media(#[MapRoute] array $params, AccountInterface $account, HttpRequest $request): Response
+    {
+        $kind = (string) ($params['kind'] ?? '');
+        $id = (string) ($params['id'] ?? '');
+
+        if (!isset(self::KINDS[$kind]) || $id === '' || preg_match('/^[a-z0-9-]+$/', $id) !== 1) {
+            return new Response('Not found', 404);
+        }
+
+        [$spec, $contentType] = self::KINDS[$kind];
+        [$subdir, $ext] = explode('|', $spec);
+        $file = $this->corpusPath() . '/' . $subdir . '/' . $id . '.' . $ext;
+        if (!is_file($file)) {
+            return new Response('Not found', 404);
+        }
+
+        $size = (int) filesize($file);
+        $start = 0;
+        $end = $size - 1;
+        $status = 200;
+        $headers = [
+            'Content-Type' => $contentType,
+            'Accept-Ranges' => 'bytes',
+            // Drafts are unreviewed staff-only content — never cache.
+            'Cache-Control' => 'private, no-store',
+        ];
+
+        $range = $request->headers->get('Range');
+        if (is_string($range) && preg_match('/^bytes=(\d*)-(\d*)$/', $range, $m) === 1) {
+            if ($m[1] !== '') {
+                $start = (int) $m[1];
+            }
+            if ($m[2] !== '') {
+                $end = (int) $m[2];
+            }
+            if ($start > $end || $start >= $size) {
+                return new Response('', 416, ['Content-Range' => 'bytes */' . $size, 'Accept-Ranges' => 'bytes']);
+            }
+            $end = min($end, $size - 1);
+            $status = 206;
+            $headers['Content-Range'] = 'bytes ' . $start . '-' . $end . '/' . $size;
+        }
+
+        $length = $end - $start + 1;
+        $headers['Content-Length'] = (string) $length;
+
+        $body = ($start === 0 && $length === $size)
+            ? (string) file_get_contents($file)
+            : (string) file_get_contents($file, false, null, $start, $length);
+
+        return new Response($body, $status, $headers);
+    }
+
+    private function corpusPath(): string
+    {
+        $env = getenv('MINOO_CORPUS_PATH');
+
+        return is_string($env) && $env !== '' ? rtrim($env, '/\\') : self::DEFAULT_CORPUS_PATH;
+    }
+}

--- a/src/Http/Controller/Anokii/IngestController.php
+++ b/src/Http/Controller/Anokii/IngestController.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use App\Anokii\Pipeline\PipelineCounts;
+use App\Anokii\Pipeline\PipelineStage;
+use App\Anokii\Pipeline\PipelineStageResolver;
+use App\Http\View\AnokiiShellContext;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\Attribute\MapQuery;
+use Waaseyaa\SSR\Attribute\MapRoute;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+
+/**
+ * Ingest tab (#877) — drag-and-drop multi-reel ingestion, the headline of
+ * Anokii Workspace v2.
+ *
+ * The drop zone uploads each video to the persistent MINOO_CORPUS_PATH staging
+ * area and immediately creates a draft example_sentence (pipeline_status=
+ * ingested) linked to the video, then RETURNS — the heavy work (ffmpeg keyframe
+ * + opus, vision draft) is done out-of-band by the `anokii:process-reels`
+ * worker over the {@see ReelProcessor} seam. The UI polls {@see self::status()}
+ * per row and a finished reel (drafted) flows straight into Transcribe.
+ *
+ * The FB-URL ingest path is kept via {@see self::url()} (and the existing
+ * `ingest:corpus` CLI). Both routes are role-gated (admin / elder_coordinator)
+ * by {@see \App\Provider\Routing\AnokiiRouteProvider}. Ojibwe is never
+ * normalized (ADR 0003); Steven's corpus is fully consented.
+ */
+final class IngestController
+{
+    private const string DEFAULT_CORPUS_PATH = 'C:/Users/jones/Projects/LLC/anishinaabemowin/content/corpus';
+
+    // Mirror config/waaseyaa.php corpus_upload_* — the PHP/Caddy web-tier limits
+    // must also be raised in the deployment image for ~100 MB videos.
+    private const int MAX_BYTES = 120 * 1024 * 1024;
+
+    /** @var list<string> */
+    private const array ALLOWED_MIME = ['video/mp4', 'video/quicktime', 'video/webm'];
+
+    /**
+     * Validation is by client extension/mime, not server finfo: the fileinfo
+     * extension is not guaranteed in every runtime, and these uploads come from
+     * staff (role-gated route). The real content check is downstream — ffmpeg in
+     * ReelProcessor rejects anything that is not decodable video.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_EXT = ['mp4', 'mov', 'm4v', 'webm'];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $html = $this->twig->render('pages/anokii/ingest.html.twig', AnokiiShellContext::build($account, 'ingest', [
+            'path' => $request->getPathInfo(),
+            'rows' => $this->activeRows(),
+            'upload_url' => '/admin/anokii/ingest/upload',
+            'status_url' => '/admin/anokii/ingest/status',
+            'url_url' => '/admin/anokii/ingest/url',
+            'transcribe_url' => '/admin/anokii/transcribe',
+            'max_mb' => intdiv(self::MAX_BYTES, 1024 * 1024),
+            'accept' => implode(',', self::ALLOWED_MIME),
+            'csrf_token' => CsrfMiddleware::token(),
+            'pipeline' => (new PipelineCounts($this->entityTypeManager))->compute(),
+            'pipeline_active' => 'ingested',
+        ]));
+
+        return new Response($html);
+    }
+
+    /**
+     * Accept one or many uploaded videos. Each is staged to
+     * MINOO_CORPUS_PATH/source-videos/<id>.mp4 and gets a draft example_sentence
+     * (pipeline_status=ingested). Processing is deferred to the worker. Returns
+     * a per-file result list so the drop zone can render each row.
+     */
+    public function upload(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $files = $this->uploadedFiles($request);
+        if ($files === []) {
+            return $this->json(['ok' => false, 'error' => 'No files received.'], 422);
+        }
+
+        $results = [];
+        foreach ($files as $file) {
+            $results[] = $this->stageOne($file);
+        }
+
+        return $this->json(['ok' => true, 'files' => $results]);
+    }
+
+    /**
+     * Poll processing status for a set of rows. `esids` is a comma-separated list.
+     */
+    public function status(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $raw = (string) $request->query->get('esids', '');
+        $esids = array_values(array_filter(array_map('intval', explode(',', $raw)), static fn (int $n): bool => $n > 0));
+        if ($esids === []) {
+            return $this->json(['ok' => true, 'rows' => []]);
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $rows = [];
+        foreach ($esids as $esid) {
+            $row = $storage->load($esid);
+            if (!$row instanceof EntityInterface) {
+                continue;
+            }
+            $rows[] = [
+                'esid' => $esid,
+                'pipeline_status' => (string) ($row->get('pipeline_status') ?: PipelineStage::INGESTED),
+                'ojibwe_text' => (string) $row->get('ojibwe_text'),
+                'english_text' => (string) $row->get('english_text'),
+                'error' => $this->processingError($row),
+            ];
+        }
+
+        return $this->json(['ok' => true, 'rows' => $rows]);
+    }
+
+    /**
+     * Keep the Facebook-URL ingest path: register a draft row for a reel URL. The
+     * media is produced when its source video is staged and the worker (or
+     * `ingest:corpus`) runs — the same operator prerequisite as the CLI path.
+     */
+    public function url(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
+    {
+        $data = $this->readBody($request);
+        $url = trim((string) ($data['url'] ?? ''));
+        if ($url === '' || !preg_match('#^https?://#i', $url)) {
+            return $this->json(['ok' => false, 'error' => 'A valid http(s) URL is required.'], 422);
+        }
+
+        $id = 'fb-' . bin2hex(random_bytes(4));
+        $esid = $this->createDraft($id, $url, '');
+
+        return $this->json(['ok' => true, 'esid' => $esid, 'corpus_id' => $id, 'pipeline_status' => PipelineStage::INGESTED]);
+    }
+
+    /**
+     * @return array{corpus_id: string, esid: int|null, status: string, error: string|null, filename: string}
+     */
+    private function stageOne(UploadedFile $file): array
+    {
+        $name = $file->getClientOriginalName();
+
+        if (!$file->isValid()) {
+            return ['corpus_id' => '', 'esid' => null, 'status' => 'error', 'error' => 'Upload failed (' . $file->getErrorMessage() . ').', 'filename' => $name];
+        }
+        if ($file->getSize() > self::MAX_BYTES) {
+            return ['corpus_id' => '', 'esid' => null, 'status' => 'error', 'error' => 'Too large (max ' . intdiv(self::MAX_BYTES, 1024 * 1024) . ' MB).', 'filename' => $name];
+        }
+        $ext = strtolower($file->getClientOriginalExtension());
+        $clientMime = (string) $file->getClientMimeType();
+        if (!in_array($ext, self::ALLOWED_EXT, true) && !in_array($clientMime, self::ALLOWED_MIME, true)) {
+            return ['corpus_id' => '', 'esid' => null, 'status' => 'error', 'error' => 'Unsupported type. Use mp4, mov, or webm.', 'filename' => $name];
+        }
+
+        $id = 'upload-' . bin2hex(random_bytes(5));
+        $dir = $this->corpusPath() . '/source-videos';
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            return ['corpus_id' => '', 'esid' => null, 'status' => 'error', 'error' => 'Could not create staging directory.', 'filename' => $name];
+        }
+
+        try {
+            $file->move($dir, $id . '.mp4');
+        } catch (\Throwable $e) {
+            return ['corpus_id' => '', 'esid' => null, 'status' => 'error', 'error' => 'Could not stage file: ' . $e->getMessage(), 'filename' => $name];
+        }
+
+        $esid = $this->createDraft($id, '', $name);
+
+        return ['corpus_id' => $id, 'esid' => $esid, 'status' => PipelineStage::INGESTED, 'error' => null, 'filename' => $name];
+    }
+
+    /**
+     * Create the ingested draft example_sentence for a staged reel. Off all
+     * public surfaces (consent off, status 0) until reviewed and published.
+     */
+    private function createDraft(string $id, string $sourceUrl, string $filename): int
+    {
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $now = time();
+        $entity = $storage->create([
+            'ojibwe_text' => '',
+            'english_text' => '',
+            'notes' => '',
+            'source_sentence_id' => 'corpus:' . $id,
+            'source_url' => $sourceUrl,
+            'video_url' => '/admin/anokii/media/video/' . $id,
+            'language_code' => 'oj',
+            'pipeline_status' => PipelineStage::INGESTED,
+            'provenance' => (string) json_encode(['id' => $id, 'source_url' => $sourceUrl, 'original_filename' => $filename], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            'consent_public' => 0,
+            'consent_ai_training' => 0,
+            'status' => 0,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $storage->save($entity);
+
+        return (int) $entity->id();
+    }
+
+    /**
+     * Active ingestion rows (ingested or drafted), newest first, for the tab list.
+     *
+     * @return list<array{esid: int, corpus_id: string, pipeline_status: string, filename: string, error: string|null}>
+     */
+    private function activeRows(): array
+    {
+        if (!$this->entityTypeManager->hasDefinition('example_sentence')) {
+            return [];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        // accessCheck(false): staff-gated tool; must show unreviewed drafts. The
+        // route's requireRole is the access boundary. See the bypass audit doc.
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('source_sentence_id', 'corpus:%', 'LIKE')
+            ->sort('created_at', 'DESC')
+            ->execute();
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $resolver = new PipelineStageResolver();
+        $rows = [];
+        foreach ($storage->loadMultiple($ids) as $row) {
+            $stage = $resolver->resolve($row);
+            if ($stage !== PipelineStage::INGESTED && $stage !== PipelineStage::DRAFTED) {
+                continue;
+            }
+            $corpusId = str_replace('corpus:', '', (string) $row->get('source_sentence_id'));
+            $rows[] = [
+                'esid' => (int) $row->id(),
+                'corpus_id' => $corpusId,
+                'pipeline_status' => $stage,
+                'filename' => $this->originalFilename($row, $corpusId),
+                'error' => $this->processingError($row),
+            ];
+            if (count($rows) >= 50) {
+                break;
+            }
+        }
+
+        return $rows;
+    }
+
+    private function originalFilename(EntityInterface $row, string $fallback): string
+    {
+        $prov = json_decode((string) ($row->get('provenance') ?? ''), true);
+        $name = is_array($prov) ? trim((string) ($prov['original_filename'] ?? '')) : '';
+
+        return $name !== '' ? $name : $fallback;
+    }
+
+    private function processingError(EntityInterface $row): ?string
+    {
+        $prov = json_decode((string) ($row->get('provenance') ?? ''), true);
+        if (!is_array($prov)) {
+            return null;
+        }
+        $error = trim((string) ($prov['processing_error'] ?? ''));
+
+        return $error !== '' ? $error : null;
+    }
+
+    /**
+     * @return list<UploadedFile>
+     */
+    private function uploadedFiles(HttpRequest $request): array
+    {
+        $flat = [];
+        $all = $request->files->all();
+        array_walk_recursive(
+            $all,
+            static function ($file) use (&$flat): void {
+                if ($file instanceof UploadedFile) {
+                    $flat[] = $file;
+                }
+            },
+        );
+
+        return $flat;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readBody(HttpRequest $request): array
+    {
+        $raw = trim((string) $request->getContent());
+        if ($raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return $request->request->all();
+    }
+
+    private function corpusPath(): string
+    {
+        $env = getenv('MINOO_CORPUS_PATH');
+
+        return is_string($env) && $env !== '' ? rtrim($env, '/\\') : self::DEFAULT_CORPUS_PATH;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload, int $status = 200): Response
+    {
+        return new Response(
+            (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            $status,
+            ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/src/Ingestion/Corpus/LocalFileReelFetcher.php
+++ b/src/Ingestion/Corpus/LocalFileReelFetcher.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+/**
+ * Produces a whiteboard keyframe + opus audio from an ALREADY-STAGED source
+ * video, using ffmpeg (#877). This is the upload-flow sibling of
+ * {@see FfmpegReelFetcher}: instead of an operator pre-downloading a Facebook
+ * reel, the Anokii drop zone uploads the file to
+ * `<MINOO_CORPUS_PATH>/source-videos/<id>.mp4`, and this fetcher runs the same
+ * deterministic ffmpeg stage on it. Reusing {@see ReelFetcherInterface} means
+ * the rest of the pipeline ({@see ReelProcessor}) is identical for uploads and
+ * the FB-URL CLI path.
+ *
+ * Nothing is committed to the repo — all media lives under MINOO_CORPUS_PATH.
+ */
+final class LocalFileReelFetcher implements ReelFetcherInterface
+{
+    public function __construct(
+        private readonly string $corpusPath,
+        private readonly string $ffmpegBinary = 'ffmpeg',
+        private readonly float $keyframeSeconds = 1.0,
+    ) {
+    }
+
+    public function fetch(string $reelUrl, string $itemId): array
+    {
+        $video = $this->corpusPath . '/source-videos/' . $itemId . '.mp4';
+        if (!is_file($video)) {
+            throw new ReelFetchException(sprintf(
+                'Uploaded source video not found at %s — the file was not staged before processing.',
+                $video,
+            ));
+        }
+
+        $thumb = $this->corpusPath . '/thumbs/' . $itemId . '.jpg';
+        $audio = $this->corpusPath . '/audio/' . $itemId . '.opus';
+        $this->ensureDir(dirname($thumb));
+        $this->ensureDir(dirname($audio));
+
+        // Keyframe a second in (skips the intro fade), then opus audio at 64k —
+        // identical settings to the FB-URL CLI fetcher so output is consistent.
+        $this->run([$this->ffmpegBinary, '-y', '-ss', (string) $this->keyframeSeconds, '-i', $video, '-frames:v', '1', '-q:v', '3', $thumb]);
+        $this->run([$this->ffmpegBinary, '-y', '-i', $video, '-vn', '-c:a', 'libopus', '-b:a', '64k', $audio]);
+
+        if (!is_file($thumb) || !is_file($audio)) {
+            throw new ReelFetchException("ffmpeg did not produce media for {$itemId}.");
+        }
+
+        return ['keyframe' => $thumb, 'audio' => $audio];
+    }
+
+    private function ensureDir(string $dir): void
+    {
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw new ReelFetchException("Could not create directory: {$dir}");
+        }
+    }
+
+    /**
+     * @param list<string> $cmd
+     */
+    private function run(array $cmd): void
+    {
+        $command = implode(' ', array_map('escapeshellarg', $cmd)) . ' 2>&1';
+        exec($command, $output, $code);
+        if ($code !== 0) {
+            throw new ReelFetchException('ffmpeg failed: ' . implode("\n", $output));
+        }
+    }
+}

--- a/src/Ingestion/Corpus/ReelProcessor.php
+++ b/src/Ingestion/Corpus/ReelProcessor.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Corpus;
+
+use App\Anokii\Pipeline\PipelineStage;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Processes one staged reel for the Anokii ingest pipeline (#877): runs the
+ * {@see ReelFetcherInterface} (ffmpeg keyframe + opus) and the
+ * {@see WhiteboardReaderInterface} vision draft, then advances the
+ * example_sentence row from `ingested` to `drafted`.
+ *
+ * This is the work the async worker (`anokii:process-reels`) does per row. It is
+ * a plain DI service — NOT a framework Queue Job — because a deserialized Job
+ * cannot resolve EntityTypeManager at handle() time. The same service backs the
+ * console worker and is unit-tested directly with fake seams.
+ *
+ * Idempotent: a row not at `ingested` is returned unchanged. Degrades safely:
+ * if the vision draft is unavailable (no ANTHROPIC_API_KEY -> NullLlmProvider),
+ * the row still advances to `drafted` with blank text for a human to complete.
+ * Ojibwe is stored EXACTLY as read — never normalized (ADR 0003).
+ */
+final class ReelProcessor
+{
+    /** Staff-gated media routes (consent-gated public routes hide drafts). */
+    private const string MEDIA_BASE = '/admin/anokii/media';
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly ReelFetcherInterface $fetcher,
+        private readonly WhiteboardReaderInterface $reader,
+    ) {
+    }
+
+    /**
+     * @return array{esid: int, status: string, error: string|null}
+     */
+    public function process(int $esid, bool $skipVision = false): array
+    {
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        $row = $storage->load($esid);
+        if (!$row instanceof EntityInterface) {
+            return ['esid' => $esid, 'status' => 'missing', 'error' => 'Row not found.'];
+        }
+
+        $stage = (string) ($row->get('pipeline_status') ?? '');
+        if ($stage !== PipelineStage::INGESTED) {
+            // Already processed (or beyond) — nothing to do.
+            return ['esid' => $esid, 'status' => $stage !== '' ? $stage : PipelineStage::INGESTED, 'error' => null];
+        }
+
+        $reelId = str_replace('corpus:', '', (string) $row->get('source_sentence_id'));
+
+        try {
+            $media = $this->fetcher->fetch((string) $row->get('source_url'), $reelId);
+
+            $draft = $skipVision
+                ? ['ojibwe' => '', 'english' => '', 'notes' => 'skip_vision']
+                : $this->reader->read($media['keyframe']);
+
+            // Verbatim — orthography is never normalized (ADR 0003).
+            $row->set('ojibwe_text', $draft['ojibwe']);
+            $row->set('english_text', $draft['english']);
+            $row->set('notes', $draft['notes']);
+            $row->set('thumbnail_url', self::MEDIA_BASE . '/thumb/' . $reelId);
+            $row->set('audio_url', self::MEDIA_BASE . '/audio/' . $reelId);
+            $row->set('provenance', $this->provenance($row, $reelId, $media, $draft['notes'], null));
+            $row->set('pipeline_status', PipelineStage::DRAFTED);
+            $row->set('updated_at', time());
+            $storage->save($row);
+
+            return ['esid' => $esid, 'status' => PipelineStage::DRAFTED, 'error' => null];
+        } catch (\Throwable $e) {
+            // Keep the row at `ingested` so it can be retried; record the error in
+            // provenance (a JSON blob — never the transcriber `notes`) so the
+            // ingest UI can surface it.
+            $row->set('provenance', $this->provenance($row, $reelId, null, '', $e->getMessage()));
+            $row->set('updated_at', time());
+            $storage->save($row);
+
+            return ['esid' => $esid, 'status' => PipelineStage::INGESTED, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * @param array{keyframe: string, audio: string}|null $media
+     */
+    private function provenance(EntityInterface $row, string $reelId, ?array $media, string $visionNotes, ?string $error): string
+    {
+        $existing = json_decode((string) ($row->get('provenance') ?? ''), true);
+        $data = is_array($existing) ? $existing : [];
+
+        $data['id'] = $reelId;
+        $data['source_url'] = (string) $row->get('source_url');
+        if ($media !== null) {
+            $data['audio_path'] = $media['audio'];
+            $data['thumbnail_path'] = $media['keyframe'];
+            $data['vision_notes'] = $visionNotes;
+            unset($data['processing_error']);
+        }
+        if ($error !== null) {
+            $data['processing_error'] = $error;
+        }
+
+        return (string) json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/src/Provider/AppCommandServiceProvider.php
+++ b/src/Provider/AppCommandServiceProvider.php
@@ -7,9 +7,12 @@ namespace App\Provider;
 use App\Console\AnokiiBackfillStatusHandler;
 use App\Console\IngestCorpusHandler;
 use App\Console\MailTestHandler;
+use App\Console\ProcessReelsHandler;
 use App\Ingestion\Corpus\CorpusIngestor;
 use App\Ingestion\Corpus\FfmpegReelFetcher;
 use App\Ingestion\Corpus\LlmWhiteboardReader;
+use App\Ingestion\Corpus\LocalFileReelFetcher;
+use App\Ingestion\Corpus\ReelProcessor;
 use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\CLI\Command\HandlerArgument;
 use Waaseyaa\CLI\Command\HandlerArgumentMode;
@@ -53,6 +56,18 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                 ),
             );
         });
+
+        $this->singleton(ProcessReelsHandler::class, function (): ProcessReelsHandler {
+            $corpusPath = $this->corpusPath();
+            return new ProcessReelsHandler(
+                $this->resolve(EntityTypeManager::class),
+                new ReelProcessor(
+                    $this->resolve(EntityTypeManager::class),
+                    new LocalFileReelFetcher($corpusPath),
+                    new LlmWhiteboardReader($this->resolve(ProviderInterface::class)),
+                ),
+            );
+        });
     }
 
     public function consoleCommands(): iterable
@@ -66,6 +81,34 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                     name: 'dry-run',
                     mode: HandlerOptionMode::None,
                     description: 'Report what would be set without writing entities',
+                ),
+            ],
+        );
+
+        yield new HandlerCommand(
+            name: 'anokii:process-reels',
+            description: 'Process staged ingest reels: ffmpeg keyframe + opus, vision draft, advance to drafted (#877)',
+            handler: [ProcessReelsHandler::class, 'execute'],
+            options: [
+                new HandlerOption(
+                    name: 'limit',
+                    mode: HandlerOptionMode::Required,
+                    description: 'Process at most N reels per pass',
+                ),
+                new HandlerOption(
+                    name: 'loop',
+                    mode: HandlerOptionMode::None,
+                    description: 'Run continuously as a worker (for systemd on the Pi)',
+                ),
+                new HandlerOption(
+                    name: 'sleep',
+                    mode: HandlerOptionMode::Required,
+                    description: 'Seconds to sleep between empty passes in --loop (default 5)',
+                ),
+                new HandlerOption(
+                    name: 'skip-vision',
+                    mode: HandlerOptionMode::None,
+                    description: 'Skip the vision LLM draft; advance with blank Ojibwe/English',
                 ),
             ],
         );

--- a/src/Provider/Routing/AnokiiRouteProvider.php
+++ b/src/Provider/Routing/AnokiiRouteProvider.php
@@ -92,6 +92,63 @@ final class AnokiiRouteProvider extends AppCoreServiceProvider
                 ->build(),
         );
 
+        // Ingest tab (#877): drag-and-drop multi-reel upload + async processing.
+        $router->addRoute(
+            'anokii.ingest',
+            RouteBuilder::create('/admin/anokii/ingest')
+                ->controller('App\Http\Controller\Anokii\IngestController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'anokii.ingest.upload',
+            RouteBuilder::create('/admin/anokii/ingest/upload')
+                ->controller('App\Http\Controller\Anokii\IngestController::upload')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'anokii.ingest.status',
+            RouteBuilder::create('/admin/anokii/ingest/status')
+                ->controller('App\Http\Controller\Anokii\IngestController::status')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'anokii.ingest.url',
+            RouteBuilder::create('/admin/anokii/ingest/url')
+                ->controller('App\Http\Controller\Anokii\IngestController::url')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->methods('POST')
+                ->build(),
+        );
+
+        // Staff-gated corpus media: serves unreviewed draft reels (status 0) that
+        // the consent-gated public routes correctly hide. requireRole is the gate.
+        $router->addRoute(
+            'anokii.media',
+            RouteBuilder::create('/admin/anokii/media/{kind}/{id}')
+                ->controller('App\Http\Controller\Anokii\AnokiiMediaController::media')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->requirement('kind', 'video|thumb|audio')
+                ->requirement('id', '[a-z0-9-]+')
+                ->build(),
+        );
+
         // Forward-looking: future workspace tabs live under /admin/anokii/{sub}.
         // All currently resolve to the same landing shell. The requirement keeps
         // this off the admin-surface `_surface` API namespace.

--- a/templates/pages/anokii/ingest.html.twig
+++ b/templates/pages/anokii/ingest.html.twig
@@ -1,0 +1,216 @@
+{#
+  Ingest tab (#877) — drag-and-drop multi-reel ingestion, rendered into the
+  Anokii shell (never forks it).
+
+  Drop (or pick) multiple videos; each uploads to the MINOO_CORPUS_PATH staging
+  area and gets a draft example_sentence (ingested). The async worker
+  (anokii:process-reels) fills the vision draft and advances to drafted; this
+  page polls /ingest/status per row and links a finished reel into Transcribe.
+  The Facebook-URL ingest path is kept below the drop zone. ADR 0003: Ojibwe is
+  never normalized; Steven's corpus is fully consented.
+#}
+{% extends "@anokii/_shell.html.twig" %}
+
+{% block title %}Ingest — Minoo Language Workspace{% endblock %}
+
+{% block shell_styles %}
+  {{ anokii_theme_css|default('')|raw }}
+  .ig-head{ margin-bottom:16px; }
+  .ig-head h1{ font-size:1.5rem; }
+  .ig-head p{ color:var(--anokii-shell-muted); max-width:60ch; }
+  .ig-drop{ border:2px dashed var(--anokii-shell-line); border-radius:14px; background:var(--anokii-shell-card); padding:30px; text-align:center; transition:border-color .15s, background .15s; }
+  .ig-drop.drag{ border-color:var(--anokii-shell-accent); background:color-mix(in oklab, var(--anokii-shell-accent) 8%, var(--anokii-shell-card)); }
+  .ig-drop p{ color:var(--anokii-shell-muted); margin-bottom:12px; }
+  .ig-pick{ font:inherit; font-weight:600; cursor:pointer; background:var(--anokii-shell-accent); color:var(--anokii-shell-accent-ink); border:0; border-radius:9px; padding:10px 18px; }
+  .ig-pick:focus-visible{ outline:3px solid var(--anokii-shell-accent); outline-offset:2px; }
+  .ig-url{ display:flex; gap:8px; margin-top:16px; flex-wrap:wrap; }
+  .ig-url input{ flex:1; min-width:220px; font:inherit; padding:9px 11px; border:1px solid var(--anokii-shell-line); border-radius:8px; background:var(--anokii-shell-bg); color:var(--anokii-shell-ink); }
+  .ig-url button{ font:inherit; cursor:pointer; border:1px solid var(--anokii-shell-accent); color:var(--anokii-shell-accent); background:transparent; border-radius:8px; padding:9px 14px; }
+  .ig-list{ margin-top:22px; display:grid; gap:10px; }
+  .ig-row{ display:grid; grid-template-columns:1fr auto; gap:10px 16px; align-items:center; background:var(--anokii-shell-card); border:1px solid var(--anokii-shell-line); border-radius:10px; padding:12px 14px; }
+  .ig-name{ font-weight:600; word-break:break-all; }
+  .ig-meta{ font-size:12.5px; color:var(--anokii-shell-muted); }
+  .ig-bar{ grid-column:1 / -1; height:6px; border-radius:4px; background:var(--anokii-shell-bg); overflow:hidden; }
+  .ig-bar > i{ display:block; height:100%; width:0; background:var(--anokii-shell-accent); transition:width .2s; }
+  .ig-state{ font-size:12.5px; font-variant-numeric:tabular-nums; white-space:nowrap; }
+  .ig-state.done{ color:var(--anokii-shell-accent); font-weight:600; }
+  .ig-state.err{ color:#c0392b; }
+  .ig-go{ color:var(--anokii-shell-accent); font-weight:600; font-size:13px; }
+  .ig-empty{ color:var(--anokii-shell-muted); font-size:13.5px; }
+{% endblock %}
+
+{% block topbar %}{% include "components/anokii/pipeline-bar.html.twig" %}{% endblock %}
+
+{% block content %}
+  <div class="ig-head">
+    <h1>Ingest</h1>
+    <p>Drop Steven's reels here to bring them into the corpus. Each file uploads, then processes in the background (keyframe, audio, and a first-draft transcription) and appears in <a href="{{ transcribe_url }}" style="color:var(--anokii-shell-accent)">Transcribe</a> when ready.</p>
+  </div>
+
+  <div id="ig-drop" class="ig-drop"
+       data-upload="{{ upload_url }}" data-status="{{ status_url }}" data-url="{{ url_url }}"
+       data-transcribe="{{ transcribe_url }}" data-csrf="{{ csrf_token }}"
+       data-accept="{{ accept }}" data-max-mb="{{ max_mb }}">
+    <p>Drag &amp; drop videos (mp4, mov, webm — up to {{ max_mb }} MB each), or</p>
+    <button type="button" class="ig-pick" id="ig-pick" aria-describedby="ig-hint">Choose files…</button>
+    <input type="file" id="ig-file" accept="{{ accept }}" multiple hidden>
+    <p id="ig-hint" class="ig-meta" style="margin-top:12px;">You can select several at once. Uploads run in parallel.</p>
+
+    <form class="ig-url" id="ig-urlform" autocomplete="off">
+      <input type="url" id="ig-urlinput" placeholder="…or paste a Facebook reel URL" aria-label="Facebook reel URL">
+      <button type="submit">Add URL</button>
+    </form>
+  </div>
+
+  <div class="ig-list" id="ig-list" aria-live="polite">
+    {% for row in rows %}
+      <div class="ig-row" data-esid="{{ row.esid }}">
+        <span class="ig-name">{{ row.filename }}</span>
+        <span class="ig-state {{ row.pipeline_status == 'drafted' ? 'done' : '' }} {{ row.error ? 'err' : '' }}">
+          {%- if row.error %}{{ row.error }}{% elseif row.pipeline_status == 'drafted' %}Ready{% else %}Processing…{% endif -%}
+        </span>
+        <span class="ig-meta">{{ row.corpus_id }}</span>
+        <span>{% if row.pipeline_status == 'drafted' %}<a class="ig-go" href="{{ transcribe_url }}">Transcribe →</a>{% endif %}</span>
+      </div>
+    {% else %}
+      <p class="ig-empty" id="ig-empty">No reels in flight. Drop some videos to begin.</p>
+    {% endfor %}
+  </div>
+{% endblock %}
+
+{% block page_scripts %}
+<script>
+(function () {
+  var zone = document.getElementById('ig-drop');
+  if (!zone) return;
+  var uploadUrl = zone.getAttribute('data-upload');
+  var statusUrl = zone.getAttribute('data-status');
+  var urlUrl = zone.getAttribute('data-url');
+  var transcribeUrl = zone.getAttribute('data-transcribe');
+  var csrf = zone.getAttribute('data-csrf');
+  var maxMb = parseInt(zone.getAttribute('data-max-mb'), 10) || 100;
+  var list = document.getElementById('ig-list');
+  var fileInput = document.getElementById('ig-file');
+  var pick = document.getElementById('ig-pick');
+  var polling = {};
+
+  function clearEmpty() {
+    var e = document.getElementById('ig-empty');
+    if (e) e.remove();
+  }
+
+  function makeRow(name) {
+    clearEmpty();
+    var row = document.createElement('div');
+    row.className = 'ig-row';
+    row.innerHTML = '<span class="ig-name"></span>' +
+      '<span class="ig-state">Uploading…</span>' +
+      '<div class="ig-bar"><i></i></div>' +
+      '<span class="ig-go-slot"></span>';
+    row.querySelector('.ig-name').textContent = name;
+    list.insertBefore(row, list.firstChild);
+    return row;
+  }
+
+  function setState(row, text, cls) {
+    var s = row.querySelector('.ig-state');
+    s.textContent = text;
+    s.className = 'ig-state' + (cls ? ' ' + cls : '');
+  }
+
+  function upload(file) {
+    if (file.size > maxMb * 1024 * 1024) {
+      var r = makeRow(file.name);
+      setState(r, 'Too large (max ' + maxMb + ' MB)', 'err');
+      return;
+    }
+    var row = makeRow(file.name);
+    var bar = row.querySelector('.ig-bar > i');
+    var fd = new FormData();
+    fd.append('file', file);
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', uploadUrl);
+    xhr.setRequestHeader('X-CSRF-Token', csrf);
+    xhr.upload.onprogress = function (e) {
+      if (e.lengthComputable) bar.style.width = Math.round((e.loaded / e.total) * 100) + '%';
+    };
+    xhr.onload = function () {
+      var res = {};
+      try { res = JSON.parse(xhr.responseText); } catch (e) {}
+      var f = res.files && res.files[0];
+      if (xhr.status >= 200 && xhr.status < 300 && f && f.esid) {
+        bar.style.width = '100%';
+        row.setAttribute('data-esid', f.esid);
+        setState(row, 'Processing…');
+        poll(f.esid, row);
+      } else {
+        setState(row, (f && f.error) || 'Upload failed', 'err');
+      }
+    };
+    xhr.onerror = function () { setState(row, 'Upload failed', 'err'); };
+    xhr.send(fd);
+  }
+
+  function poll(esid, row) {
+    if (polling[esid]) return;
+    polling[esid] = setInterval(function () {
+      fetch(statusUrl + '?esids=' + esid, { headers: { 'Accept': 'application/json' } })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          var rows = (data && data.rows) || [];
+          var info = rows[0];
+          if (!info) return;
+          if (info.error) {
+            setState(row, info.error, 'err');
+            clearInterval(polling[esid]); delete polling[esid];
+          } else if (info.pipeline_status === 'drafted') {
+            setState(row, 'Ready', 'done');
+            row.querySelector('.ig-go-slot').innerHTML = '<a class="ig-go" href="' + transcribeUrl + '">Transcribe →</a>';
+            clearInterval(polling[esid]); delete polling[esid];
+          }
+        }).catch(function () {});
+    }, 3000);
+  }
+
+  function handleFiles(files) {
+    Array.prototype.forEach.call(files, function (f) { upload(f); });
+  }
+
+  pick.addEventListener('click', function () { fileInput.click(); });
+  fileInput.addEventListener('change', function () { handleFiles(fileInput.files); fileInput.value = ''; });
+
+  ['dragenter', 'dragover'].forEach(function (ev) {
+    zone.addEventListener(ev, function (e) { e.preventDefault(); zone.classList.add('drag'); });
+  });
+  ['dragleave', 'drop'].forEach(function (ev) {
+    zone.addEventListener(ev, function (e) { e.preventDefault(); if (ev === 'drop' || e.target === zone) zone.classList.remove('drag'); });
+  });
+  zone.addEventListener('drop', function (e) {
+    if (e.dataTransfer && e.dataTransfer.files) handleFiles(e.dataTransfer.files);
+  });
+
+  document.getElementById('ig-urlform').addEventListener('submit', function (e) {
+    e.preventDefault();
+    var input = document.getElementById('ig-urlinput');
+    var url = input.value.trim();
+    if (!url) return;
+    var row = makeRow(url);
+    setState(row, 'Registering…');
+    fetch(urlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+      body: JSON.stringify({ url: url })
+    }).then(function (r) { return r.json(); }).then(function (res) {
+      if (res.ok && res.esid) { setState(row, 'Queued (stage source video, then run the worker)'); input.value = ''; }
+      else { setState(row, res.error || 'Failed', 'err'); }
+    }).catch(function () { setState(row, 'Failed', 'err'); });
+  });
+
+  // Resume polling for any server-rendered rows still processing.
+  Array.prototype.forEach.call(list.querySelectorAll('.ig-row[data-esid]'), function (row) {
+    var s = row.querySelector('.ig-state');
+    if (s && s.textContent.indexOf('Processing') !== -1) poll(row.getAttribute('data-esid'), row);
+  });
+})();
+</script>
+{% endblock %}

--- a/tests/App/Integration/Http/Admin/AnokiiIngestTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiIngestTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Http\Controller\Anokii\IngestController;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\SSR\SsrServiceProvider;
+
+/**
+ * Anokii Ingest tab (#877): the drop zone is role-gated; an upload stages the
+ * video and creates an ingested draft example_sentence; the status endpoint
+ * reports per-row pipeline stage.
+ *
+ * The upload + status handlers are exercised directly (a real multipart upload
+ * through the kernel needs SAPI move_uploaded_file + fileinfo, neither present
+ * under CLI), with a test-mode UploadedFile and a temp MINOO_CORPUS_PATH. Route
+ * gating is exercised through the full kernel.
+ */
+#[CoversNothing]
+final class AnokiiIngestTest extends HttpKernelTestCase
+{
+    private static int $adminUid = 0;
+    private static string $corpusDir = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$corpusDir = sys_get_temp_dir() . '/anokii-ingest-' . bin2hex(random_bytes(4));
+        mkdir(self::$corpusDir, 0o755, true);
+        putenv('MINOO_CORPUS_PATH=' . self::$corpusDir);
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $admin = $users->create(['name' => 'Ig Admin', 'mail' => 'ig-admin@example.test', 'status' => true, 'created' => time(), 'roles' => ['admin'], 'permissions' => []]);
+        $users->save($admin);
+        self::$adminUid = (int) $admin->id();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('MINOO_CORPUS_PATH');
+        parent::tearDownAfterClass();
+    }
+
+    private function controller(): IngestController
+    {
+        return new IngestController(
+            self::$kernel->getEntityTypeManager(),
+            SsrServiceProvider::getTwigEnvironment(),
+        );
+    }
+
+    private function account(): AccountInterface
+    {
+        $account = self::$kernel->getEntityTypeManager()->getStorage('user')->load(self::$adminUid);
+        self::assertInstanceOf(AccountInterface::class, $account);
+
+        return $account;
+    }
+
+    #[Test]
+    public function the_drop_zone_renders_for_staff(): void
+    {
+        $response = $this->sendAs(self::$adminUid, '/admin/anokii/ingest');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('ig-drop', $body);
+        self::assertStringContainsString('Choose files', $body);
+        self::assertStringContainsString('anokii-pipeline', $body);
+        self::assertStringNotContainsString('/_nuxt/', $body);
+    }
+
+    #[Test]
+    public function anonymous_is_denied_the_ingest_tab(): void
+    {
+        $response = $this->send('GET', '/admin/anokii/ingest');
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND, Response::HTTP_UNAUTHORIZED]);
+        self::assertStringNotContainsString('ig-drop', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function upload_stages_the_file_and_creates_an_ingested_draft(): void
+    {
+        // A test-mode UploadedFile renames (no SAPI move_uploaded_file needed).
+        $src = sys_get_temp_dir() . '/reel-src-' . bin2hex(random_bytes(3)) . '.mp4';
+        file_put_contents($src, 'FAKE-MP4-BYTES');
+        $upload = new UploadedFile($src, 'steven-reel.mp4', 'video/mp4', null, true);
+
+        $request = new HttpRequest([], [], [], [], ['file' => $upload]);
+        $response = $this->controller()->upload([], [], $this->account(), $request);
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertTrue($payload['ok']);
+        self::assertCount(1, $payload['files']);
+
+        $file = $payload['files'][0];
+        self::assertSame(PipelineStage::INGESTED, $file['status']);
+        self::assertNull($file['error']);
+        self::assertStringStartsWith('upload-', $file['corpus_id']);
+        self::assertGreaterThan(0, $file['esid']);
+
+        // The staged source video exists under MINOO_CORPUS_PATH/source-videos.
+        self::assertFileExists(self::$corpusDir . '/source-videos/' . $file['corpus_id'] . '.mp4');
+
+        // The entity is an ingested draft, off public surfaces.
+        $row = self::$kernel->getEntityTypeManager()->getStorage('example_sentence')->load($file['esid']);
+        self::assertInstanceOf(EntityInterface::class, $row);
+        self::assertSame(PipelineStage::INGESTED, (string) $row->get('pipeline_status'));
+        self::assertSame('corpus:' . $file['corpus_id'], (string) $row->get('source_sentence_id'));
+        self::assertSame(0, (int) $row->get('status'));
+        self::assertSame(0, (int) $row->get('consent_public'));
+        self::assertSame('/admin/anokii/media/video/' . $file['corpus_id'], (string) $row->get('video_url'));
+    }
+
+    #[Test]
+    public function upload_rejects_a_non_video_extension(): void
+    {
+        $src = sys_get_temp_dir() . '/bad-' . bin2hex(random_bytes(3)) . '.txt';
+        file_put_contents($src, 'not a video');
+        $upload = new UploadedFile($src, 'notes.txt', 'text/plain', null, true);
+
+        $request = new HttpRequest([], [], [], [], ['file' => $upload]);
+        $payload = json_decode((string) $this->controller()->upload([], [], $this->account(), $request)->getContent(), true);
+
+        self::assertSame('error', $payload['files'][0]['status']);
+        self::assertNull($payload['files'][0]['esid']);
+    }
+
+    #[Test]
+    public function status_reports_pipeline_stage_for_rows(): void
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $row = $storage->create([
+            'ojibwe_text' => '', 'english_text' => '',
+            'source_sentence_id' => 'corpus:st-1',
+            'pipeline_status' => PipelineStage::DRAFTED,
+            'status' => 0, 'consent_public' => 0, 'created_at' => time(), 'updated_at' => time(),
+        ]);
+        $storage->save($row);
+        $esid = (int) $row->id();
+
+        $request = new HttpRequest(['esids' => (string) $esid]);
+        $payload = json_decode((string) $this->controller()->status([], [], $this->account(), $request)->getContent(), true);
+
+        self::assertTrue($payload['ok']);
+        self::assertCount(1, $payload['rows']);
+        self::assertSame($esid, $payload['rows'][0]['esid']);
+        self::assertSame(PipelineStage::DRAFTED, $payload['rows'][0]['pipeline_status']);
+    }
+
+    #[Test]
+    public function fb_url_path_registers_an_ingested_draft(): void
+    {
+        $request = new HttpRequest();
+        $request->initialize([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode(['url' => 'https://www.facebook.com/reel/123']));
+        $payload = json_decode((string) $this->controller()->url([], [], $this->account(), $request)->getContent(), true);
+
+        self::assertTrue($payload['ok']);
+        self::assertStringStartsWith('fb-', $payload['corpus_id']);
+        self::assertSame(PipelineStage::INGESTED, $payload['pipeline_status']);
+    }
+
+    private function sendAs(int $uid, string $uri): Response
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = $uid;
+
+        return self::$kernel->handle();
+    }
+}

--- a/tests/App/Integration/Ingestion/ReelProcessorTest.php
+++ b/tests/App/Integration/Ingestion/ReelProcessorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Ingestion\Corpus\ReelFetcherInterface;
+use App\Ingestion\Corpus\ReelFetchException;
+use App\Ingestion\Corpus\ReelProcessor;
+use App\Ingestion\Corpus\WhiteboardReaderInterface;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ReelProcessor (#877): advances an ingested example_sentence to drafted by
+ * running the ffmpeg + vision seams, with the orthography stored verbatim
+ * (ADR 0003), idempotent re-runs, and a safe failure path.
+ */
+#[CoversClass(ReelProcessor::class)]
+final class ReelProcessorTest extends HttpKernelTestCase
+{
+    private function seedIngested(string $corpusId): int
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $row = $storage->create([
+            'ojibwe_text' => '',
+            'english_text' => '',
+            'source_sentence_id' => 'corpus:' . $corpusId,
+            'pipeline_status' => PipelineStage::INGESTED,
+            'consent_public' => 0,
+            'status' => 0,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $storage->save($row);
+
+        return (int) $row->id();
+    }
+
+    private function fakeFetcher(): ReelFetcherInterface
+    {
+        return new class () implements ReelFetcherInterface {
+            public int $calls = 0;
+
+            public function fetch(string $reelUrl, string $itemId): array
+            {
+                ++$this->calls;
+
+                return ['keyframe' => '/tmp/' . $itemId . '.jpg', 'audio' => '/tmp/' . $itemId . '.opus'];
+            }
+        };
+    }
+
+    #[Test]
+    public function it_advances_ingested_to_drafted_and_stores_verbatim(): void
+    {
+        $esid = $this->seedIngested('rp-1');
+        $reader = new class () implements WhiteboardReaderInterface {
+            public function read(string $keyframePath): array
+            {
+                // Leading/trailing spaces must survive — never normalized (ADR 0003).
+                return ['ojibwe' => '  Zhooniyaans  ', 'english' => 'butter knife', 'notes' => 'vision'];
+            }
+        };
+
+        $processor = new ReelProcessor(self::$kernel->getEntityTypeManager(), $this->fakeFetcher(), $reader);
+        $result = $processor->process($esid);
+
+        self::assertSame(PipelineStage::DRAFTED, $result['status']);
+        self::assertNull($result['error']);
+
+        $row = self::$kernel->getEntityTypeManager()->getStorage('example_sentence')->load($esid);
+        self::assertSame(PipelineStage::DRAFTED, (string) $row->get('pipeline_status'));
+        self::assertSame('  Zhooniyaans  ', (string) $row->get('ojibwe_text'), 'Ojibwe must be verbatim.');
+        self::assertSame('butter knife', (string) $row->get('english_text'));
+        self::assertSame('/admin/anokii/media/thumb/rp-1', (string) $row->get('thumbnail_url'));
+        self::assertSame('/admin/anokii/media/audio/rp-1', (string) $row->get('audio_url'));
+    }
+
+    #[Test]
+    public function it_is_idempotent_and_does_not_reprocess_a_drafted_row(): void
+    {
+        $esid = $this->seedIngested('rp-2');
+        $reader = new class () implements WhiteboardReaderInterface {
+            public function read(string $keyframePath): array
+            {
+                return ['ojibwe' => 'A', 'english' => 'B', 'notes' => ''];
+            }
+        };
+        $fetcher = $this->fakeFetcher();
+        $processor = new ReelProcessor(self::$kernel->getEntityTypeManager(), $fetcher, $reader);
+
+        $processor->process($esid);
+        $second = $processor->process($esid);
+
+        self::assertSame(PipelineStage::DRAFTED, $second['status']);
+        self::assertSame(1, $fetcher->calls, 'A drafted row must not be fetched/processed again.');
+    }
+
+    #[Test]
+    public function a_fetch_failure_keeps_the_row_ingested_and_records_the_error(): void
+    {
+        $esid = $this->seedIngested('rp-3');
+        $failing = new class () implements ReelFetcherInterface {
+            public function fetch(string $reelUrl, string $itemId): array
+            {
+                throw new ReelFetchException('ffmpeg exploded');
+            }
+        };
+        $reader = new class () implements WhiteboardReaderInterface {
+            public function read(string $keyframePath): array
+            {
+                return ['ojibwe' => '', 'english' => '', 'notes' => ''];
+            }
+        };
+
+        $processor = new ReelProcessor(self::$kernel->getEntityTypeManager(), $failing, $reader);
+        $result = $processor->process($esid);
+
+        self::assertSame(PipelineStage::INGESTED, $result['status']);
+        self::assertSame('ffmpeg exploded', $result['error']);
+
+        $row = self::$kernel->getEntityTypeManager()->getStorage('example_sentence')->load($esid);
+        self::assertSame(PipelineStage::INGESTED, (string) $row->get('pipeline_status'));
+        $prov = json_decode((string) $row->get('provenance'), true);
+        self::assertSame('ffmpeg exploded', $prov['processing_error'] ?? null);
+    }
+}


### PR DESCRIPTION
Closes #877. The headline feature of **Anokii Workspace v2**.

## What it does
An **Ingest** tab with a drop zone that accepts **multiple** videos (mp4/mov/webm) at once. Per-file rows show upload + processing progress and errors. On drop, each file:
1. uploads to `MINOO_CORPUS_PATH/source-videos/<id>.mp4`,
2. gets a draft `example_sentence` (`pipeline_status=ingested`) linked to the video,
3. the request returns immediately,
4. is processed out-of-band (ffmpeg keyframe + `.opus` audio, then the vision/LLM draft) → `drafted`,
5. and appears in **Transcribe** automatically. The UI polls `GET /ingest/status` per row.

The **Facebook-URL** ingest path is kept (`POST /ingest/url` + the `ingest:corpus` CLI).

## Why not a framework Queue `Job`
A deserialized `Waaseyaa\Queue\Job` can't resolve `EntityTypeManager` at `handle()` time (no global container accessor; `Job` has no container hook; the default `JobHandler` just calls `$job->handle()`, and `SyncQueue` runs in-request). So processing is a plain DI service — **`ReelProcessor`** — driven by a console worker over a **row-status queue**: the `ingested` rows *are* the queue. This reuses the #854 seams, is fully testable with DI, and deploys as a simple looped command on the Pi.

## Pieces
- `LocalFileReelFetcher` — implements the #854 `ReelFetcherInterface`; same ffmpeg stage on an uploaded staged file as the FB-URL path.
- `ReelProcessor` — fetch + vision draft → `drafted`. Idempotent; degrades to blank draft without `ANTHROPIC_API_KEY` (`NullLlmProvider`); records errors to `provenance.processing_error` and keeps the row `ingested` for retry. Ojibwe stored verbatim (ADR 0003).
- `IngestController` — drop zone, upload (one/many), status poll, FB-URL. Validates by extension/client-mime (fileinfo isn't guaranteed in every runtime; ffmpeg is the real content gate downstream). Staff-gated.
- `anokii:process-reels [--limit --loop --sleep --skip-vision]` — the worker; `--loop` is the Pi systemd service.
- `AnokiiMediaController` — staff-gated `/admin/anokii/media/{video,thumb,audio}/{id}` serves unreviewed drafts (status 0) that the consent-gated public routes correctly hide.

## Infra (some lands in waaseyaa-infra at deploy)
- **ffmpeg** added to the container image (`Dockerfile`).
- `config/waaseyaa.php`: `corpus_upload_max_bytes` (120 MiB) + video mime allowlist.
- ⚠️ PHP (`upload_max_filesize`/`post_max_size`) and Caddy (`request_body max_size`) limits must be raised in the deployment image for ~100 MB videos — flagged for the deploy step. `ANTHROPIC_API_KEY` on the Pi enables the vision draft (degrades gracefully if absent). A `queue:work`-style `anokii:process-reels --loop` worker runs on the Pi.

## Constraints honored
Role gating `admin,elder_coordinator`; ADR 0003 (never normalize); FB-URL CLI path unchanged; corpus fully consented (drafts are off public surfaces via status 0 / consent 0, not via caveating Steven's content).

## Gates
- ✅ PHPUnit (547 tests, 2 known skips) · PHPStan L5 · cs-fixer (LF) · schema:check (no drift — `pipeline_status`/uploads live in `_data`/config)

## Tests
- `ReelProcessorTest` — `ingested → drafted`, verbatim orthography, idempotency, safe failure path.
- `AnokiiIngestTest` — drop-zone gating, upload creates an `ingested` draft + stages the file, bad-type rejection, status endpoint, FB-URL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)