### PR TITLE
feat(#888): re-home the corpus pipeline as the language module tile

### DIFF
--- a/config/anokii.yaml
+++ b/config/anokii.yaml
@@ -18,11 +18,13 @@ tenancy_mode: sovereign
 # reading in DistributionConfig::moduleEnabled()). To turn a module on for
 # production in a later issue, move its id from "preview" to "enabled".
 #
-# language: the Anishinaabemowin language module (translation memory, /api/lang,
-# gap log, gated ASR). Present but OFF for now. It sits under "preview" so
-# DistributionConfig::moduleEnabled('language') returns false. A later milestone
-# issue graduates it to "enabled" once the module provider exists.
+# language: the Anishinaabemowin language module. Enabled (#888): its admin tile
+# is minoo's working corpus pipeline (ingest, transcribe, curate, publish),
+# re-homed at /admin/anokii/language. moduleEnabled('language') is therefore true,
+# so the catalog renders it as a live tool. Its data and API layers (translation
+# memory, /api/lang, gap log, gated ASR) land in later milestone issues behind
+# this same flag.
 modules:
-  enabled: []
-  preview:
+  enabled:
     - language
+  preview: []

--- a/src/Http/Controller/Anokii/LanguageWorkspaceController.php
+++ b/src/Http/Controller/Anokii/LanguageWorkspaceController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Anokii;
+
+use App\Anokii\Pipeline\PipelineCounts;
+use App\Http\View\AnokiiShellContext;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * The language module landing at /admin/anokii/language (#888).
+ *
+ * The corpus pipeline (ingest, transcribe, curate, publish) is the admin face of
+ * the language module. This is its Overview: the live funnel (a count per stage,
+ * each a jump to where those items are worked) plus the single "do next" CTA. It
+ * is the page issue 2 lifted off the workspace home when /admin/anokii became the
+ * AdminModules catalog; the Language catalog card links here.
+ *
+ * Role-gated (admin / elder_coordinator) by {@see \App\Provider\Routing\AnokiiRouteProvider}.
+ * Chrome (pipeline nav + breadcrumb) comes from {@see AnokiiShellContext::build()};
+ * the Ingest / Transcribe / Curate tabs keep their own controllers.
+ */
+final class LanguageWorkspaceController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    public function index(AccountInterface $account, HttpRequest $request): Response
+    {
+        $snapshot = (new PipelineCounts($this->entityTypeManager))->compute();
+
+        $html = $this->twig->render('pages/anokii/index.html.twig', AnokiiShellContext::build($account, 'home', [
+            'path' => $request->getPathInfo(),
+            'pipeline' => $snapshot,
+            'counts' => $snapshot['counts'],
+            'total' => $snapshot['total'],
+            'do_next' => $snapshot['do_next'],
+        ]));
+
+        return new Response($html);
+    }
+}

--- a/src/Http/View/AnokiiShellContext.php
+++ b/src/Http/View/AnokiiShellContext.php
@@ -66,7 +66,11 @@ final class AnokiiShellContext
      */
     public static function catalog(AccountInterface $account, DistributionConfig $distribution, array $extra = []): array
     {
-        $modules = AdminModules::resolve(self::catalogLiveIds($distribution));
+        $modules = AdminModules::resolve(
+            self::catalogLiveIds($distribution),
+            self::catalogOverrides(),
+            self::catalogExtraModules($distribution),
+        );
         [$nav, $live, $preview] = self::splitCatalog($modules);
 
         return $extra + self::catalogChrome($account, 'dashboard', $nav) + [
@@ -90,7 +94,11 @@ final class AnokiiShellContext
             return null;
         }
 
-        $modules = AdminModules::resolve(self::catalogLiveIds($distribution));
+        $modules = AdminModules::resolve(
+            self::catalogLiveIds($distribution),
+            self::catalogOverrides(),
+            self::catalogExtraModules($distribution),
+        );
         [$nav] = self::splitCatalog($modules);
 
         return $extra + self::catalogChrome($account, $moduleId, $nav) + ['module' => $module];
@@ -141,6 +149,45 @@ final class AnokiiShellContext
     }
 
     /**
+     * Install-specific catalog additions appended via AdminModules::resolve()'s
+     * $extra. The `language` module is minoo's corpus pipeline, gated on
+     * DistributionConfig like every other module: when enabled its card links to
+     * the real admin tile at /admin/anokii/language, otherwise it shows as a
+     * product-preview card. (#888)
+     *
+     * @return list<array<string, mixed>>
+     */
+    private static function catalogExtraModules(DistributionConfig $distribution): array
+    {
+        $enabled = $distribution->moduleEnabled('language');
+
+        return [[
+            'id' => 'language',
+            'label' => 'Language',
+            'group' => 'Workspace',
+            'order' => 1,
+            'live' => $enabled,
+            'href' => $enabled ? '/admin/anokii/language' : '/admin/anokii/m/language',
+            'desc' => 'Build the dictionary and lessons from the community corpus: ingest, transcribe, curate, publish.',
+            'icon' => '<path d="M4 5h6a2 2 0 0 1 2 2v12a2 2 0 0 0-2-2H4V5Z" stroke="currentColor" stroke-width="1.7" fill="none" stroke-linejoin="round"/><path d="M20 5h-6a2 2 0 0 0-2 2v12a2 2 0 0 1 2-2h6V5Z" stroke="currentColor" stroke-width="1.7" fill="none" stroke-linejoin="round"/>',
+            'badge' => $enabled ? '' : 'Preview',
+            'tile' => true,
+        ]];
+    }
+
+    /**
+     * Per-install presentation overrides for canonical catalog modules. Pins the
+     * workspace home first so the appended language module (order 1) slots in
+     * right after it, keeping a single "Workspace" nav group header.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function catalogOverrides(): array
+    {
+        return ['dashboard' => ['order' => 0]];
+    }
+
+    /**
      * Split a resolved AdminModules set into [nav, live_cards, preview_cards],
      * mirroring Anokii\Admin\AdminShell so the package templates render as
      * designed while minoo keeps its own account context.
@@ -185,14 +232,15 @@ final class AnokiiShellContext
 
     /**
      * Sidebar nav in pipeline flow order (#876): Ingest -> Transcribe -> Curate
-     * -> Lessons. The Overview funnel is the workspace home.
+     * -> Lessons. Overview is the language module landing at /admin/anokii/language
+     * (#888); the catalog dashboard is the workspace home reached via the brand.
      *
      * @return list<array{id: string, label: string, href: string, group?: string, badge?: string}>
      */
     private static function nav(): array
     {
         return [
-            ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii', 'group' => 'Workspace'],
+            ['id' => 'home', 'label' => 'Overview', 'href' => '/admin/anokii/language', 'group' => 'Workspace'],
             ['id' => 'ingest', 'label' => 'Ingest', 'href' => '/admin/anokii/ingest', 'group' => 'Pipeline'],
             ['id' => 'transcribe', 'label' => 'Transcribe', 'href' => '/admin/anokii/transcribe'],
             ['id' => 'curate', 'label' => 'Curate', 'href' => '/admin/anokii/curate'],

--- a/src/Provider/Routing/AnokiiRouteProvider.php
+++ b/src/Provider/Routing/AnokiiRouteProvider.php
@@ -170,6 +170,21 @@ final class AnokiiRouteProvider extends AppCoreServiceProvider
                 ->build(),
         );
 
+        // Language module landing (#888): the corpus pipeline Overview funnel,
+        // re-homed here off the workspace home when /admin/anokii became the
+        // catalog. The Language catalog card links here. Above the /{sub}
+        // catch-all so the literal path wins.
+        $router->addRoute(
+            'anokii.language',
+            RouteBuilder::create('/admin/anokii/language')
+                ->controller('App\Http\Controller\Anokii\LanguageWorkspaceController::index')
+                ->requireRole(self::STAFF_ROLES)
+                ->priority(self::TAB_PRIORITY)
+                ->render()
+                ->methods('GET')
+                ->build(),
+        );
+
         // Product-preview ("coming soon") pages for catalog modules not yet live.
         // AdminModules points preview cards and nav entries here as
         // /admin/anokii/m/{id}. Above the /{sub} catch-all so this two-segment

--- a/tests/App/Integration/Http/Admin/LanguageWorkspaceTest.php
+++ b/tests/App/Integration/Http/Admin/LanguageWorkspaceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Anokii\Pipeline\PipelineStage;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The language module re-homed under the catalog (#888):
+ *   - the catalog dashboard lists Language as a live tool linking to
+ *     /admin/anokii/language,
+ *   - /admin/anokii/language is the corpus pipeline Overview funnel (live counts,
+ *     a "do next" CTA, the cross-tab breadcrumb, flow-order nav),
+ *   - the pipeline Overview nav points back to /admin/anokii/language,
+ *   - anonymous is denied.
+ *
+ * Counts are deterministic: per-class :memory: DB, seeded below.
+ */
+#[CoversNothing]
+final class LanguageWorkspaceTest extends HttpKernelTestCase
+{
+    private static int $adminUid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $admin = $users->create(['name' => 'Lang Admin', 'mail' => 'lang-admin@example.test', 'status' => true, 'created' => time(), 'roles' => ['admin'], 'permissions' => []]);
+        $users->save($admin);
+        self::$adminUid = (int) $admin->id();
+
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $i = 0;
+        $seed = static function (array $values) use ($sentences, &$i): void {
+            ++$i;
+            $sentences->save($sentences->create($values + [
+                'source_sentence_id' => 'corpus:lw-' . $i,
+                'consent_public' => 0,
+                'status' => 0,
+                'created_at' => time(),
+                'updated_at' => time(),
+            ]));
+        };
+
+        // 2 ingested, 3 drafted, 1 transcribed (derived), 1 curated. Total 7.
+        $seed(['ojibwe_text' => '', 'english_text' => '', 'pipeline_status' => PipelineStage::INGESTED]);
+        $seed(['ojibwe_text' => '', 'english_text' => '', 'pipeline_status' => PipelineStage::INGESTED]);
+        $seed(['ojibwe_text' => 'a', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'b', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'c', 'english_text' => '', 'pipeline_status' => PipelineStage::DRAFTED]);
+        $seed(['ojibwe_text' => 'Makwa', 'english_text' => 'bear']);
+        $seed(['ojibwe_text' => 'Waaban', 'english_text' => 'dawn', 'pipeline_status' => PipelineStage::CURATED]);
+    }
+
+    #[Test]
+    public function the_catalog_lists_language_as_a_live_tool(): void
+    {
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii')->getContent();
+
+        self::assertStringContainsString('Your tools', $body, 'Live-tools section is present.');
+        self::assertStringContainsString('Language', $body);
+        self::assertStringContainsString('href="/admin/anokii/language"', $body, 'The Language card links to its tile.');
+    }
+
+    #[Test]
+    public function the_language_tile_renders_the_pipeline_overview_funnel(): void
+    {
+        $response = $this->sendAs(self::$adminUid, '/admin/anokii/language');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('anokii-app', $body);
+        self::assertStringContainsString('ov-funnel', $body);
+        self::assertStringContainsString('7 items in the pipeline', $body);
+        self::assertStringContainsString('/admin/anokii/ingest?stage=ingested', $body);
+    }
+
+    #[Test]
+    public function the_do_next_cta_points_at_the_busiest_actionable_stage(): void
+    {
+        // drafted=3 beats transcribed=1 and ingested=2 -> CTA is "Transcribe".
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii/language')->getContent();
+
+        self::assertStringContainsString('3 drafts awaiting transcription', $body);
+        self::assertStringContainsString('Transcribe', $body);
+    }
+
+    #[Test]
+    public function the_overview_nav_points_at_the_language_tile(): void
+    {
+        $body = (string) $this->sendAs(self::$adminUid, '/admin/anokii/language')->getContent();
+
+        self::assertStringContainsString('href="/admin/anokii/language"', $body, 'Overview nav points to the module landing.');
+
+        $ingest = strpos($body, 'href="/admin/anokii/ingest"');
+        $transcribe = strpos($body, 'href="/admin/anokii/transcribe"');
+        self::assertNotFalse($ingest);
+        self::assertNotFalse($transcribe);
+        self::assertLessThan($transcribe, $ingest, 'Ingest precedes Transcribe in the pipeline nav.');
+    }
+
+    #[Test]
+    public function anonymous_is_denied(): void
+    {
+        $response = $this->send('GET', '/admin/anokii/language');
+
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_FOUND, Response::HTTP_UNAUTHORIZED]);
+        self::assertStringNotContainsString('ov-funnel', (string) $response->getContent());
+    }
+
+    private function sendAs(int $uid, string $uri): Response
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = $uid;
+
+        return self::$kernel->handle();
+    }
+}

