### PR TITLE
feat(#894): /api/lang lookup endpoints gated on the language module

### DIFF
--- a/docs/security/sql-entity-query-access-check-bypass-audit.md
+++ b/docs/security/sql-entity-query-access-check-bypass-audit.md
@@ -90,6 +90,7 @@ These sites never have an end-user `AccountInterface` available, or run after th
 | `src/Http/Controller/Ingestion/IngestionDashboardController.php` | 101 | `loadLastSync` — admin-only last-sync timestamp. | 2026-05-19 |
 | `src/Http/Controller/People/VolunteerController.php` | 151 | `phoneExists` private uniqueness check — phone numbers cannot be duplicated across volunteers regardless of caller's view scope. Mirrors the framework's `RelationshipValidator` pattern (integrity check spans access boundaries). | 2026-05-19 |
 | `src/Http/Controller/Lesson/LessonController.php` | 165 | Admin-gated Lesson 1 course surface. guard() enforces `administer content` and every lesson route uses requireAuthentication() before any read; deliberately loads the consent-gated corpus rows for the curated lesson, with the route gate as the access boundary. | 2026-06-14 |
+| `src/Language/TranslationMemoryService.php` | 197 | `logGap` dedup of the admin-only `tm_gap_log` (issue #894). System-context operational write from the public `/api/lang` miss path: no end-user account is meaningful for finding the existing miss row to increment, and gap data is never user-visible (its lifecycle-string status keeps it admin-only). The translation lookup reads above this use `setAccount($account)`. | 2026-06-24 |
 
 ### Conditional fallback — set account when available, bypass otherwise
 

--- a/src/Http/Controller/Language/LanguageApiController.php
+++ b/src/Http/Controller/Language/LanguageApiController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller\Language;
+
+use App\Http\Controller\Concerns\JsonResponseTrait;
+use App\Language\DialectCodeProvider;
+use App\Language\TranslationMemoryService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\SSR\Attribute\MapQuery;
+
+/**
+ * The public /api/lang JSON surface (issue #894), mounted as a peer to the
+ * package /api/chat and gated on the language module flag by
+ * {@see \App\Provider\Routing\LanguageApiRouteProvider}.
+ *
+ * Read-only English-to-Anishinaabemowin lookups against the translation memory.
+ * Consent gating is enforced at the entity layer (the request account is passed
+ * through to the access-checked query), so anonymous callers only ever see
+ * published, public-consent rows.
+ */
+final class LanguageApiController
+{
+    use JsonResponseTrait;
+
+    public function __construct(
+        private readonly DialectCodeProvider $dialects,
+        private readonly TranslationMemoryService $translationMemory,
+    ) {
+    }
+
+    /**
+     * GET /api/lang/dialects: the dialect codes the API accepts.
+     */
+    public function dialects(): JsonResponse
+    {
+        return $this->json(['dialects' => $this->dialects->all()]);
+    }
+
+    /**
+     * GET /api/lang/translate?q=&dialect=: look up one English string.
+     *
+     * @param array<string, mixed> $query
+     */
+    public function translate(#[MapQuery] array $query, AccountInterface $account): JsonResponse
+    {
+        $q = is_string($query['q'] ?? null) ? trim($query['q']) : '';
+        if ($q === '') {
+            return $this->json(['error' => 'Missing required query parameter: q'], 422);
+        }
+
+        $dialect = is_string($query['dialect'] ?? null) && $query['dialect'] !== '' ? $query['dialect'] : null;
+        if ($dialect !== null && !$this->dialects->isValid($dialect)) {
+            return $this->json([
+                'error' => 'Unknown dialect code',
+                'dialect' => $dialect,
+                'valid' => $this->dialects->codes(),
+            ], 422);
+        }
+
+        return $this->json($this->translationMemory->lookup($q, $dialect, $account));
+    }
+}

--- a/src/Language/TranslationMemoryService.php
+++ b/src/Language/TranslationMemoryService.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * The translation-memory lookup contract (issue #894, tracker Section C):
+ * exact match first, then fuzzy, then write or increment a gap-log row on a miss.
+ *
+ * Reads are consent-gated through the access-checked query (the request account
+ * is bound, so LanguageAccessPolicy filters to published, public-consent rows).
+ * The gap-log write is a system-context path (operational miss log, admin-only),
+ * so it binds no account and opts out of per-row access checks; see
+ * docs/security/sql-entity-query-access-check-bypass-audit.md.
+ */
+final class TranslationMemoryService
+{
+    /** Minimum similar_text percent for a fuzzy hit. */
+    public const int FUZZY_THRESHOLD = 70;
+
+    /**
+     * Cap on candidate rows scanned for fuzzy matching. A perf guard, not a
+     * silent truncation of correctness: exact lookup is hash-indexed and never
+     * capped; only the fuzzy fallback bounds its in-PHP similarity scan. A real
+     * deployment would back this with a trigram index.
+     */
+    private const int FUZZY_SCAN_LIMIT = 200;
+
+    public function __construct(private readonly EntityTypeManager $entityTypeManager)
+    {
+    }
+
+    /**
+     * Look up an English string for the given dialect (or dialect-agnostic when
+     * null): exact, then fuzzy, then log the gap.
+     *
+     * @return array<string, mixed>
+     */
+    public function lookup(string $english, ?string $dialect, AccountInterface $account): array
+    {
+        $normalized = self::normalize($english);
+        if ($normalized === '') {
+            return ['match_type' => 'invalid', 'query' => $english];
+        }
+
+        $exact = $this->findExact($normalized, $dialect, $account);
+        if ($exact !== null) {
+            return $this->hit('exact', $exact, null);
+        }
+
+        $fuzzy = $this->findFuzzy($normalized, $dialect, $account);
+        if ($fuzzy !== null) {
+            return $this->hit('fuzzy', $fuzzy['entity'], $fuzzy['score']);
+        }
+
+        $this->logGap($normalized, $english, $dialect);
+
+        return [
+            'match_type' => 'miss',
+            'query' => $english,
+            'dialect' => $dialect,
+            'logged' => true,
+        ];
+    }
+
+    /**
+     * Normalize an English string for matching and hashing: trim, collapse
+     * internal whitespace, lowercase.
+     */
+    public static function normalize(string $english): string
+    {
+        $collapsed = (string) preg_replace('/\s+/', ' ', trim($english));
+
+        return mb_strtolower($collapsed);
+    }
+
+    /**
+     * The exact-lookup hash of an already-normalized string.
+     */
+    public static function hash(string $normalized): string
+    {
+        return hash('sha256', $normalized);
+    }
+
+    private function findExact(string $normalized, ?string $dialect, AccountInterface $account): ?EntityInterface
+    {
+        $storage = $this->entityTypeManager->getStorage('translation_memory');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->condition('source_hash', self::hash($normalized))
+            ->execute();
+        if ($ids === []) {
+            return null;
+        }
+
+        return $this->pickByDialect(array_values($storage->loadMultiple($ids)), $dialect);
+    }
+
+    /**
+     * @return array{entity: EntityInterface, score: int}|null
+     */
+    private function findFuzzy(string $normalized, ?string $dialect, AccountInterface $account): ?array
+    {
+        $storage = $this->entityTypeManager->getStorage('translation_memory');
+        $query = $storage->getQuery()->setAccount($account)
+            ->condition('status', 1)
+            ->condition('consent_public', 1);
+        if ($dialect !== null && $dialect !== '') {
+            $query->condition('dialect_code', $dialect);
+        }
+        $ids = $query->execute();
+        if ($ids === []) {
+            return null;
+        }
+        $ids = array_slice($ids, 0, self::FUZZY_SCAN_LIMIT);
+
+        $best = null;
+        $bestScore = 0;
+        foreach (array_values($storage->loadMultiple($ids)) as $row) {
+            $source = self::normalize((string) $row->get('source_en'));
+            $percent = 0.0;
+            similar_text($normalized, $source, $percent);
+            $score = (int) round($percent);
+            if ($score > $bestScore) {
+                $bestScore = $score;
+                $best = $row;
+            }
+        }
+
+        return $best !== null && $bestScore >= self::FUZZY_THRESHOLD
+            ? ['entity' => $best, 'score' => $bestScore]
+            : null;
+    }
+
+    /**
+     * @param list<EntityInterface> $rows
+     */
+    private function pickByDialect(array $rows, ?string $dialect): ?EntityInterface
+    {
+        if ($rows === []) {
+            return null;
+        }
+        $dialect = $dialect !== null && $dialect !== '' ? $dialect : null;
+
+        if ($dialect !== null) {
+            foreach ($rows as $row) {
+                if ((string) $row->get('dialect_code') === $dialect) {
+                    return $row;
+                }
+            }
+        }
+
+        foreach ($rows as $row) {
+            if ((string) $row->get('dialect_code') === '') {
+                return $row;
+            }
+        }
+
+        // A dialect was requested but only other-dialect rows exist: no match.
+        return $dialect === null ? $rows[0] : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function hit(string $type, EntityInterface $entity, ?int $matchScore): array
+    {
+        $dialect = (string) $entity->get('dialect_code');
+
+        return array_filter([
+            'match_type' => $type,
+            'translation' => (string) $entity->get('translation'),
+            'dialect' => $dialect !== '' ? $dialect : null,
+            'confidence' => (int) $entity->get('confidence'),
+            'needs_speaker_review' => (int) $entity->get('needs_speaker_review') === 1,
+            'source' => (string) $entity->get('source_en'),
+            'match_score' => $matchScore,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    private function logGap(string $normalized, string $original, ?string $dialect): void
+    {
+        $storage = $this->entityTypeManager->getStorage('tm_gap_log');
+        $hash = self::hash($normalized);
+        $dialectCode = $dialect !== null && $dialect !== '' ? $dialect : '';
+        $now = time();
+
+        // System-context write: the gap log is admin-only and dedup needs no
+        // end-user account, so bind none and opt out of per-row access checks.
+        // See docs/security/sql-entity-query-access-check-bypass-audit.md.
+        $ids = $storage->getQuery()->accessCheck(false)
+            ->condition('source_hash', $hash)
+            ->condition('dialect_code', $dialectCode)
+            ->execute();
+
+        if ($ids !== []) {
+            $gap = $storage->load(reset($ids));
+            if ($gap !== null) {
+                $gap->set('request_count', (int) $gap->get('request_count') + 1);
+                $gap->set('last_requested_at', $now);
+                $gap->set('updated_at', $now);
+                $storage->save($gap);
+
+                return;
+            }
+        }
+
+        $gap = $storage->create([
+            'source_en' => $original,
+            'source_hash' => $hash,
+            'dialect_code' => $dialectCode,
+            'lookup_type' => 'exact_miss',
+            'request_count' => 1,
+            'last_requested_at' => $now,
+            'status' => 'open',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $storage->save($gap);
+    }
+}

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -7,7 +7,9 @@ namespace App\Provider;
 use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
 use App\Language\DialectCodeProvider;
+use App\Language\TranslationMemoryService;
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
 
 /**
  * The Anokii language module's wiring (issue #890), following the config-gated
@@ -35,6 +37,13 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
         // contract; the backing can move to a taxonomy package later without
         // touching callers.
         $this->singleton(DialectCodeProvider::class, static fn (): DialectCodeProvider => new DialectCodeProvider());
+
+        // The translation-memory lookup (exact -> fuzzy -> gap-log), resolved by
+        // the /api/lang controller. Reads are consent-gated at the entity layer.
+        $this->singleton(
+            TranslationMemoryService::class,
+            fn (): TranslationMemoryService => new TranslationMemoryService($this->resolve(EntityTypeManager::class)),
+        );
 
         $this->entityType(new EntityType(
             id: 'translation_memory',

--- a/src/Provider/MinooRoutingStackProvider.php
+++ b/src/Provider/MinooRoutingStackProvider.php
@@ -8,6 +8,7 @@ use App\Provider\Routing\AdminRouteProvider;
 use App\Provider\Routing\AnokiiRouteProvider;
 use App\Provider\Routing\AuthApiRouteProvider;
 use App\Provider\Routing\GamesApiRouteProvider;
+use App\Provider\Routing\LanguageApiRouteProvider;
 use App\Provider\Routing\LessonRouteProvider;
 use App\Provider\Routing\PublicAccountRouteProvider;
 use App\Provider\Routing\PublicContentRouteProvider;
@@ -39,6 +40,8 @@ final class MinooRoutingStackProvider extends ServiceProvider
             new AuthApiRouteProvider(),
             new GamesApiRouteProvider(),
             new LessonRouteProvider(),
+            // Public /api/lang surface, gated on the language module flag.
+            new LanguageApiRouteProvider(),
             new StaticPagesRouteProvider(),
             // Anokii shell must register before the admin-surface SPA catch-all
             // so its priority-100 /admin/anokii routes win over admin_spa.

--- a/src/Provider/Routing/LanguageApiRouteProvider.php
+++ b/src/Provider/Routing/LanguageApiRouteProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Routing;
+
+use Anokii\Config\DistributionConfig;
+use App\Provider\AppCoreServiceProvider;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Routing\RouteBuilder;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+/**
+ * The public /api/lang language API routes (issue #894).
+ *
+ * Mounted as a peer to the package /api/chat, gated on
+ * DistributionConfig::moduleEnabled('language'): when the language module is off
+ * these routes are not registered at all, so the surface comes and goes with the
+ * module flag. The routes are public (allowAll); consent gating happens at the
+ * entity layer inside the controller's lookup. Composed by
+ * {@see \App\Provider\MinooRoutingStackProvider}, which forwards the kernel
+ * services resolver so $this->resolve() works here.
+ */
+final class LanguageApiRouteProvider extends AppCoreServiceProvider
+{
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        $config = $this->resolve(DistributionConfig::class);
+        if (!$config instanceof DistributionConfig || !$config->moduleEnabled('language')) {
+            return;
+        }
+
+        $router->addRoute(
+            'api.lang.dialects',
+            RouteBuilder::create('/api/lang/dialects')
+                ->controller('App\Http\Controller\Language\LanguageApiController::dialects')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.lang.translate',
+            RouteBuilder::create('/api/lang/translate')
+                ->controller('App\Http\Controller\Language\LanguageApiController::translate')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+    }
+}

--- a/tests/App/Integration/Http/Language/LanguageApiTest.php
+++ b/tests/App/Integration/Http/Language/LanguageApiTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Language;
+
+use App\Language\TranslationMemoryService;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The public /api/lang surface (issue #894): exact, fuzzy, and logged-miss
+ * lookups, consent gating, dialect validation, and the dialects listing. The
+ * language module is enabled in config/anokii.yaml, so the routes are mounted.
+ */
+#[CoversNothing]
+final class LanguageApiTest extends HttpKernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('translation_memory');
+        $seed = static function (array $values) use ($storage): void {
+            $source = (string) $values['source_en'];
+            $storage->save($storage->create($values + [
+                'source_hash' => TranslationMemoryService::hash(TranslationMemoryService::normalize($source)),
+                'consent_public' => 1,
+                'status' => 1,
+                'created_at' => time(),
+                'updated_at' => time(),
+            ]));
+        };
+
+        $seed(['source_en' => 'bear', 'translation' => 'makwa', 'dialect_code' => 'oji-east', 'confidence' => 90, 'needs_speaker_review' => 0]);
+        $seed(['source_en' => 'good morning', 'translation' => 'mino-gigizheb', 'dialect_code' => 'oji-east', 'confidence' => 60, 'needs_speaker_review' => 1]);
+        // Consent-gated row: must never surface to anonymous callers.
+        $storage->save($storage->create([
+            'source_en' => 'secret word',
+            'source_hash' => TranslationMemoryService::hash(TranslationMemoryService::normalize('secret word')),
+            'translation' => 'giimooj',
+            'dialect_code' => 'oji-east',
+            'consent_public' => 0,
+            'status' => 1,
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]));
+    }
+
+    #[Test]
+    public function dialects_endpoint_lists_the_codes(): void
+    {
+        $response = $this->send('GET', '/api/lang/dialects');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $body = $this->decode($response);
+        $codes = array_column($body['dialects'], 'code');
+        self::assertContains('oji-east', $codes);
+        self::assertContains('oji-ottawa', $codes);
+    }
+
+    #[Test]
+    public function exact_match_is_case_and_whitespace_insensitive(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => '  Bear ', 'dialect' => 'oji-east']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame('makwa', $body['translation']);
+        self::assertSame(90, $body['confidence']);
+        self::assertFalse($body['needs_speaker_review']);
+    }
+
+    #[Test]
+    public function a_close_string_fuzzy_matches_and_carries_a_score(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'good mornin', 'dialect' => 'oji-east']));
+
+        self::assertSame('fuzzy', $body['match_type']);
+        self::assertSame('mino-gigizheb', $body['translation']);
+        self::assertTrue($body['needs_speaker_review']);
+        self::assertArrayHasKey('match_score', $body);
+        self::assertGreaterThanOrEqual(TranslationMemoryService::FUZZY_THRESHOLD, $body['match_score']);
+    }
+
+    #[Test]
+    public function a_miss_is_reported_and_logged_as_a_gap(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'quantum entanglement', 'dialect' => 'oji-east']));
+        self::assertSame('miss', $body['match_type']);
+
+        $gaps = self::$kernel->getEntityTypeManager()->getStorage('tm_gap_log');
+        $ids = $gaps->getQuery()->accessCheck(false)
+            ->condition('source_hash', TranslationMemoryService::hash('quantum entanglement'))
+            ->execute();
+        self::assertNotEmpty($ids, 'The miss wrote a gap-log row.');
+    }
+
+    #[Test]
+    public function repeated_misses_increment_the_gap_request_count(): void
+    {
+        $this->send('GET', '/api/lang/translate', ['q' => 'helicopter', 'dialect' => 'oji-east']);
+        $this->send('GET', '/api/lang/translate', ['q' => 'helicopter', 'dialect' => 'oji-east']);
+
+        $gaps = self::$kernel->getEntityTypeManager()->getStorage('tm_gap_log');
+        $ids = $gaps->getQuery()->accessCheck(false)
+            ->condition('source_hash', TranslationMemoryService::hash('helicopter'))
+            ->condition('dialect_code', 'oji-east')
+            ->execute();
+        self::assertCount(1, $ids, 'Repeat misses dedupe to one row.');
+        $gap = $gaps->load(reset($ids));
+        self::assertNotNull($gap);
+        self::assertGreaterThanOrEqual(2, (int) $gap->get('request_count'));
+    }
+
+    #[Test]
+    public function consent_gated_rows_never_surface(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'secret word', 'dialect' => 'oji-east']));
+
+        self::assertSame('miss', $body['match_type'], 'A consent_public=0 row must not be returned.');
+    }
+
+    #[Test]
+    public function missing_query_is_a_422(): void
+    {
+        $response = $this->send('GET', '/api/lang/translate', ['dialect' => 'oji-east']);
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function unknown_dialect_is_a_422(): void
+    {
+        $response = $this->send('GET', '/api/lang/translate', ['q' => 'bear', 'dialect' => 'klingon']);
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        $decoded = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/tests/App/Unit/Language/TranslationMemoryServiceTest.php
+++ b/tests/App/Unit/Language/TranslationMemoryServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language;
+
+use App\Language\TranslationMemoryService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TranslationMemoryService::class)]
+final class TranslationMemoryServiceTest extends TestCase
+{
+    #[Test]
+    public function normalize_trims_collapses_whitespace_and_lowercases(): void
+    {
+        self::assertSame('hello world', TranslationMemoryService::normalize("  Hello   World  "));
+        self::assertSame('good morning', TranslationMemoryService::normalize("Good\tMorning"));
+        self::assertSame('', TranslationMemoryService::normalize('   '));
+    }
+
+    #[Test]
+    public function hash_is_deterministic_and_distinguishes_inputs(): void
+    {
+        $a = TranslationMemoryService::hash(TranslationMemoryService::normalize('bear'));
+        $b = TranslationMemoryService::hash(TranslationMemoryService::normalize('Bear'));
+        $c = TranslationMemoryService::hash(TranslationMemoryService::normalize('wolf'));
+
+        self::assertSame($a, $b, 'Normalized inputs hash equally regardless of case.');
+        self::assertNotSame($a, $c, 'Different strings hash differently.');
+    }
+}


