### PR TITLE
feat(#879): responsive + a11y polish of the workspace

### DIFF
--- a/bin/seed-test-user
+++ b/bin/seed-test-user
@@ -75,6 +75,25 @@ if ($existing !== []) {
     fprintf(STDOUT, "Test user created: test@minoo.test / TestPass123!\n");
 }
 
+// Seed elder-coordinator test user (Anokii Language Workspace access, #879).
+$existingCoordinator = $storage->getQuery()->accessCheck(false)->condition('mail', 'coordinator@minoo.test')->execute();
+
+if ($existingCoordinator !== []) {
+    fprintf(STDOUT, "Coordinator user already exists.\n");
+} else {
+    $coordinator = $storage->create([
+        'name' => 'Coordinator User',
+        'mail' => 'coordinator@minoo.test',
+        'status' => true,
+        'created' => time(),
+        'roles' => ['elder_coordinator'],
+        'permissions' => [],
+    ]);
+    $coordinator->setRawPassword('CoordPass123!');
+    $storage->save($coordinator);
+    fprintf(STDOUT, "Coordinator user created: coordinator@minoo.test / CoordPass123!\n");
+}
+
 // Seed non-volunteer test user.
 $existingMember = $storage->getQuery()->accessCheck(false)->condition('mail', 'member@minoo.test')->execute();
 

--- a/templates/components/anokii/pipeline-bar.html.twig
+++ b/templates/components/anokii/pipeline-bar.html.twig
@@ -31,6 +31,10 @@
   @media(max-width:620px){
     .anokii-content button, .anokii-content .ig-pick, .anokii-content .tx-mark, .anokii-content .cu-btn{ min-height:44px; }
   }
+  /* Links inside prose must be distinguishable without colour (WCAG 1.4.1) —
+     the shell sets text-decoration:none globally, so underline in-text links. */
+  .anokii-content p a, .anokii-content .ov-empty a, .anokii-content .tx-empty a,
+  .anokii-content .cu-empty a, .anokii-content .ig-empty a{ text-decoration:underline; }
   /* Screen-reader-only helper (the Anokii shell ships no external stylesheet). */
   .sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
 </style>

--- a/templates/components/anokii/pipeline-bar.html.twig
+++ b/templates/components/anokii/pipeline-bar.html.twig
@@ -21,6 +21,18 @@
   .anokii-pipeline a.pl-step:hover{ color:var(--anokii-shell-ink); }
   .anokii-pipeline a.pl-step:hover .pl-count{ border-color:var(--anokii-shell-accent); }
   @media(max-width:620px){ .anokii-pipeline{ padding:8px 16px; font-size:12px; } .anokii-pipeline .pl-step:not(:last-child)::after{ margin-left:8px; } }
+  /* Shared workspace a11y baseline (#879): visible keyboard focus on every
+     interactive control across every tab, and comfortable mobile tap targets. */
+  .anokii-content a:focus-visible, .anokii-content button:focus-visible,
+  .anokii-content input:focus-visible, .anokii-content select:focus-visible,
+  .anokii-content textarea:focus-visible, .anokii-pipeline a:focus-visible{
+    outline:3px solid var(--anokii-shell-accent); outline-offset:2px; border-radius:4px;
+  }
+  @media(max-width:620px){
+    .anokii-content button, .anokii-content .ig-pick, .anokii-content .tx-mark, .anokii-content .cu-btn{ min-height:44px; }
+  }
+  /* Screen-reader-only helper (the Anokii shell ships no external stylesheet). */
+  .sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
 </style>
 <nav class="anokii-pipeline" aria-label="Corpus pipeline progress">
   {% for step in pipeline_bar %}

--- a/templates/pages/anokii/curate.html.twig
+++ b/templates/pages/anokii/curate.html.twig
@@ -17,7 +17,8 @@
   .cu-counter{ color:var(--anokii-shell-muted); font-variant-numeric:tabular-nums; }
   .cu-nav{ display:flex; gap:16px; font-size:13px; margin-bottom:18px; }
   .cu-nav a{ color:var(--anokii-shell-accent); font-weight:600; }
-  .cu-table{ width:100%; border-collapse:collapse; }
+  .cu-tablewrap{ overflow-x:auto; -webkit-overflow-scrolling:touch; }
+  .cu-table{ width:100%; min-width:680px; border-collapse:collapse; }
   .cu-table th, .cu-table td{ text-align:left; padding:10px 12px; border-bottom:1px solid var(--anokii-shell-line); vertical-align:middle; }
   .cu-table th{ font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--anokii-shell-muted); }
   .cu-oj{ font-weight:600; }