--- a/tests/App/Unit/Anokii/AnokiiCatalogContextTest.php
+++ b/tests/App/Unit/Anokii/AnokiiCatalogContextTest.php
@@ -66,6 +66,31 @@ final class AnokiiCatalogContextTest extends TestCase
         self::assertSame('documents', $module['id']);
     }
 
+    #[Test]
+    public function the_language_module_is_a_live_tile_when_enabled(): void
+    {
+        $ctx = AnokiiShellContext::catalog($this->account(), DistributionConfig::fromArray([
+            'modules' => ['enabled' => ['language']],
+        ]));
+
+        $language = self::navEntry(self::toArray($ctx['nav']), 'language');
+        self::assertSame('/admin/anokii/language', $language['href'], 'Enabled language links to its admin tile.');
+        self::assertSame('', $language['badge']);
+
+        $liveHrefs = array_map(static fn (array $card): mixed => $card['href'] ?? null, self::toArray($ctx['live_cards']));
+        self::assertContains('/admin/anokii/language', $liveHrefs, 'Language appears as a live tool card.');
+    }
+
+    #[Test]
+    public function the_language_module_is_a_preview_card_when_disabled(): void
+    {
+        $ctx = AnokiiShellContext::catalog($this->account(), DistributionConfig::fromArray([]));
+
+        $language = self::navEntry(self::toArray($ctx['nav']), 'language');
+        self::assertSame('/admin/anokii/m/language', $language['href'], 'Disabled language links to its coming-soon page.');
+        self::assertSame('Preview', $language['badge']);
+    }
+
     private function account(): AccountInterface
     {
         $account = $this->createMock(AccountInterface::class);

--- a/tests/App/Unit/Config/AnokiiDistributionConfigTest.php
+++ b/tests/App/Unit/Config/AnokiiDistributionConfigTest.php
@@ -25,11 +25,13 @@ final class AnokiiDistributionConfigTest extends TestCase
     }
 
     #[Test]