### PR DESCRIPTION
Closes #894. Issue 6 of the **Anokii parity and the language module** milestone (#65). Builds on the DialectCodeProvider (#893).

## What changed
Adds the public `/api/lang` surface, mounted as a peer to the package `/api/chat` and gated on `DistributionConfig::moduleEnabled('language')`.

- **`App\Language\TranslationMemoryService`**: the lookup contract (tracker Section C) — exact (`source_hash` + dialect, with a dialect-agnostic fallback) → fuzzy (`similar_text` over `source_en` within the dialect, threshold 70) → write or increment a `tm_gap_log` row on a miss. Reads are consent-gated via the access-checked query (the request account is bound, so `LanguageAccessPolicy` filters to published, public-consent rows). The fuzzy fallback caps its in-PHP scan (a documented perf guard; exact lookup is hash-indexed and uncapped).
- **`App\Http\Controller\Language\LanguageApiController`** (JSON via `JsonResponseTrait`): `GET /api/lang/translate?q=&dialect=` (returns `match_type`, `translation`, `dialect`, `confidence`, `needs_speaker_review`, and `match_score` for fuzzy) and `GET /api/lang/dialects`. 422 on missing `q` or unknown dialect (validated via `DialectCodeProvider`).
- **`App\Provider\Routing\LanguageApiRouteProvider`**: mounts the routes only when the module is enabled; registered in `MinooRoutingStackProvider` (which forwards the kernel resolver so the gate can read `DistributionConfig`). `TranslationMemoryService` bound as a singleton in `LanguageModuleServiceProvider`.
- Documented the gap-log dedup `accessCheck(false)` write in the security bypass audit (system-context, admin-only gap data; the lookup reads use `setAccount`).

## Out of scope
ASR (issue 7); TM seeding / admin UI (the API works against whatever rows exist; misses log gaps).

## Tests and gates (all green)
- `TranslationMemoryServiceTest` (unit): normalize/hash.
- `LanguageApiTest` (integration): exact (case/whitespace-insensitive), fuzzy with score, logged miss, gap dedup/increment, consent-gated rows never surface, 422 on missing `q` and unknown dialect, dialects listing.
- `MinooUnit` 471 (2 env skips), `MinooIntegration` 123, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.