@@ -54,8 +55,10 @@
   {% if rows is empty %}
     <div class="cu-empty">Nothing at this stage yet. Confirm Anishinaabemowin + English in <a href="{{ transcribe_url }}" style="color:var(--anokii-shell-accent)">Transcribe</a> and mark items transcribed to bring them here.</div>
   {% else %}
+    <div class="cu-tablewrap">
     <table class="cu-table">
-      <thead><tr><th>Anishinaabemowin</th><th>English</th><th>Stage</th><th>Vocabulary</th><th>Lesson</th><th>Actions</th></tr></thead>
+      <caption class="sr-only">Transcribed utterances to promote, add to a lesson, and publish.</caption>
+      <thead><tr><th scope="col">Anishinaabemowin</th><th scope="col">English</th><th scope="col">Stage</th><th scope="col">Vocabulary</th><th scope="col">Lesson</th><th scope="col">Actions</th></tr></thead>
       <tbody>
         {% for row in rows %}
           <tr data-esid="{{ row.esid }}">
@@ -77,13 +80,14 @@
               <div class="cu-actions">
                 {% if not row.promoted %}<button type="button" class="cu-btn" data-promote>Promote{% if row.parts > 1 %} ({{ row.parts }} parts){% endif %}</button>{% endif %}
                 <button type="button" class="cu-btn primary" data-publish {{ row.published ? 'disabled' : '' }}>{{ row.published ? 'Published' : 'Publish' }}</button>
-                <span class="cu-status" data-status></span>
+                <span class="cu-status" data-status role="status" aria-live="polite"></span>
               </div>
             </td>
           </tr>
         {% endfor %}
       </tbody>
     </table>
+    </div>
   {% endif %}
 {% endblock %}
 

--- a/templates/pages/anokii/ingest.html.twig
+++ b/templates/pages/anokii/ingest.html.twig
@@ -47,7 +47,8 @@
     <p>Drop Steven's reels here to bring them into the corpus. Each file uploads, then processes in the background (keyframe, audio, and a first-draft transcription) and appears in <a href="{{ transcribe_url }}" style="color:var(--anokii-shell-accent)">Transcribe</a> when ready.</p>
   </div>
 
-  <div id="ig-drop" class="ig-drop"
+  <div id="ig-drop" class="ig-drop" role="group"
+       aria-label="Upload reels: drag and drop video files here, or use the Choose files button"
        data-upload="{{ upload_url }}" data-status="{{ status_url }}" data-url="{{ url_url }}"
        data-transcribe="{{ transcribe_url }}" data-csrf="{{ csrf_token }}"
        data-accept="{{ accept }}" data-max-mb="{{ max_mb }}">

--- a/templates/pages/anokii/transcribe.html.twig
+++ b/templates/pages/anokii/transcribe.html.twig
@@ -92,7 +92,7 @@
           <div class="tx-foot">
             <button type="button" class="tx-mark" data-mark>Mark transcribed →</button>
             <span class="tx-stage">{{ row.pipeline_status }}</span>
-            <span class="tx-status" id="st-{{ row.esid }}"></span>
+            <span class="tx-status" id="st-{{ row.esid }}" role="status" aria-live="polite"></span>
           </div>
         </div>
       </div>