-    public function language_module_is_off_by_default(): void
+    public function language_module_is_enabled_in_config(): void
     {
+        // Graduated from preview to enabled in #888 (the corpus pipeline is the
+        // language module's live admin tile at /admin/anokii/language).
         $config = DistributionConfig::fromFile(__DIR__ . '/../../../../config/anokii.yaml');
 
-        $this->assertFalse($config->moduleEnabled('language'));
+        $this->assertTrue($config->moduleEnabled('language'));
     }
 
     #[Test]


### PR DESCRIPTION
Closes #888. Issue 3 of the **Anokii parity and the language module** milestone (#65). Builds on the catalog shell (#887).

## What changed
Adds a `language` module to the catalog (via `AdminModules::resolve()`'s `$extra`) and re-homes minoo's existing corpus pipeline under it as the module's admin tile.

- **`config/anokii.yaml`**: graduate `language` from preview to enabled, so `DistributionConfig::moduleEnabled('language')` is true and the catalog renders it as a live tool. Its data/API layers (TM, `/api/lang`, ASR) land behind this same flag in later issues.
- **`AnokiiShellContext`**: append the gated `language` module row via `$extra` (live → `/admin/anokii/language`, else a preview card), and pin the home first via an `order` override so Language slots in right after it under one Workspace nav group.
- **`LanguageWorkspaceController`**: renders the pipeline Overview funnel at `/admin/anokii/language` (the page issue 2 lifted off the workspace home when it became the catalog). Reuses `PipelineCounts` + `index.html.twig` + the pipeline shell context.
- **`AnokiiRouteProvider`**: add the `/admin/anokii/language` route at tab priority.
- **`AnokiiShellContext::build()`**: repoint the pipeline Overview nav to `/admin/anokii/language` so the tabs and the module landing stay consistent.

## Scope guardrails (per the issue)
- Ingest/Transcribe/Curate controllers and templates unchanged.
- No `LanguageModuleServiceProvider`, no `translation_memory` / `tm_gap_log` entities (issue 4); no `DialectCodeProvider` (5), no `/api/lang` (6), no `AsrClient` (7). No CoIntelligence graph entities (D3).

## Tests and gates (all green)
- New `LanguageWorkspaceTest` (integration): the catalog lists Language as a live tool linking to `/admin/anokii/language`; that route renders the pipeline Overview funnel; the do-next CTA; the Overview nav points at the tile; anonymous denied.
- Extended `AnokiiCatalogContextTest` (unit): language is a live tile when enabled, a preview card when disabled.
- Updated `AnokiiDistributionConfigTest`: `language` is now enabled in config (graduated).
- `MinooUnit` 456 (2 env skips), `MinooIntegration` 113, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.