### PR TITLE
feat(#890): LanguageModuleServiceProvider with translation_memory and tm_gap_log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
                 "App\\Provider\\MinooRoutingStackProvider",
                 "App\\Provider\\AppBootServiceProvider",
                 "App\\Provider\\AnokiiServiceProvider",
+                "App\\Provider\\LanguageModuleServiceProvider",
                 "App\\Provider\\AppCommandServiceProvider",
                 "App\\Provider\\BimaajiBridgeProvider"
             ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41ee696bd9a04227f27f63bdaf80f547",
+    "content-hash": "78419792cca331104468a4c0f03bebfc",
     "packages": [
         {
             "name": "defuse/php-encryption",

--- a/migrations/20260624_120000_create_translation_memory_tables.php
+++ b/migrations/20260624_120000_create_translation_memory_tables.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Create the language-module translation-memory tables (issue #890):
+ * translation_memory and tm_gap_log, both content entities.
+ *
+ * Content-entity schema is the framework _data CLOB shape; all field values live
+ * in the _data JSON blob, never in dedicated columns. The label key column is
+ * source_en for both. The :memory: test kernel auto-creates these from the entity
+ * definitions; this migration gives production the same tables.
+ */
+return new class () extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        $connection = $schema->getConnection();
+
+        if (!$schema->hasTable('translation_memory')) {
+            $connection->executeStatement('
+                CREATE TABLE translation_memory (
+                    tmid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid CLOB,
+                    bundle CLOB,
+                    source_en CLOB,
+                    langcode CLOB,
+                    _data CLOB
+                )
+            ');
+        }
+
+        if (!$schema->hasTable('tm_gap_log')) {
+            $connection->executeStatement('
+                CREATE TABLE tm_gap_log (
+                    glid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid CLOB,
+                    bundle CLOB,
+                    source_en CLOB,
+                    langcode CLOB,
+                    _data CLOB
+                )
+            ');
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        foreach (['translation_memory', 'tm_gap_log'] as $table) {
+            if ($schema->hasTable($table)) {
+                $schema->getConnection()->executeStatement('DROP TABLE ' . $table);
+            }
+        }
+    }
+};

--- a/src/Access/Language/LanguageAccessPolicy.php
+++ b/src/Access/Language/LanguageAccessPolicy.php
@@ -10,10 +10,14 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 
-#[PolicyAttribute(entityType: ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker'])]
+#[PolicyAttribute(entityType: ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log'])]
 final class LanguageAccessPolicy implements AccessPolicyInterface
 {
-    private const ENTITY_TYPES = ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker'];
+    // translation_memory is published + consent-gated like the other content
+    // (public when status is 1 and consent_public is on). tm_gap_log carries a
+    // lifecycle string status (open|queued_for_speaker|resolved), so the integer
+    // status-1 view gate below never opens it: gap data stays admin-only.
+    private const ENTITY_TYPES = ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log'];
 
     public function appliesTo(string $entityTypeId): bool
     {

--- a/src/Entity/Language/TmGapLog.php
+++ b/src/Entity/Language/TmGapLog.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Language;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+/**
+ * A translation-memory gap-log entry: one English string the lookup could not
+ * satisfy (issue #890). Mirrors the ingest_log write pattern (a service builds
+ * it, a workflow drives a status lifecycle) but is lookup-miss-scoped, not
+ * materialization-scoped. Its `status` is a lifecycle string (open ->
+ * queued_for_speaker -> resolved), so it is never publicly viewable: the
+ * LanguageAccessPolicy view gate keys on an integer status of 1, which a string
+ * status never satisfies, leaving gap data admin-only.
+ */
+final class TmGapLog extends ContentEntityBase
+{
+    protected string $entityTypeId = 'tm_gap_log';
+
+    protected array $entityKeys = [
+        'id' => 'glid',
+        'uuid' => 'uuid',
+        'label' => 'source_en',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $defaults = [
+            'status' => 'open',
+            'request_count' => 1,
+            'created_at' => 0,
+            'updated_at' => 0,
+        ];
+        foreach ($defaults as $key => $value) {
+            if (!array_key_exists($key, $values)) {
+                $values[$key] = $value;
+            }
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Entity/Language/TranslationMemory.php
+++ b/src/Entity/Language/TranslationMemory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Language;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+/**
+ * A translation-memory entry: one English source string mapped to its
+ * Anishinaabemowin translation, tagged with dialect and consent (#888 milestone,
+ * issue #890). The lookup contract (exact then fuzzy then gap-log) and the
+ * /api/lang surface that reads these land in later issues; this is the data model
+ * the language module owns. `translation` is stored plain (not JSON-wrapped) to
+ * avoid the dictionary_entry definition gotcha.
+ */
+final class TranslationMemory extends ContentEntityBase
+{
+    protected string $entityTypeId = 'translation_memory';
+
+    protected array $entityKeys = [
+        'id' => 'tmid',
+        'uuid' => 'uuid',
+        'label' => 'source_en',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $defaults = [
+            'status' => 1,
+            'language_code' => 'oj',
+            'needs_speaker_review' => 1,
+            'confidence' => 0,
+            'consent_public' => 1,
+            'consent_ai_training' => 0,
+            'created_at' => 0,
+            'updated_at' => 0,
+        ];
+        foreach ($defaults as $key => $value) {
+            if (!array_key_exists($key, $values)) {
+                $values[$key] = $value;
+            }
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider;
+
+use App\Entity\Language\TmGapLog;
+use App\Entity\Language\TranslationMemory;
+use Waaseyaa\Entity\EntityType;
+
+/**
+ * The Anokii language module's wiring (issue #890), following the config-gated
+ * module-provider seam (the package CoIntelligenceServiceProvider pattern).
+ *
+ * This is the self-contained home for the language capability: it owns the
+ * module's data model and, in later milestone issues, its services
+ * (DialectCodeProvider, the translation-memory lookup, the gated AsrClient) and
+ * its public surface (the /api/lang routes, mounted gated on
+ * DistributionConfig::moduleEnabled('language')). Keeping it as one provider
+ * makes the eventual extraction to a waaseyaa/anokii-language package cheap.
+ *
+ * Entities are registered unconditionally (like the package CoIntelligence
+ * provider registers its graph) so the schema is consistent regardless of the
+ * module flag; only the public surfaces get gated. The :memory: test kernel
+ * auto-creates these tables from the entity definitions; production gets them
+ * from migrations/20260624_120000_create_translation_memory_tables.php.
+ */
+final class LanguageModuleServiceProvider extends AppCoreServiceProvider
+{
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: 'translation_memory',
+            label: 'Translation Memory',
+            class: TranslationMemory::class,
+            keys: ['id' => 'tmid', 'uuid' => 'uuid', 'label' => 'source_en'],
+            group: 'language',
+            _fieldDefinitions: [
+                'source_en' => ['type' => 'string', 'label' => 'English Source', 'description' => 'The normalized English source string.', 'weight' => 0],
+                'source_hash' => ['type' => 'string', 'label' => 'Source Hash', 'description' => 'Hash of the normalized source for exact lookup.', 'weight' => 1],
+                'dialect_code' => ['type' => 'string', 'label' => 'Dialect Code', 'description' => 'References dialect_region.code; null means dialect-agnostic.', 'weight' => 2],
+                'translation' => ['type' => 'string', 'label' => 'Translation', 'description' => 'Anishinaabemowin translation, stored plain (not JSON-wrapped).', 'weight' => 5],
+                'confidence' => ['type' => 'integer', 'label' => 'Confidence', 'description' => 'Confidence score 0 to 100.', 'weight' => 6, 'default' => 0],
+                'needs_speaker_review' => ['type' => 'boolean', 'label' => 'Needs Speaker Review', 'weight' => 7, 'default' => 1],
+                'match_origin' => ['type' => 'string', 'label' => 'Match Origin', 'description' => 'How the row was created: seed|imported|speaker|fuzzy_promoted.', 'weight' => 8],
+                'speaker_id' => ['type' => 'entity_reference', 'label' => 'Speaker', 'settings' => ['target_type' => 'speaker'], 'weight' => 10],
+                'contributor_id' => ['type' => 'entity_reference', 'label' => 'Contributor', 'settings' => ['target_type' => 'contributor'], 'weight' => 11],
+                'attribution_source' => ['type' => 'string', 'label' => 'Attribution Source', 'weight' => 16],
+                'attribution_url' => ['type' => 'uri', 'label' => 'Attribution URL', 'weight' => 17],
+                'source_url' => ['type' => 'uri', 'label' => 'Source URL', 'description' => 'Where the English seed came from.', 'weight' => 18],
+                'provenance' => ['type' => 'text', 'label' => 'Provenance', 'description' => 'Full provenance record JSON.', 'weight' => 20],
+                'language_code' => ['type' => 'string', 'label' => 'Language Code', 'weight' => 25, 'default' => 'oj'],
+                'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this translation may be served publicly.', 'weight' => 28, 'default' => 1],
+                'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'weight' => 29, 'default' => 0],
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
+        ));
+
+        $this->entityType(new EntityType(
+            id: 'tm_gap_log',
+            label: 'Translation Gap Log',
+            class: TmGapLog::class,
+            keys: ['id' => 'glid', 'uuid' => 'uuid', 'label' => 'source_en'],
+            group: 'language',
+            _fieldDefinitions: [
+                'source_en' => ['type' => 'string', 'label' => 'English Source', 'description' => 'The requested English string, normalized.', 'weight' => 0],
+                'source_hash' => ['type' => 'string', 'label' => 'Source Hash', 'description' => 'Dedupe key.', 'weight' => 1],
+                'dialect_code' => ['type' => 'string', 'label' => 'Dialect Code', 'description' => 'Requested dialect (references dialect_region.code), nullable.', 'weight' => 2],
+                'lookup_type' => ['type' => 'string', 'label' => 'Lookup Type', 'description' => 'exact_miss or fuzzy_below_threshold.', 'weight' => 3],
+                'best_fuzzy_score' => ['type' => 'integer', 'label' => 'Best Fuzzy Score', 'description' => 'Best similarity seen 0 to 100, nullable.', 'weight' => 4],
+                'request_count' => ['type' => 'integer', 'label' => 'Request Count', 'description' => 'Incremented on repeat misses (the gap frequency).', 'weight' => 5, 'default' => 1],
+                'last_requested_at' => ['type' => 'timestamp', 'label' => 'Last Requested', 'weight' => 6],
+                'status' => ['type' => 'string', 'label' => 'Status', 'description' => 'open | queued_for_speaker | resolved.', 'weight' => 7, 'default' => 'open'],
+                'resolved_tm_id' => ['type' => 'integer', 'label' => 'Resolved Translation', 'description' => 'The translation_memory row that closed the gap, nullable.', 'weight' => 8],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
+        ));
+    }
+}

--- a/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
+++ b/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Entity;
+
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The language module's data model is registered by LanguageModuleServiceProvider
+ * and round-trips through entity storage (issue #890). Boots the real kernel, so
+ * it also proves the provider is discovered and the :memory: tables auto-create
+ * from the entity definitions.
+ */
+#[CoversNothing]
+final class LanguageModuleEntitiesTest extends HttpKernelTestCase
+{
+    #[Test]
+    public function translation_memory_round_trips_through_storage(): void
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('translation_memory');
+
+        $tm = $storage->create([
+            'source_en' => 'bear',
+            'source_hash' => hash('sha256', 'bear'),
+            'dialect_code' => 'oji-east',
+            'translation' => 'makwa',
+            'confidence' => 80,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $storage->save($tm);
+
+        $loaded = $storage->load($tm->id());
+        self::assertNotNull($loaded);
+        self::assertSame('bear', $loaded->get('source_en'));
+        self::assertSame('makwa', $loaded->get('translation'));
+        self::assertSame('oji-east', $loaded->get('dialect_code'));
+        self::assertSame(1, $loaded->get('needs_speaker_review'), 'Default review flag persists.');
+    }
+
+    #[Test]
+    public function tm_gap_log_round_trips_through_storage(): void
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('tm_gap_log');
+
+        $gap = $storage->create([
+            'source_en' => 'snowmobile',
+            'source_hash' => hash('sha256', 'snowmobile'),
+            'dialect_code' => 'oji-east',
+            'lookup_type' => 'exact_miss',
+            'request_count' => 3,
+            'last_requested_at' => time(),
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $storage->save($gap);
+
+        $loaded = $storage->load($gap->id());
+        self::assertNotNull($loaded);
+        self::assertSame('snowmobile', $loaded->get('source_en'));
+        self::assertSame('exact_miss', $loaded->get('lookup_type'));
+        self::assertSame(3, $loaded->get('request_count'));
+        self::assertSame('open', $loaded->get('status'), 'Default lifecycle status persists.');
+    }
+}

--- a/tests/App/Unit/Access/Language/LanguageAccessPolicyTest.php
+++ b/tests/App/Unit/Access/Language/LanguageAccessPolicyTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Unit\Access\Language;
 
 use App\Access\Language\LanguageAccessPolicy;
 use App\Entity\Language\DictionaryEntry;
+use App\Entity\Language\TmGapLog;
+use App\Entity\Language\TranslationMemory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +26,82 @@ final class LanguageAccessPolicyTest extends TestCase
         $this->assertTrue($policy->appliesTo('word_part'));
         $this->assertTrue($policy->appliesTo('dialect_region'));
         $this->assertTrue($policy->appliesTo('speaker'));
+        $this->assertTrue($policy->appliesTo('translation_memory'));
+        $this->assertTrue($policy->appliesTo('tm_gap_log'));
         $this->assertFalse($policy->appliesTo('node'));
+    }
+
+    #[Test]
+    public function anonymous_can_view_published_consented_translation_memory(): void
+    {
+        $policy = new LanguageAccessPolicy();
+        $tm = new TranslationMemory(['source_en' => 'bear', 'translation' => 'makwa', 'status' => 1, 'consent_public' => 1]);
+
+        $this->assertTrue($policy->access($tm, 'view', $this->anonymous())->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_view_consent_gated_translation_memory(): void
+    {
+        $policy = new LanguageAccessPolicy();
+        $tm = new TranslationMemory(['source_en' => 'bear', 'translation' => 'makwa', 'status' => 1, 'consent_public' => 0]);
+
+        $this->assertFalse($policy->access($tm, 'view', $this->anonymous())->isAllowed());
+    }
+
+    #[Test]
+    public function gap_log_is_admin_only_never_public(): void
+    {
+        $policy = new LanguageAccessPolicy();
+        // A string lifecycle status never satisfies the integer status-1 view gate.
+        $gap = new TmGapLog(['source_en' => 'snowmobile', 'status' => 'open']);
+
+        $this->assertFalse($policy->access($gap, 'view', $this->anonymous())->isAllowed());
+        $this->assertTrue($policy->access($gap, 'view', $this->admin())->isAllowed());
+    }
+
+    private function anonymous(): AccountInterface
+    {
+        return new class () implements AccountInterface {
+            public function id(): int
+            {
+                return 0;
+            }
+            public function hasPermission(string $p): bool
+            {
+                return $p === 'access content';
+            }
+            public function getRoles(): array
+            {
+                return ['anonymous'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    private function admin(): AccountInterface
+    {
+        return new class () implements AccountInterface {
+            public function id(): int
+            {
+                return 1;
+            }
+            public function hasPermission(string $p): bool
+            {
+                return $p === 'administer content';
+            }
+            public function getRoles(): array
+            {
+                return ['admin'];
+            }
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
     }
 
     #[Test]

--- a/tests/App/Unit/Entity/Language/TmGapLogTest.php
+++ b/tests/App/Unit/Entity/Language/TmGapLogTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity\Language;
+
+use App\Entity\Language\TmGapLog;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TmGapLog::class)]
+final class TmGapLogTest extends TestCase
+{
+    #[Test]
+    public function it_creates_with_the_missed_source(): void
+    {
+        $gap = new TmGapLog([
+            'source_en' => 'snowmobile',
+            'dialect_code' => 'oji-east',
+            'lookup_type' => 'exact_miss',
+        ]);
+
+        $this->assertSame('snowmobile', $gap->get('source_en'));
+        $this->assertSame('oji-east', $gap->get('dialect_code'));
+        $this->assertSame('exact_miss', $gap->get('lookup_type'));
+        $this->assertSame('tm_gap_log', $gap->getEntityTypeId());
+    }
+
+    #[Test]
+    public function it_defaults_to_an_open_status_with_one_request(): void
+    {
+        $gap = new TmGapLog(['source_en' => 'helicopter']);
+
+        $this->assertSame('open', $gap->get('status'));
+        $this->assertSame(1, $gap->get('request_count'));
+    }
+
+    #[Test]
+    public function explicit_values_override_defaults(): void
+    {
+        $gap = new TmGapLog([
+            'source_en' => 'helicopter',
+            'status' => 'queued_for_speaker',
+            'request_count' => 7,
+        ]);
+
+        $this->assertSame('queued_for_speaker', $gap->get('status'));
+        $this->assertSame(7, $gap->get('request_count'));
+    }
+}

--- a/tests/App/Unit/Entity/Language/TranslationMemoryTest.php
+++ b/tests/App/Unit/Entity/Language/TranslationMemoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity\Language;
+
+use App\Entity\Language\TranslationMemory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TranslationMemory::class)]
+final class TranslationMemoryTest extends TestCase
+{
+    #[Test]
+    public function it_creates_with_source_translation_and_dialect(): void
+    {
+        $tm = new TranslationMemory([
+            'source_en' => 'bear',
+            'translation' => 'makwa',
+            'dialect_code' => 'oji-east',
+        ]);
+
+        $this->assertSame('bear', $tm->get('source_en'));
+        $this->assertSame('makwa', $tm->get('translation'));
+        $this->assertSame('oji-east', $tm->get('dialect_code'));
+        $this->assertSame('translation_memory', $tm->getEntityTypeId());
+    }
+
+    #[Test]
+    public function it_defaults_to_needs_speaker_review_with_zero_confidence(): void
+    {
+        $tm = new TranslationMemory(['source_en' => 'water', 'translation' => 'nibi']);
+
+        $this->assertSame(1, $tm->get('needs_speaker_review'));
+        $this->assertSame(0, $tm->get('confidence'));
+    }
+
+    #[Test]
+    public function it_defaults_language_code_status_and_consent(): void
+    {
+        $tm = new TranslationMemory(['source_en' => 'fire', 'translation' => 'ishkode']);
+
+        $this->assertSame('oj', $tm->get('language_code'));
+        $this->assertSame(1, $tm->get('status'));
+        $this->assertSame(1, $tm->get('consent_public'));
+        $this->assertSame(0, $tm->get('consent_ai_training'));
+    }
+
+    #[Test]
+    public function explicit_values_override_defaults(): void
+    {
+        $tm = new TranslationMemory([
+            'source_en' => 'hello',
+            'translation' => 'aaniin',
+            'needs_speaker_review' => 0,
+            'confidence' => 95,
+            'match_origin' => 'speaker',
+        ]);
+
+        $this->assertSame(0, $tm->get('needs_speaker_review'));
+        $this->assertSame(95, $tm->get('confidence'));
+        $this->assertSame('speaker', $tm->get('match_origin'));
+    }
+}


### PR DESCRIPTION
Closes #890. Issue 4 of the **Anokii parity and the language module** milestone (#65). Builds on the language tile (#889).

## What changed
Adds the language module's data model behind the config-gated module-provider seam (the package `CoIntelligenceServiceProvider` pattern).

- **`App\Provider\LanguageModuleServiceProvider`** (new, added to `extra.waaseyaa.providers`; `composer.lock` hash refreshed): registers the `translation_memory` and `tm_gap_log` entities. Entities register unconditionally (like the package CoIntelligence provider registers its graph); the module's public surfaces (`/api/lang`, later issues) get gated on `DistributionConfig::moduleEnabled('language')`. Keeping it one provider makes the eventual `waaseyaa/anokii-language` extraction cheap.
- **`translation_memory`** (tracker C.1): `source_en` (label), `source_hash`, `dialect_code`, `translation` (plain, not JSON-wrapped), `confidence`, `needs_speaker_review`, `match_origin`, `speaker_id`, `contributor_id`, attribution, `source_url`, `provenance`, `language_code`, consent, `status`, timestamps.
- **`tm_gap_log`** (tracker C.2): `source_en` (label), `source_hash`, `dialect_code`, `lookup_type`, `best_fuzzy_score`, `request_count`, `last_requested_at`, `status` (lifecycle string), `resolved_tm_id`, timestamps.
- **`LanguageAccessPolicy`** now covers both: `translation_memory` is consent-gated public read (like `dictionary_entry`); `tm_gap_log` is admin-only because its lifecycle-string status never satisfies the integer status-1 view gate.
- **Migration** `20260624_120000_create_translation_memory_tables.php`: both `_data` CLOB tables for production; the `:memory:` test kernel auto-creates them from the entity definitions.

## Out of scope (later issues)
`DialectCodeProvider` (5), `/api/lang` (6), `AsrClient` (7), the lookup service.

## Tests and gates (all green)
- `TranslationMemoryTest`, `TmGapLogTest` (unit): entity defaults + overrides.
- `LanguageModuleEntitiesTest` (integration): entities registered, schema auto-creates, storage round-trip (also proves the provider is discovered).
- Extended `LanguageAccessPolicyTest`: `translation_memory` consent gate (public when published+consented, denied when consent off); `tm_gap_log` admin-only.
- `ComposerProviderParityTest` green; `composer validate` clean.
- `MinooUnit` 466 (2 env skips), `MinooIntegration` 115, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.