### PR TITLE
feat(#896): AsrClient seam with a consent-gated unavailable stub

### DIFF
--- a/src/Language/Asr/AsrClient.php
+++ b/src/Language/Asr/AsrClient.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Asr;
+
+/**
+ * The seam the language module resolves to reach the separate Python/GPU ASR
+ * worker (issue #896, decision D8).
+ *
+ * minoo.live never transcribes in-process: the Pi serves inference only, and
+ * training and transcription run on a separate GPU worker this client calls. The
+ * default binding is {@see UnavailableAsrClient}, which is fail-closed until the
+ * Phase 0 consent agreement with Steven Bennett / Sagamok exists and a real HTTP
+ * client is wired. There is no public ASR surface yet.
+ */
+interface AsrClient
+{
+    /**
+     * Whether transcription is available on this install (a worker is configured
+     * and the consent gate is satisfied).
+     */
+    public function isAvailable(): bool;
+
+    /**
+     * Transcribe an audio reference (a corpus path or id) in the given dialect.
+     * Returns a non-ok {@see AsrResult} when unavailable rather than throwing for
+     * the expected gated-off case.
+     */
+    public function transcribe(string $audioReference, ?string $dialect = null): AsrResult;
+}

--- a/src/Language/Asr/AsrResult.php
+++ b/src/Language/Asr/AsrResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Asr;
+
+/**
+ * The outcome of an ASR transcription request (issue #896).
+ *
+ * Either a transcript (ok) or an explained failure (not ok), for example the
+ * Phase 0 consent gate not being satisfied. A value object so callers branch on
+ * `ok` rather than on exceptions for the expected gated-off case.
+ */
+final readonly class AsrResult
+{
+    private function __construct(
+        public bool $ok,
+        public string $transcript,
+        public string $message,
+    ) {
+    }
+
+    public static function transcript(string $transcript): self
+    {
+        return new self(true, $transcript, '');
+    }
+
+    public static function unavailable(string $message): self
+    {
+        return new self(false, '', $message);
+    }
+}

--- a/src/Language/Asr/UnavailableAsrClient.php
+++ b/src/Language/Asr/UnavailableAsrClient.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Asr;
+
+/**
+ * The default, fail-closed ASR client (issue #896).
+ *
+ * Always unavailable: no transcription happens on this install until the Phase 0
+ * consent agreement with Steven Bennett / Sagamok exists and a real worker-backed
+ * client replaces this binding. Every call returns a non-ok result explaining the
+ * gate, so a future caller cannot accidentally transcribe ungated audio.
+ */
+final class UnavailableAsrClient implements AsrClient
+{
+    private const string GATE_MESSAGE = 'ASR is gated behind the Phase 0 consent agreement and is not available on this install.';
+
+    public function isAvailable(): bool
+    {
+        return false;
+    }
+
+    public function transcribe(string $audioReference, ?string $dialect = null): AsrResult
+    {
+        return AsrResult::unavailable(self::GATE_MESSAGE);
+    }
+}

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Provider;
 
 use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
+use App\Language\Asr\AsrClient;
+use App\Language\Asr\UnavailableAsrClient;
 use App\Language\DialectCodeProvider;
 use App\Language\TranslationMemoryService;
 use Waaseyaa\Entity\EntityType;
@@ -44,6 +46,11 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
             TranslationMemoryService::class,
             fn (): TranslationMemoryService => new TranslationMemoryService($this->resolve(EntityTypeManager::class)),
         );
+
+        // The ASR seam to the separate Python/GPU worker. Fail-closed by default:
+        // no transcription until the Phase 0 consent agreement exists and a real
+        // worker-backed client replaces this binding. No public ASR surface (D8).
+        $this->singleton(AsrClient::class, static fn (): AsrClient => new UnavailableAsrClient());
 
         $this->entityType(new EntityType(
             id: 'translation_memory',

--- a/tests/App/Unit/Language/Asr/UnavailableAsrClientTest.php
+++ b/tests/App/Unit/Language/Asr/UnavailableAsrClientTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language\Asr;
+
+use App\Language\Asr\AsrClient;
+use App\Language\Asr\AsrResult;
+use App\Language\Asr\UnavailableAsrClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(UnavailableAsrClient::class)]
+#[CoversClass(AsrResult::class)]
+final class UnavailableAsrClientTest extends TestCase
+{
+    #[Test]
+    public function it_is_the_asr_client_seam_and_is_never_available(): void
+    {
+        $client = new UnavailableAsrClient();
+
+        self::assertInstanceOf(AsrClient::class, $client);
+        self::assertFalse($client->isAvailable());
+    }
+
+    #[Test]
+    public function transcribe_fails_closed_with_a_consent_gate_message(): void
+    {
+        $result = (new UnavailableAsrClient())->transcribe('corpus:reel-1', 'oji-east');
+
+        self::assertFalse($result->ok);
+        self::assertSame('', $result->transcript);
+        self::assertStringContainsString('Phase 0 consent agreement', $result->message);
+    }
+
+    #[Test]
+    public function the_result_value_object_distinguishes_transcript_from_unavailable(): void
+    {
+        $ok = AsrResult::transcript('makwa');
+        self::assertTrue($ok->ok);
+        self::assertSame('makwa', $ok->transcript);
+
+        $no = AsrResult::unavailable('gated');
+        self::assertFalse($no->ok);
+        self::assertSame('gated', $no->message);
+    }
+}


### PR DESCRIPTION
Closes #896. Issue 7 (final) of the **Anokii parity and the language module** milestone (#65). Builds on `/api/lang` (#895).

## What changed
Adds the seam the language module resolves to reach the separate Python/GPU ASR worker, fail-closed until the Phase 0 consent agreement with Steven Bennett / Sagamok exists (decision D8). The Pi serves inference only; **no public ASR surface** is mounted.

- **`App\Language\Asr\AsrClient`** interface: `isAvailable()`, `transcribe()`.
- **`App\Language\Asr\AsrResult`** value object: `ok`, `transcript`, `message`; factories `transcript()` / `unavailable()`.
- **`App\Language\Asr\UnavailableAsrClient`**: the default binding. Always unavailable; `transcribe()` returns a non-ok result explaining the Phase 0 consent gate, so a future caller cannot accidentally transcribe ungated audio. A real worker-backed HTTP client replaces this binding once consent and the worker exist.
- Bound as the default `AsrClient` in `LanguageModuleServiceProvider`. No routes, no controller, no public surface.

## Tests and gates (all green)
- `UnavailableAsrClientTest`: the seam is never available; `transcribe()` fails closed with the gate message; the result value object distinguishes transcript from unavailable. The kernel-boot integration test covers the new binding.
- `MinooUnit` 474 (2 env skips), `MinooIntegration` 123, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.

This is the final issue of milestone #65.