--- a/tests/App/Integration/Http/Admin/AnokiiAccessibilityTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiAccessibilityTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Anokii workspace accessibility markers (#879). Server-rendered guarantees that
+ * back the (non-blocking) axe Playwright spec: keyboard-operable drop zone with
+ * a file-picker fallback, visible focus, live regions, and a responsive,
+ * labelled curate table. These run in the suite so a regression fails the gate.
+ */
+#[CoversNothing]
+final class AnokiiAccessibilityTest extends HttpKernelTestCase
+{
+    private static int $coordUid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $coord = $users->create(['name' => 'A11y Coordinator', 'mail' => 'a11y-coord@example.test', 'status' => true, 'created' => time(), 'roles' => ['elder_coordinator'], 'permissions' => []]);
+        $users->save($coord);
+        self::$coordUid = (int) $coord->id();
+
+        // One row at each tab's default stage so per-row status regions render.
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $sentences->save($sentences->create([
+            'ojibwe_text' => 'gaa', 'english_text' => '', 'source_sentence_id' => 'corpus:a11y-1',
+            'pipeline_status' => 'drafted', 'status' => 0, 'consent_public' => 0, 'created_at' => time(), 'updated_at' => time(),
+        ]));
+        $sentences->save($sentences->create([
+            'ojibwe_text' => 'Makwa', 'english_text' => 'bear', 'source_sentence_id' => 'corpus:a11y-2',
+            'pipeline_status' => 'transcribed', 'status' => 0, 'consent_public' => 0, 'created_at' => time(), 'updated_at' => time(),
+        ]));
+    }
+
+    #[Test]
+    public function the_drop_zone_is_keyboard_accessible_with_a_file_picker_fallback(): void
+    {
+        $body = (string) $this->sendAs('/admin/anokii/ingest')->getContent();
+
+        self::assertStringContainsString('role="group"', $body);
+        self::assertStringContainsString('aria-label="Upload reels', $body);
+        self::assertStringContainsString('id="ig-pick"', $body, 'Keyboard-focusable Choose files button.');
+        self::assertStringContainsString('type="file"', $body, 'File-picker fallback input.');
+    }
+
+    #[Test]
+    public function every_tab_ships_visible_focus_and_the_sr_only_helper(): void
+    {
+        foreach (['/admin/anokii', '/admin/anokii/ingest', '/admin/anokii/transcribe', '/admin/anokii/curate'] as $path) {
+            $body = (string) $this->sendAs($path)->getContent();
+            self::assertStringContainsString(':focus-visible', $body, "Focus ring CSS on {$path}");
+            self::assertStringContainsString('.sr-only', $body, "sr-only helper on {$path}");
+        }
+    }
+
+    #[Test]
+    public function the_curate_table_is_responsive_and_labelled(): void
+    {
+        $body = (string) $this->sendAs('/admin/anokii/curate')->getContent();
+
+        self::assertStringContainsString('cu-tablewrap', $body, 'Horizontal-scroll wrapper for mobile.');
+        self::assertStringContainsString('scope="col"', $body, 'Column header scope.');
+        self::assertStringContainsString('class="sr-only">Transcribed utterances', $body, 'Table caption.');
+    }
+
+    #[Test]
+    public function status_regions_announce_to_screen_readers(): void
+    {
+        $tx = (string) $this->sendAs('/admin/anokii/transcribe')->getContent();
+        self::assertStringContainsString('aria-live="polite"', $tx);
+
+        $cu = (string) $this->sendAs('/admin/anokii/curate')->getContent();
+        self::assertStringContainsString('aria-live="polite"', $cu);
+    }
+
+    private function sendAs(string $uri): Response
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = self::$coordUid;
+
+        return self::$kernel->handle();
+    }
+}

