### PR TITLE
feat(#892): DialectCodeProvider seam over ConfigSeeder dialect codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,11 +311,11 @@ Minoo is the **application layer**. It owns entity types, map-driven UX, dialect
 
 **Import rules:**
 - Minoo imports from Waaseyaa (framework) — never the reverse
-- Minoo consumes the shared taxonomy contract (`jonesrussell/indigenous-taxonomy`) for category/region/dialect constants
+- Minoo resolves dialect codes through the `App\Language\DialectCodeProvider` seam, backed by `App\Seed\ConfigSeeder::dialectRegions()` (which also seeds the `dialect_region` config entity). The `jonesrussell/indigenous-taxonomy` package referenced in earlier notes is NOT installed; it is a deferred future backing for this seam, not a current dependency (see `docs/anishinaabemowin-language-api-tracker.md` A.3).
 - Minoo may call North Cloud APIs (via the app-facing NC client interface + adapter on top of `waaseyaa/northcloud`) but must not import NC Go packages
 - North Cloud must not contain Minoo-specific entity types or templates
 
 **Shared contracts:**
-- `jonesrussell/indigenous-taxonomy` — categories, regions, dialect codes (PHP package)
+- Dialect codes: `App\Language\DialectCodeProvider` over `ConfigSeeder::dialectRegions()` (the de facto contract; a `jonesrussell/indigenous-taxonomy` package is a deferred option, not installed)
 - Waaseyaa ingestion envelope schema — used by Python harvesters to feed Minoo directly
 - NC source-manager API — used by harvesters to register sources

--- a/src/Language/DialectCodeProvider.php
+++ b/src/Language/DialectCodeProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language;
+
+use App\Seed\ConfigSeeder;
+
+/**
+ * The single seam for valid Anishinaabemowin (and related) dialect codes (issue
+ * #892).
+ *
+ * Backed today by {@see ConfigSeeder::dialectRegions()}, the de facto canonical
+ * contract that also seeds the dialect_region config entity. Callers (the future
+ * /api/lang dialect parameter, ingestion mapping of NorthCloud's free-text
+ * Language) depend on this provider, not on the seeder or a package, so the
+ * backing can move to a jonesrussell/indigenous-taxonomy package later without
+ * rewriting them. Package publication is deferred until multi-nation federation
+ * needs it (see docs/anishinaabemowin-language-api-tracker.md A.3).
+ */
+final class DialectCodeProvider
+{
+    /**
+     * The valid dialect codes, for example oji-east, oji-ottawa.
+     *
+     * @return list<string>
+     */
+    public function codes(): array
+    {
+        return array_column(ConfigSeeder::dialectRegions(), 'code');
+    }
+
+    /**
+     * Whether a requested dialect code is one of the canonical codes.
+     */
+    public function isValid(string $code): bool
+    {
+        return in_array($code, $this->codes(), true);
+    }
+
+    /**
+     * A lightweight view of the dialects for display and selection: the code, the
+     * endonym, the English display name, and the ISO 639-3 code.
+     *
+     * @return list<array{code: string, name: string, display_name: string, iso_639_3: string}>
+     */
+    public function all(): array
+    {
+        return array_map(
+            static fn (array $row): array => [
+                'code' => $row['code'],
+                'name' => $row['name'],
+                'display_name' => $row['display_name'],
+                'iso_639_3' => $row['iso_639_3'],
+            ],
+            ConfigSeeder::dialectRegions(),
+        );
+    }
+}

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Provider;
 
 use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
+use App\Language\DialectCodeProvider;
 use Waaseyaa\Entity\EntityType;
 
 /**
@@ -29,6 +30,12 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
 {
     public function register(): void
     {
+        // The single seam for valid dialect codes. Bound here so the module's
+        // services and (issue 6) the /api/lang dialect parameter resolve one
+        // contract; the backing can move to a taxonomy package later without
+        // touching callers.
+        $this->singleton(DialectCodeProvider::class, static fn (): DialectCodeProvider => new DialectCodeProvider());
+
         $this->entityType(new EntityType(
             id: 'translation_memory',
             label: 'Translation Memory',

--- a/tests/App/Unit/Language/DialectCodeProviderTest.php
+++ b/tests/App/Unit/Language/DialectCodeProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language;
+
+use App\Language\DialectCodeProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DialectCodeProvider::class)]
+final class DialectCodeProviderTest extends TestCase
+{
+    #[Test]
+    public function codes_include_the_canonical_dialects(): void
+    {
+        $codes = (new DialectCodeProvider())->codes();
+
+        // The RHT nations map to these; the full set is the ConfigSeeder contract.
+        self::assertContains('oji-east', $codes);
+        self::assertContains('oji-ottawa', $codes);
+        self::assertGreaterThanOrEqual(10, count($codes));
+        self::assertSame(array_values(array_unique($codes)), $codes, 'Codes are unique.');
+    }
+
+    #[Test]
+    public function is_valid_accepts_canonical_codes_and_rejects_others(): void
+    {
+        $provider = new DialectCodeProvider();
+
+        self::assertTrue($provider->isValid('oji-east'));
+        self::assertTrue($provider->isValid('mohawk'));
+        self::assertFalse($provider->isValid('klingon'));
+        self::assertFalse($provider->isValid(''));
+        self::assertFalse($provider->isValid('OJI-EAST'), 'Validation is case-sensitive.');
+    }
+
+    #[Test]
+    public function all_exposes_display_names_and_iso_codes(): void
+    {
+        $all = (new DialectCodeProvider())->all();
+
+        $byCode = [];
+        foreach ($all as $row) {
+            $byCode[$row['code']] = $row;
+        }
+
+        self::assertArrayHasKey('oji-east', $byCode);
+        self::assertSame('Eastern Ojibwe', $byCode['oji-east']['display_name']);
+        self::assertSame('ojg', $byCode['oji-east']['iso_639_3']);
+        self::assertNotSame('', $byCode['oji-east']['name'], 'The endonym is present.');
+    }
+}


### PR DESCRIPTION
Closes #892. Issue 5 of the **Anokii parity and the language module** milestone (#65). Builds on the language module provider (#891).

## What changed
Adds the single seam for valid dialect codes, so callers (issue 6's `/api/lang` dialect parameter) depend on one contract that can move to a `jonesrussell/indigenous-taxonomy` package later without a rewrite.

- **`App\Language\DialectCodeProvider`**: `codes()`, `isValid()`, and `all()` (code, endonym, English `display_name`, `iso_639_3`), backed by `App\Seed\ConfigSeeder::dialectRegions()` (the de facto canonical contract that also seeds the `dialect_region` config entity).
- Bound as a singleton in `LanguageModuleServiceProvider` so the module's services and the future `/api/lang` resolve one provider.
- **`CLAUDE.md`** "Architectural Boundaries": corrects the stale claim that `jonesrussell/indigenous-taxonomy` is an installed shared contract. It is not; dialect codes come from `ConfigSeeder` via this seam, and the package is a deferred future backing (tracker A.3).

## Out of scope
`/api/lang` routes (issue 6); taxonomy package publication.

## Tests and gates (all green)
- `DialectCodeProviderTest`: codes include the canonical dialects (`oji-east`, `oji-ottawa`, ...); `isValid()` is case-sensitive and rejects unknowns; `all()` exposes display names + ISO codes. Kernel-boot integration test already covers the new singleton binding.
- `MinooUnit` 469 (2 env skips), `MinooIntegration` 115, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.