--- a/tests/playwright/accessibility-anokii.spec.ts
+++ b/tests/playwright/accessibility-anokii.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// The Anokii Language Workspace is role-gated (admin / elder_coordinator), so
+// these axe checks log in as the seeded elder-coordinator first (#879).
+const workspacePages = [
+  '/admin/anokii',
+  '/admin/anokii/ingest',
+  '/admin/anokii/transcribe',
+  '/admin/anokii/curate',
+];
+
+test.describe('Anokii workspace accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'coordinator@minoo.test');
+    await page.fill('input[name="password"]', 'CoordPass123!');
+    await page.click('.form button[type="submit"]');
+    await page.waitForURL(/\/(feed|admin\/anokii|)?$/);
+  });
+
+  for (const path of workspacePages) {
+    test(`accessibility: ${path} has no critical or serious violations`, async ({ page }) => {
+      await page.goto(path);
+      await page.locator('.anokii-app').first().waitFor();
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa'])
+        // axe-core cannot parse oklch()/color-mix() and computes incorrect contrast.
+        // Contrast is manually verified, matching the public accessibility suite.
+        .disableRules(['color-contrast'])
+        .analyze();
+
+      const critical = results.violations.filter(v =>
+        v.impact === 'critical' || v.impact === 'serious'
+      );
+      expect(critical).toEqual([]);
+    });
+  }
+
+  test('ingest drop zone is keyboard-operable with a file-picker fallback', async ({ page }) => {
+    await page.goto('/admin/anokii/ingest');
+    const pick = page.locator('#ig-pick');
+    await expect(pick).toBeVisible();
+    await pick.focus();
+    await expect(pick).toBeFocused();
+    // The hidden <input type=file> is the fallback the button drives.
+    await expect(page.locator('#ig-file')).toHaveAttribute('type', 'file');
+    await expect(page.locator('#ig-drop')).toHaveAttribute('aria-label', /drag and drop/i);
+  });
+});


### PR DESCRIPTION
Closes #879. Accessibility + responsive pass over the Anokii Workspace v2 surface.

## What changed
- **Keyboard-operable drop zone with a file-picker fallback** — the focusable "Choose files" button drives the hidden `<input type=file>`; the zone is a labelled `role="group"`. Drag-and-drop is an enhancement, never the only path.
- **Visible focus + tap targets** — a `:focus-visible` outline on every interactive control across all four tabs, plus 44px mobile tap targets. Added once in the shared `pipeline-bar` partial (the single include on every tab) so it can't drift.
- **Live regions** — per-row status in Transcribe and Curate announce via `role="status" aria-live="polite"` (the ingest list already had `aria-live`).
- **Responsive Curate table** — horizontal-scroll wrapper + `min-width` so the data table reflows on mobile instead of breaking; `sr-only` caption + `scope="col"` headers. The `sr-only` helper is defined in the shell context (the Anokii shell ships no external stylesheet).
- **axe coverage** — a new `elder_coordinator` test fixture (`coordinator@minoo.test`) + an authenticated axe Playwright spec over the four workspace pages.

## Notes
- The axe spec disables `color-contrast` to match the existing public accessibility suite — axe-core can't parse `oklch()`/`color-mix()` and computes wrong ratios; contrast is manually verified.
- No external stylesheet changed (the Anokii shell is inline-styled), so no `?v=` cache-bust applies.
- Role gating and ADR 0003 unchanged.

## Gates
- ✅ PHPUnit (555, 2 known skips) · PHPStan L5 · cs-fixer (LF) · schema:check · Playwright (incl. new workspace axe spec)

## Tests
- `AnokiiAccessibilityTest` (gate-blocking, server-side): keyboard drop zone + file fallback, focus CSS present, `sr-only` helper, live regions, responsive labelled table.
- `accessibility-anokii.spec.ts` (Playwright, non-blocking): axe over `/admin/anokii`, `/ingest`, `/transcribe`, `/curate` + drop-zone keyboard operability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)