### PR TITLE
feat(#898): reconcile the language layer onto the BCP 47 tag contract

### DIFF
--- a/docs/anishinaabemowin-language-api-tracker.md
+++ b/docs/anishinaabemowin-language-api-tracker.md
@@ -43,6 +43,41 @@ These were handed down with the recon brief and are not up for re-litigation her
    serves inference only. Training needs a GPU host that is not the Pi.
 5. Dialect and consent are tagged on every record.
 
+## Language tags (single ecosystem contract)
+
+This is the canonical language-tag contract for the whole ecosystem: Minoo, Anokii,
+rhtcircle, and the CMS all consume it. It is BCP 47, canonical everywhere.
+
+- **Three layers, with fallback.** The language is `oj`, whose autonym is
+  "Anishinaabemowin" (never an ISO exonym). A tag may carry an optional dialect
+  middle code (an ISO 639-3 subtag, e.g. `oj-ojg`), and an optional community
+  provenance as a BCP 47 private-use subtag `-x-<community>` (e.g. `oj-x-sagamok`).
+  Fallback runs `oj-x-sagamok -> oj -> en`.
+- **The TM retains community granularity.** Translation-memory rows key on the
+  full tag (`oj-x-sagamok`), never on a dialect-only code. The lookup fallback is
+  exact tag, then any row in the same DERIVED dialect grouping, then the
+  tag-agnostic row (`oj` or empty). A dialect grouping is never stored or keyed
+  on.
+- **Dialect groupings are derived, not stored.** A grouping such as Nishnaabemwin
+  (which straddles otw and ojg) is computed from the tag at read time, never
+  written in its place. Sagamok derives Nishnaabemwin / Eastern Ojibwe, with the
+  human label "Nishnaabemwin (Sagamok)".
+- **Sagamok corpus is tagged `oj-x-sagamok`** wherever provenance is set
+  (example_sentence, translation memory).
+- **Implementation seam (app-side, Minoo).** `App\Language\LanguageTag` parses and
+  validates a tag; `App\Language\DialectCodeProvider` validates, derives the
+  grouping (`dialectFor`/`dialectCodeForTag`), and produces labels, backed by
+  `App\Seed\ConfigSeeder::dialectRegions()` (groupings) and
+  `communityDialects()` (community membership). `/api/lang` accepts and returns
+  tags. No framework change is required: the entity `langcode` stays `oj` (the
+  framework already falls back `oj -> en`), and the community layer lives in
+  Minoo's own `language_tag` field resolved by Minoo's own lookup. See
+  `docs/anokii-parity-and-language-module.md` for the module seam.
+- **Private-use length note.** BCP 47 private-use subtags are at most 8 characters
+  each, so long community slugs (e.g. mississauga, thessalon) need an assigned
+  short community code before they can be tagged; that is an ecosystem data
+  decision, deferred. `sagamok` fits as-is.
+
 ## Governance gate (Phase 0)
 
 Nothing derived from Steven Bennett's paired audio corpus may be published, and no model

--- a/src/Http/Controller/Language/LanguageApiController.php
+++ b/src/Http/Controller/Language/LanguageApiController.php
@@ -32,15 +32,22 @@ final class LanguageApiController
     }
 
     /**
-     * GET /api/lang/dialects: the dialect codes the API accepts.
+     * GET /api/lang/dialects: the language and dialect groupings the API exposes,
+     * as BCP 47 tags. Community tags (oj-x-<community>) are open provenance and
+     * are not enumerated here.
      */
     public function dialects(): JsonResponse
     {
-        return $this->json(['dialects' => $this->dialects->all()]);
+        return $this->json([
+            'language' => ['tag' => 'oj', 'label' => $this->dialects->label('oj')],
+            'dialects' => $this->dialects->all(),
+        ]);
     }
 
     /**
-     * GET /api/lang/translate?q=&dialect=: look up one English string.
+     * GET /api/lang/translate?q=&tag=: look up one English string. `tag` is a BCP
+     * 47 tag (oj, an oj-<dialect> tag, or oj-x-<community>); `dialect` is accepted
+     * as a back-compat alias. A malformed tag is a 422.
      *
      * @param array<string, mixed> $query
      */
@@ -51,15 +58,17 @@ final class LanguageApiController
             return $this->json(['error' => 'Missing required query parameter: q'], 422);
         }
 
-        $dialect = is_string($query['dialect'] ?? null) && $query['dialect'] !== '' ? $query['dialect'] : null;
-        if ($dialect !== null && !$this->dialects->isValid($dialect)) {
+        $raw = $query['tag'] ?? $query['dialect'] ?? null;
+        $tag = is_string($raw) && $raw !== '' ? $raw : null;
+        if ($tag !== null && !$this->dialects->isValid($tag)) {
             return $this->json([
-                'error' => 'Unknown dialect code',
-                'dialect' => $dialect,
-                'valid' => $this->dialects->codes(),
+                'error' => 'Malformed language tag',
+                'tag' => $tag,
+                'hint' => 'Expected a BCP 47 tag: oj, an oj-<dialect> tag, or oj-x-<community> (for example oj-x-sagamok).',
+                'recognized_dialects' => $this->dialects->codes(),
             ], 422);
         }
 
-        return $this->json($this->translationMemory->lookup($q, $dialect, $account));
+        return $this->json($this->translationMemory->lookup($q, $tag, $account));
     }
 }

--- a/src/Language/DialectCodeProvider.php
+++ b/src/Language/DialectCodeProvider.php
@@ -7,47 +7,68 @@ namespace App\Language;
 use App\Seed\ConfigSeeder;
 
 /**
- * The single seam for valid Anishinaabemowin (and related) dialect codes (issue
- * #892).
+ * The single seam for the BCP 47 language-tag contract (issues #892, #898).
  *
- * Backed today by {@see ConfigSeeder::dialectRegions()}, the de facto canonical
- * contract that also seeds the dialect_region config entity. Callers (the future
- * /api/lang dialect parameter, ingestion mapping of NorthCloud's free-text
- * Language) depend on this provider, not on the seeder or a package, so the
- * backing can move to a jonesrussell/indigenous-taxonomy package later without
- * rewriting them. Package publication is deferred until multi-nation federation
- * needs it (see docs/anishinaabemowin-language-api-tracker.md A.3).
+ * Validates Minoo language tags (`oj`, optional dialect middle code, optional
+ * `-x-<community>` provenance) and derives the dialect grouping for a tag without
+ * ever storing it in the tag's place. Backed by {@see ConfigSeeder::dialectRegions()}
+ * (the dialect groupings) and {@see ConfigSeeder::communityDialects()} (community
+ * membership), so the backing can move to a jonesrussell/indigenous-taxonomy
+ * package later without rewriting callers (deferred; see the tracker A.3 and the
+ * Language tags section).
  */
 final class DialectCodeProvider
 {
+    private const string LANGUAGE = 'oj';
+
+    private const string AUTONYM = 'Anishinaabemowin';
+
     /**
-     * The valid dialect codes, for example oji-east, oji-ottawa.
+     * Whether a tag is a well-formed Minoo BCP 47 tag.
+     */
+    public function isValid(string $tag): bool
+    {
+        return LanguageTag::parse($tag, $this->dialectSubtags()) !== null;
+    }
+
+    /**
+     * The recognized non-community tags: the bare language plus each dialect-level
+     * tag `oj-<iso>`. Community tags (`oj-x-<community>`) are open provenance and
+     * are validated structurally rather than enumerated here.
      *
      * @return list<string>
      */
     public function codes(): array
     {
-        return array_column(ConfigSeeder::dialectRegions(), 'code');
+        $codes = [self::LANGUAGE];
+        foreach ($this->dialectSubtags() as $iso) {
+            $codes[] = self::LANGUAGE . '-' . $iso;
+        }
+
+        return $codes;
     }
 
     /**
-     * Whether a requested dialect code is one of the canonical codes.
-     */
-    public function isValid(string $code): bool
-    {
-        return in_array($code, $this->codes(), true);
-    }
-
-    /**
-     * A lightweight view of the dialects for display and selection: the code, the
-     * endonym, the English display name, and the ISO 639-3 code.
+     * The valid dialect middle subtags (ISO 639-3 codes) a tag may carry.
      *
-     * @return list<array{code: string, name: string, display_name: string, iso_639_3: string}>
+     * @return list<string>
+     */
+    public function dialectSubtags(): array
+    {
+        return array_column(ConfigSeeder::dialectRegions(), 'iso_639_3');
+    }
+
+    /**
+     * The dialect groupings for display and selection, each with its dialect-level
+     * tag, internal code, endonym, English display name, and ISO 639-3 code.
+     *
+     * @return list<array{tag: string, code: string, name: string, display_name: string, iso_639_3: string}>
      */
     public function all(): array
     {
         return array_map(
             static fn (array $row): array => [
+                'tag' => self::LANGUAGE . '-' . $row['iso_639_3'],
                 'code' => $row['code'],
                 'name' => $row['name'],
                 'display_name' => $row['display_name'],
@@ -55,5 +76,91 @@ final class DialectCodeProvider
             ],
             ConfigSeeder::dialectRegions(),
         );
+    }
+
+    /**
+     * The dialect grouping code (e.g. `oji-east`) derived from a tag, or null for
+     * the bare language, a malformed tag, or a community with no confirmed
+     * membership. Derivation only; nothing is stored.
+     */
+    public function dialectCodeForTag(string $tag): ?string
+    {
+        $parsed = LanguageTag::parse($tag, $this->dialectSubtags());
+        if ($parsed === null) {
+            return null;
+        }
+
+        if ($parsed->dialectSubtag !== null) {
+            foreach (ConfigSeeder::dialectRegions() as $row) {
+                if ($row['iso_639_3'] === $parsed->dialectSubtag) {
+                    return $row['code'];
+                }
+            }
+
+            return null;
+        }
+
+        if ($parsed->community !== null) {
+            return ConfigSeeder::communityDialects()[$parsed->community] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * The dialect grouping row for a tag, or null when none is derivable.
+     *
+     * @return array{code: string, name: string, display_name: string, iso_639_3: string}|null
+     */
+    public function dialectFor(string $tag): ?array
+    {
+        $code = $this->dialectCodeForTag($tag);
+        if ($code === null) {
+            return null;
+        }
+
+        foreach (ConfigSeeder::dialectRegions() as $row) {
+            if ($row['code'] === $code) {
+                return [
+                    'code' => $row['code'],
+                    'name' => $row['name'],
+                    'display_name' => $row['display_name'],
+                    'iso_639_3' => $row['iso_639_3'],
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A human label for a tag, e.g. "Nishnaabemwin (Sagamok)" for `oj-x-sagamok`,
+     * "Eastern Ojibwe" for `oj-ojg`, "Anishinaabemowin" for `oj`. Returns the raw
+     * tag for a malformed input.
+     */
+    public function label(string $tag): string
+    {
+        $parsed = LanguageTag::parse($tag, $this->dialectSubtags());
+        if ($parsed === null) {
+            return $tag;
+        }
+
+        $grouping = $this->dialectFor($tag);
+        $groupingName = $grouping !== null ? $grouping['name'] : self::AUTONYM;
+
+        if ($parsed->community !== null) {
+            return $groupingName . ' (' . $this->communityLabel($parsed->community) . ')';
+        }
+
+        if ($grouping !== null) {
+            return $grouping['display_name'];
+        }
+
+        return self::AUTONYM;
+    }
+
+    private function communityLabel(string $community): string
+    {
+        return ucwords(str_replace('-', ' ', $community));
     }
 }

--- a/src/Language/LanguageTag.php
+++ b/src/Language/LanguageTag.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language;
+
+/**
+ * A parsed BCP 47 language tag in the Minoo contract (issue #898).
+ *
+ * Three layers: the language `oj` (autonym Anishinaabemowin), an optional dialect
+ * middle subtag (an ISO 639-3 code such as `ojg` or `otw`), and an optional
+ * community provenance carried as a BCP 47 private-use subtag `-x-<community>`.
+ * Examples: `oj`, `oj-ojg`, `oj-x-sagamok`, `oj-otw-x-wikwemikong`.
+ *
+ * Parsing is the single well-formedness gate. Membership questions (which dialect
+ * a community belongs to) are derived elsewhere by {@see DialectCodeProvider};
+ * this class only validates structure and exposes the parts.
+ */
+final readonly class LanguageTag
+{
+    private function __construct(
+        public string $language,
+        public ?string $dialectSubtag,
+        public ?string $community,
+        public string $canonical,
+    ) {
+    }
+
+    /**
+     * Parse a raw tag, or return null when it is not a well-formed Minoo tag.
+     * Case-insensitive; the canonical form is lowercased.
+     *
+     * @param list<string> $validDialectSubtags the recognized dialect middle codes
+     */
+    public static function parse(string $raw, array $validDialectSubtags): ?self
+    {
+        $tag = strtolower(trim($raw));
+        if ($tag === '') {
+            return null;
+        }
+
+        $community = null;
+        $langPart = $tag;
+        if (str_contains($tag, '-x-')) {
+            [$langPart, $private] = explode('-x-', $tag, 2);
+            // Private-use subtags: one or more 1-to-8 char alphanumeric pieces.
+            if (preg_match('/^[a-z0-9]{1,8}(-[a-z0-9]{1,8})*$/', $private) !== 1) {
+                return null;
+            }
+            $community = $private;
+        } elseif ($tag === 'x' || str_ends_with($tag, '-x')) {
+            // A dangling private-use singleton with nothing after it.
+            return null;
+        }
+
+        $parts = explode('-', $langPart);
+        if ($parts[0] !== 'oj') {
+            return null;
+        }
+
+        $dialectSubtag = null;
+        if (count($parts) === 2) {
+            $dialectSubtag = $parts[1];
+            if (!in_array($dialectSubtag, $validDialectSubtags, true)) {
+                return null;
+            }
+        } elseif (count($parts) > 2) {
+            // More than one subtag before -x- is not part of the contract.
+            return null;
+        }
+
+        $canonical = 'oj'
+            . ($dialectSubtag !== null ? '-' . $dialectSubtag : '')
+            . ($community !== null ? '-x-' . $community : '');
+
+        return new self('oj', $dialectSubtag, $community, $canonical);
+    }
+}

--- a/src/Language/TranslationMemoryService.php
+++ b/src/Language/TranslationMemoryService.php
@@ -9,13 +9,19 @@ use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 
 /**
- * The translation-memory lookup contract (issue #894, tracker Section C):
- * exact match first, then fuzzy, then write or increment a gap-log row on a miss.
+ * The translation-memory lookup contract (issues #894, #898): exact match first,
+ * then fuzzy, then write or increment a gap-log row on a miss.
  *
- * Reads are consent-gated through the access-checked query (the request account
- * is bound, so LanguageAccessPolicy filters to published, public-consent rows).
- * The gap-log write is a system-context path (operational miss log, admin-only),
- * so it binds no account and opts out of per-row access checks; see
+ * Keyed on the full BCP 47 language tag (`language_tag`, e.g. `oj-x-sagamok`), so
+ * community granularity is never lost. The exact fallback order is: the requested
+ * tag, then any row in the same DERIVED dialect grouping, then the tag-agnostic
+ * language row. A dialect grouping is never stored or keyed on; it is derived from
+ * the tag by {@see DialectCodeProvider}.
+ *
+ * Reads are consent-gated through the access-checked query (the request account is
+ * bound, so LanguageAccessPolicy filters to published, public-consent rows). The
+ * gap-log write is a system-context path (operational miss log, admin-only), so it
+ * binds no account and opts out of per-row access checks; see
  * docs/security/sql-entity-query-access-check-bypass-audit.md.
  */
 final class TranslationMemoryService
@@ -24,46 +30,53 @@ final class TranslationMemoryService
     public const int FUZZY_THRESHOLD = 70;
 
     /**
-     * Cap on candidate rows scanned for fuzzy matching. A perf guard, not a
-     * silent truncation of correctness: exact lookup is hash-indexed and never
-     * capped; only the fuzzy fallback bounds its in-PHP similarity scan. A real
-     * deployment would back this with a trigram index.
+     * Cap on candidate rows scanned for fuzzy matching. A perf guard, not a silent
+     * truncation of correctness: exact lookup is hash-indexed and never capped;
+     * only the fuzzy fallback bounds its in-PHP similarity scan. A real deployment
+     * would back this with a trigram index.
      */
     private const int FUZZY_SCAN_LIMIT = 200;
 
-    public function __construct(private readonly EntityTypeManager $entityTypeManager)
-    {
+    /** Language tags treated as tag-agnostic (no community or dialect). */
+    private const array AGNOSTIC_TAGS = ['', 'oj'];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly DialectCodeProvider $dialects,
+    ) {
     }
 
     /**
-     * Look up an English string for the given dialect (or dialect-agnostic when
+     * Look up an English string for the given BCP 47 tag (or tag-agnostic when
      * null): exact, then fuzzy, then log the gap.
      *
      * @return array<string, mixed>
      */
-    public function lookup(string $english, ?string $dialect, AccountInterface $account): array
+    public function lookup(string $english, ?string $tag, AccountInterface $account): array
     {
         $normalized = self::normalize($english);
         if ($normalized === '') {
             return ['match_type' => 'invalid', 'query' => $english];
         }
 
-        $exact = $this->findExact($normalized, $dialect, $account);
+        $tag = $tag !== null && $tag !== '' ? $tag : null;
+
+        $exact = $this->findExact($normalized, $tag, $account);
         if ($exact !== null) {
             return $this->hit('exact', $exact, null);
         }
 
-        $fuzzy = $this->findFuzzy($normalized, $dialect, $account);
+        $fuzzy = $this->findFuzzy($normalized, $tag, $account);
         if ($fuzzy !== null) {
             return $this->hit('fuzzy', $fuzzy['entity'], $fuzzy['score']);
         }
 
-        $this->logGap($normalized, $english, $dialect);
+        $this->logGap($normalized, $english, $tag);
 
         return [
             'match_type' => 'miss',
             'query' => $english,
-            'dialect' => $dialect,
+            'tag' => $tag,
             'logged' => true,
         ];
     }
@@ -87,7 +100,7 @@ final class TranslationMemoryService
         return hash('sha256', $normalized);
     }
 
-    private function findExact(string $normalized, ?string $dialect, AccountInterface $account): ?EntityInterface
+    private function findExact(string $normalized, ?string $tag, AccountInterface $account): ?EntityInterface
     {
         $storage = $this->entityTypeManager->getStorage('translation_memory');
         $ids = $storage->getQuery()->setAccount($account)
@@ -99,20 +112,21 @@ final class TranslationMemoryService
             return null;
         }
 
-        return $this->pickByDialect(array_values($storage->loadMultiple($ids)), $dialect);
+        return $this->pickByTag(array_values($storage->loadMultiple($ids)), $tag);
     }
 
     /**
      * @return array{entity: EntityInterface, score: int}|null
      */
-    private function findFuzzy(string $normalized, ?string $dialect, AccountInterface $account): ?array
+    private function findFuzzy(string $normalized, ?string $tag, AccountInterface $account): ?array
     {
         $storage = $this->entityTypeManager->getStorage('translation_memory');
         $query = $storage->getQuery()->setAccount($account)
             ->condition('status', 1)
             ->condition('consent_public', 1);
-        if ($dialect !== null && $dialect !== '') {
-            $query->condition('dialect_code', $dialect);
+        if ($tag !== null) {
+            // Community-scoped fuzzy: a near-spelling within the same tag.
+            $query->condition('language_tag', $tag);
         }
         $ids = $query->execute();
         if ($ids === []) {
@@ -139,31 +153,49 @@ final class TranslationMemoryService
     }
 
     /**
+     * Exact tag, then same derived dialect grouping, then the tag-agnostic row.
+     *
      * @param list<EntityInterface> $rows
      */
-    private function pickByDialect(array $rows, ?string $dialect): ?EntityInterface
+    private function pickByTag(array $rows, ?string $tag): ?EntityInterface
     {
         if ($rows === []) {
             return null;
         }
-        $dialect = $dialect !== null && $dialect !== '' ? $dialect : null;
 
-        if ($dialect !== null) {
+        if ($tag !== null) {
+            // 1. Exact tag.
             foreach ($rows as $row) {
-                if ((string) $row->get('dialect_code') === $dialect) {
+                if ((string) $row->get('language_tag') === $tag) {
                     return $row;
+                }
+            }
+
+            // 2. Same derived dialect grouping (another community, never a
+            // dialect-only stored code).
+            $grouping = $this->dialects->dialectCodeForTag($tag);
+            if ($grouping !== null) {
+                foreach ($rows as $row) {
+                    $rowTag = (string) $row->get('language_tag');
+                    if (in_array($rowTag, self::AGNOSTIC_TAGS, true)) {
+                        continue;
+                    }
+                    if ($this->dialects->dialectCodeForTag($rowTag) === $grouping) {
+                        return $row;
+                    }
                 }
             }
         }
 
+        // 3. Tag-agnostic.
         foreach ($rows as $row) {
-            if ((string) $row->get('dialect_code') === '') {
+            if (in_array((string) $row->get('language_tag'), self::AGNOSTIC_TAGS, true)) {
                 return $row;
             }
         }
 
-        // A dialect was requested but only other-dialect rows exist: no match.
-        return $dialect === null ? $rows[0] : null;
+        // A tag was requested but only other-grouping rows exist: no match.
+        return $tag === null ? $rows[0] : null;
     }
 
     /**
@@ -171,12 +203,15 @@ final class TranslationMemoryService
      */
     private function hit(string $type, EntityInterface $entity, ?int $matchScore): array
     {
-        $dialect = (string) $entity->get('dialect_code');
+        $rowTag = (string) $entity->get('language_tag');
+        $grouping = $rowTag !== '' ? $this->dialects->dialectFor($rowTag) : null;
 
         return array_filter([
             'match_type' => $type,
             'translation' => (string) $entity->get('translation'),
-            'dialect' => $dialect !== '' ? $dialect : null,
+            'tag' => $rowTag !== '' ? $rowTag : null,
+            'dialect' => $grouping !== null ? $grouping['display_name'] : null,
+            'label' => $rowTag !== '' ? $this->dialects->label($rowTag) : null,
             'confidence' => (int) $entity->get('confidence'),
             'needs_speaker_review' => (int) $entity->get('needs_speaker_review') === 1,
             'source' => (string) $entity->get('source_en'),
@@ -184,11 +219,11 @@ final class TranslationMemoryService
         ], static fn (mixed $value): bool => $value !== null);
     }
 
-    private function logGap(string $normalized, string $original, ?string $dialect): void
+    private function logGap(string $normalized, string $original, ?string $tag): void
     {
         $storage = $this->entityTypeManager->getStorage('tm_gap_log');
         $hash = self::hash($normalized);
-        $dialectCode = $dialect !== null && $dialect !== '' ? $dialect : '';
+        $tagValue = $tag ?? '';
         $now = time();
 
         // System-context write: the gap log is admin-only and dedup needs no
@@ -196,7 +231,7 @@ final class TranslationMemoryService
         // See docs/security/sql-entity-query-access-check-bypass-audit.md.
         $ids = $storage->getQuery()->accessCheck(false)
             ->condition('source_hash', $hash)
-            ->condition('dialect_code', $dialectCode)
+            ->condition('language_tag', $tagValue)
             ->execute();
 
         if ($ids !== []) {
@@ -214,7 +249,7 @@ final class TranslationMemoryService
         $gap = $storage->create([
             'source_en' => $original,
             'source_hash' => $hash,
-            'dialect_code' => $dialectCode,
+            'language_tag' => $tagValue,
             'lookup_type' => 'exact_miss',
             'request_count' => 1,
             'last_requested_at' => $now,

--- a/src/Provider/Entity/EntityFoundationProvider.php
+++ b/src/Provider/Entity/EntityFoundationProvider.php
@@ -123,6 +123,11 @@ final class EntityFoundationProvider extends AppCoreServiceProvider
                 'source_date' => ['type' => 'string', 'label' => 'Source Date', 'description' => 'Publication date of the original source (YYYY-MM-DD).', 'weight' => 24],
                 'provenance' => ['type' => 'text', 'label' => 'Provenance', 'description' => 'Full provenance record JSON (source, media paths, credits).', 'weight' => 26],
                 'language_code' => ['type' => 'string', 'label' => 'Language Code', 'weight' => 25, 'default' => 'oj'],
+                // BCP 47 provenance tag for the utterance, e.g. oj-x-sagamok for
+                // Steven's Sagamok corpus (#898). Empty until a tagged ingest sets
+                // it; the dialect grouping is derived from it, never stored. No
+                // corpus data is loaded here (Phase 0 consent gate holds).
+                'language_tag' => ['type' => 'string', 'label' => 'Language Tag', 'description' => 'BCP 47 community provenance tag (oj-x-<community>); empty when unset.', 'weight' => 27],
                 'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this sentence may be shown on public pages.', 'weight' => 28, 'default' => 1],
                 'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'description' => 'Whether this sentence may be used for AI training. Default: no.', 'weight' => 29, 'default' => 0],
                 'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -44,7 +44,10 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
         // the /api/lang controller. Reads are consent-gated at the entity layer.
         $this->singleton(
             TranslationMemoryService::class,
-            fn (): TranslationMemoryService => new TranslationMemoryService($this->resolve(EntityTypeManager::class)),
+            fn (): TranslationMemoryService => new TranslationMemoryService(
+                $this->resolve(EntityTypeManager::class),
+                $this->resolve(DialectCodeProvider::class),
+            ),
         );
 
         // The ASR seam to the separate Python/GPU worker. Fail-closed by default:
@@ -61,7 +64,7 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
             _fieldDefinitions: [
                 'source_en' => ['type' => 'string', 'label' => 'English Source', 'description' => 'The normalized English source string.', 'weight' => 0],
                 'source_hash' => ['type' => 'string', 'label' => 'Source Hash', 'description' => 'Hash of the normalized source for exact lookup.', 'weight' => 1],
-                'dialect_code' => ['type' => 'string', 'label' => 'Dialect Code', 'description' => 'References dialect_region.code; null means dialect-agnostic.', 'weight' => 2],
+                'language_tag' => ['type' => 'string', 'label' => 'Language Tag', 'description' => 'Full BCP 47 tag, e.g. oj-x-sagamok. Community granularity is retained here; the dialect grouping is derived, never stored. Empty or oj means tag-agnostic.', 'weight' => 2],
                 'translation' => ['type' => 'string', 'label' => 'Translation', 'description' => 'Anishinaabemowin translation, stored plain (not JSON-wrapped).', 'weight' => 5],
                 'confidence' => ['type' => 'integer', 'label' => 'Confidence', 'description' => 'Confidence score 0 to 100.', 'weight' => 6, 'default' => 0],
                 'needs_speaker_review' => ['type' => 'boolean', 'label' => 'Needs Speaker Review', 'weight' => 7, 'default' => 1],
@@ -90,7 +93,7 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
             _fieldDefinitions: [
                 'source_en' => ['type' => 'string', 'label' => 'English Source', 'description' => 'The requested English string, normalized.', 'weight' => 0],
                 'source_hash' => ['type' => 'string', 'label' => 'Source Hash', 'description' => 'Dedupe key.', 'weight' => 1],
-                'dialect_code' => ['type' => 'string', 'label' => 'Dialect Code', 'description' => 'Requested dialect (references dialect_region.code), nullable.', 'weight' => 2],
+                'language_tag' => ['type' => 'string', 'label' => 'Language Tag', 'description' => 'Requested BCP 47 tag (e.g. oj-x-sagamok), empty when tag-agnostic.', 'weight' => 2],
                 'lookup_type' => ['type' => 'string', 'label' => 'Lookup Type', 'description' => 'exact_miss or fuzzy_below_threshold.', 'weight' => 3],
                 'best_fuzzy_score' => ['type' => 'integer', 'label' => 'Best Fuzzy Score', 'description' => 'Best similarity seen 0 to 100, nullable.', 'weight' => 4],
                 'request_count' => ['type' => 'integer', 'label' => 'Request Count', 'description' => 'Incremented on repeat misses (the gap frequency).', 'weight' => 5, 'default' => 1],

--- a/src/Seed/ConfigSeeder.php
+++ b/src/Seed/ConfigSeeder.php
@@ -146,4 +146,36 @@ final class ConfigSeeder
             ],
         ];
     }
+
+    /**
+     * Community-to-dialect membership: maps a BCP 47 private-use community subtag
+     * (the `<community>` in `oj-x-<community>`) to its dialect grouping code in
+     * {@see dialectRegions()}. Used to DERIVE the dialect grouping on read (the
+     * stored language tag is the full community tag; the grouping is never stored
+     * in its place).
+     *
+     * North shore of Lake Huron nations are Nishnaabemwin / Eastern Ojibwe
+     * (`oji-east`; consistent with the `canada:ontario:north-shore-huron` region
+     * on that dialect).
+     *
+     * Only communities whose slug is a valid BCP 47 private-use sequence (each
+     * hyphen-separated subtag at most 8 characters) appear here, since the tag is
+     * `oj-x-<community>`. Long-slug nations (e.g. mississauga, thessalon,
+     * batchewana, atikameksheng, wahnapitae) need an assigned short community code
+     * before they can be tagged; that is an ecosystem data decision, deferred, so
+     * they are left out rather than mapped to an unusable tag. Manitoulin and
+     * Georgian Bay communities also need per-community dialect confirmation. An
+     * unmapped community is still a well-formed tag; it just derives no grouping
+     * yet, rather than asserting a dialect the data does not support.
+     *
+     * @return array<string, string>
+     */
+    public static function communityDialects(): array
+    {
+        return [
+            'sagamok' => 'oji-east',
+            'serpent-river' => 'oji-east',
+            'garden-river' => 'oji-east',
+        ];
+    }
 }

--- a/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
+++ b/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
@@ -25,7 +25,7 @@ final class LanguageModuleEntitiesTest extends HttpKernelTestCase
         $tm = $storage->create([
             'source_en' => 'bear',
             'source_hash' => hash('sha256', 'bear'),
-            'dialect_code' => 'oji-east',
+            'language_tag' => 'oj-x-sagamok',
             'translation' => 'makwa',
             'confidence' => 80,
             'created_at' => time(),
@@ -37,7 +37,7 @@ final class LanguageModuleEntitiesTest extends HttpKernelTestCase
         self::assertNotNull($loaded);
         self::assertSame('bear', $loaded->get('source_en'));
         self::assertSame('makwa', $loaded->get('translation'));
-        self::assertSame('oji-east', $loaded->get('dialect_code'));
+        self::assertSame('oj-x-sagamok', $loaded->get('language_tag'));
         self::assertSame(1, $loaded->get('needs_speaker_review'), 'Default review flag persists.');
     }
 
@@ -49,7 +49,7 @@ final class LanguageModuleEntitiesTest extends HttpKernelTestCase
         $gap = $storage->create([
             'source_en' => 'snowmobile',
             'source_hash' => hash('sha256', 'snowmobile'),
-            'dialect_code' => 'oji-east',
+            'language_tag' => 'oj-x-sagamok',
             'lookup_type' => 'exact_miss',
             'request_count' => 3,
             'last_requested_at' => time(),

--- a/tests/App/Integration/Http/Language/LanguageApiTest.php
+++ b/tests/App/Integration/Http/Language/LanguageApiTest.php
@@ -11,8 +11,9 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * The public /api/lang surface (issue #894): exact, fuzzy, and logged-miss
- * lookups, consent gating, dialect validation, and the dialects listing. The
+ * The public /api/lang surface on the BCP 47 tag contract (issues #894, #898):
+ * exact tag match, fallback to oj, dialect-derived grouping, fuzzy, logged miss,
+ * consent gating, tag validation, and the tag-aware dialects listing. The
  * language module is enabled in config/anokii.yaml, so the routes are mounted.
  */
 #[CoversNothing]
@@ -34,14 +35,20 @@ final class LanguageApiTest extends HttpKernelTestCase
             ]));
         };
 
-        $seed(['source_en' => 'bear', 'translation' => 'makwa', 'dialect_code' => 'oji-east', 'confidence' => 90, 'needs_speaker_review' => 0]);
-        $seed(['source_en' => 'good morning', 'translation' => 'mino-gigizheb', 'dialect_code' => 'oji-east', 'confidence' => 60, 'needs_speaker_review' => 1]);
-        // Consent-gated row: must never surface to anonymous callers.
+        // Sagamok community rows.
+        $seed(['source_en' => 'bear', 'translation' => 'makwa', 'language_tag' => 'oj-x-sagamok', 'confidence' => 90, 'needs_speaker_review' => 0]);
+        $seed(['source_en' => 'good morning', 'translation' => 'mino-gigizheb', 'language_tag' => 'oj-x-sagamok', 'confidence' => 60, 'needs_speaker_review' => 1]);
+        // Tag-agnostic row (bare oj) for the fallback-to-oj case.
+        $seed(['source_en' => 'water', 'translation' => 'nibi', 'language_tag' => 'oj']);
+        // Same dialect grouping (serpent-river is also oji-east) for the
+        // dialect-derived fallback: no Sagamok "fox" row exists.
+        $seed(['source_en' => 'fox', 'translation' => 'waagosh', 'language_tag' => 'oj-x-serpent-river']);
+        // Consent-gated Sagamok row: must never surface to anonymous callers.
         $storage->save($storage->create([
             'source_en' => 'secret word',
             'source_hash' => TranslationMemoryService::hash(TranslationMemoryService::normalize('secret word')),
             'translation' => 'giimooj',
-            'dialect_code' => 'oji-east',
+            'language_tag' => 'oj-x-sagamok',
             'consent_public' => 0,
             'status' => 1,
             'created_at' => time(),
@@ -50,90 +57,98 @@ final class LanguageApiTest extends HttpKernelTestCase
     }
 
     #[Test]
-    public function dialects_endpoint_lists_the_codes(): void
+    public function dialects_endpoint_lists_tags(): void
     {
-        $response = $this->send('GET', '/api/lang/dialects');
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = $this->decode($this->send('GET', '/api/lang/dialects'));
 
-        $body = $this->decode($response);
-        $codes = array_column($body['dialects'], 'code');
-        self::assertContains('oji-east', $codes);
-        self::assertContains('oji-ottawa', $codes);
+        self::assertSame('oj', $body['language']['tag']);
+        $byCode = [];
+        foreach ($body['dialects'] as $row) {
+            $byCode[$row['code']] = $row;
+        }
+        self::assertSame('oj-ojg', $byCode['oji-east']['tag']);
+        self::assertArrayHasKey('oji-ottawa', $byCode);
     }
 
     #[Test]
-    public function exact_match_is_case_and_whitespace_insensitive(): void
+    public function exact_community_tag_match_is_case_insensitive_and_carries_the_tag(): void
     {
-        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => '  Bear ', 'dialect' => 'oji-east']));
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => '  Bear ', 'tag' => 'oj-x-sagamok']));
 
         self::assertSame('exact', $body['match_type']);
         self::assertSame('makwa', $body['translation']);
+        self::assertSame('oj-x-sagamok', $body['tag']);
+        self::assertSame('Nishnaabemwin (Sagamok)', $body['label']);
         self::assertSame(90, $body['confidence']);
         self::assertFalse($body['needs_speaker_review']);
     }
 
     #[Test]
-    public function a_close_string_fuzzy_matches_and_carries_a_score(): void
+    public function it_falls_back_to_the_tag_agnostic_oj_row(): void
     {
-        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'good mornin', 'dialect' => 'oji-east']));
+        // "water" exists only as the bare-oj row; a Sagamok query still finds it.
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'water', 'tag' => 'oj-x-sagamok']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame('nibi', $body['translation']);
+        self::assertSame('oj', $body['tag']);
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_same_dialect_grouping(): void
+    {
+        // "fox" exists only as serpent-river; both serpent-river and sagamok are
+        // oji-east, so a Sagamok query resolves it via the derived grouping.
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'fox', 'tag' => 'oj-x-sagamok']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame('waagosh', $body['translation']);
+        self::assertSame('oj-x-serpent-river', $body['tag']);
+    }
+
+    #[Test]
+    public function a_close_string_fuzzy_matches_within_the_tag(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'good mornin', 'tag' => 'oj-x-sagamok']));
 
         self::assertSame('fuzzy', $body['match_type']);
         self::assertSame('mino-gigizheb', $body['translation']);
-        self::assertTrue($body['needs_speaker_review']);
-        self::assertArrayHasKey('match_score', $body);
         self::assertGreaterThanOrEqual(TranslationMemoryService::FUZZY_THRESHOLD, $body['match_score']);
     }
 
     #[Test]
-    public function a_miss_is_reported_and_logged_as_a_gap(): void
+    public function a_miss_is_logged_as_a_gap_keyed_on_the_full_tag(): void
     {
-        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'quantum entanglement', 'dialect' => 'oji-east']));
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'quantum entanglement', 'tag' => 'oj-x-sagamok']));
         self::assertSame('miss', $body['match_type']);
 
         $gaps = self::$kernel->getEntityTypeManager()->getStorage('tm_gap_log');
         $ids = $gaps->getQuery()->accessCheck(false)
             ->condition('source_hash', TranslationMemoryService::hash('quantum entanglement'))
+            ->condition('language_tag', 'oj-x-sagamok')
             ->execute();
-        self::assertNotEmpty($ids, 'The miss wrote a gap-log row.');
-    }
-
-    #[Test]
-    public function repeated_misses_increment_the_gap_request_count(): void
-    {
-        $this->send('GET', '/api/lang/translate', ['q' => 'helicopter', 'dialect' => 'oji-east']);
-        $this->send('GET', '/api/lang/translate', ['q' => 'helicopter', 'dialect' => 'oji-east']);
-
-        $gaps = self::$kernel->getEntityTypeManager()->getStorage('tm_gap_log');
-        $ids = $gaps->getQuery()->accessCheck(false)
-            ->condition('source_hash', TranslationMemoryService::hash('helicopter'))
-            ->condition('dialect_code', 'oji-east')
-            ->execute();
-        self::assertCount(1, $ids, 'Repeat misses dedupe to one row.');
-        $gap = $gaps->load(reset($ids));
-        self::assertNotNull($gap);
-        self::assertGreaterThanOrEqual(2, (int) $gap->get('request_count'));
+        self::assertNotEmpty($ids, 'The miss wrote a gap-log row keyed on the full community tag.');
     }
 
     #[Test]
     public function consent_gated_rows_never_surface(): void
     {
-        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'secret word', 'dialect' => 'oji-east']));
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'secret word', 'tag' => 'oj-x-sagamok']));
 
-        self::assertSame('miss', $body['match_type'], 'A consent_public=0 row must not be returned.');
+        self::assertSame('miss', $body['match_type']);
     }
 
     #[Test]
     public function missing_query_is_a_422(): void
     {
-        $response = $this->send('GET', '/api/lang/translate', ['dialect' => 'oji-east']);
-        self::assertSame(422, $response->getStatusCode());
+        self::assertSame(422, $this->send('GET', '/api/lang/translate', ['tag' => 'oj-x-sagamok'])->getStatusCode());
     }
 
     #[Test]
-    public function unknown_dialect_is_a_422(): void
+    public function a_malformed_tag_is_a_422(): void
     {
-        $response = $this->send('GET', '/api/lang/translate', ['q' => 'bear', 'dialect' => 'klingon']);
-        self::assertSame(422, $response->getStatusCode());
+        // The old custom dialect code is no longer a valid tag.
+        self::assertSame(422, $this->send('GET', '/api/lang/translate', ['q' => 'bear', 'tag' => 'oji-east'])->getStatusCode());
     }
 
     /**

--- a/tests/App/Unit/Entity/Language/TmGapLogTest.php
+++ b/tests/App/Unit/Entity/Language/TmGapLogTest.php
@@ -17,12 +17,12 @@ final class TmGapLogTest extends TestCase
     {
         $gap = new TmGapLog([
             'source_en' => 'snowmobile',
-            'dialect_code' => 'oji-east',
+            'language_tag' => 'oj-x-sagamok',
             'lookup_type' => 'exact_miss',
         ]);
 
         $this->assertSame('snowmobile', $gap->get('source_en'));
-        $this->assertSame('oji-east', $gap->get('dialect_code'));
+        $this->assertSame('oj-x-sagamok', $gap->get('language_tag'));
         $this->assertSame('exact_miss', $gap->get('lookup_type'));
         $this->assertSame('tm_gap_log', $gap->getEntityTypeId());
     }

--- a/tests/App/Unit/Entity/Language/TranslationMemoryTest.php
+++ b/tests/App/Unit/Entity/Language/TranslationMemoryTest.php
@@ -13,17 +13,17 @@ use PHPUnit\Framework\TestCase;
 final class TranslationMemoryTest extends TestCase
 {
     #[Test]
-    public function it_creates_with_source_translation_and_dialect(): void
+    public function it_creates_with_source_translation_and_tag(): void
     {
         $tm = new TranslationMemory([
             'source_en' => 'bear',
             'translation' => 'makwa',
-            'dialect_code' => 'oji-east',
+            'language_tag' => 'oj-x-sagamok',
         ]);
 
         $this->assertSame('bear', $tm->get('source_en'));
         $this->assertSame('makwa', $tm->get('translation'));
-        $this->assertSame('oji-east', $tm->get('dialect_code'));
+        $this->assertSame('oj-x-sagamok', $tm->get('language_tag'));
         $this->assertSame('translation_memory', $tm->getEntityTypeId());
     }
 

--- a/tests/App/Unit/Language/DialectCodeProviderTest.php
+++ b/tests/App/Unit/Language/DialectCodeProviderTest.php
@@ -13,42 +13,69 @@ use PHPUnit\Framework\TestCase;
 final class DialectCodeProviderTest extends TestCase
 {
     #[Test]
-    public function codes_include_the_canonical_dialects(): void
+    public function is_valid_accepts_bcp47_tags_and_rejects_the_old_codes(): void
+    {
+        $p = new DialectCodeProvider();
+
+        self::assertTrue($p->isValid('oj'));
+        self::assertTrue($p->isValid('oj-x-sagamok'));
+        self::assertTrue($p->isValid('oj-ojg'));
+        self::assertTrue($p->isValid('OJ-X-SAGAMOK'), 'Case-insensitive.');
+
+        self::assertFalse($p->isValid('oji-east'), 'The old custom dialect code is not a valid tag.');
+        self::assertFalse($p->isValid('klingon'));
+        self::assertFalse($p->isValid(''));
+        self::assertFalse($p->isValid('oj-x'), 'Dangling private-use is malformed.');
+    }
+
+    #[Test]
+    public function codes_are_tag_aware_and_drop_the_old_codes(): void
     {
         $codes = (new DialectCodeProvider())->codes();
 
-        // The RHT nations map to these; the full set is the ConfigSeeder contract.
-        self::assertContains('oji-east', $codes);
-        self::assertContains('oji-ottawa', $codes);
-        self::assertGreaterThanOrEqual(10, count($codes));
-        self::assertSame(array_values(array_unique($codes)), $codes, 'Codes are unique.');
+        self::assertContains('oj', $codes);
+        self::assertContains('oj-ojg', $codes);
+        self::assertNotContains('oji-east', $codes, 'No custom dialect codes; only BCP 47 tags.');
     }
 
     #[Test]
-    public function is_valid_accepts_canonical_codes_and_rejects_others(): void
+    public function all_exposes_groupings_with_their_tags(): void
     {
-        $provider = new DialectCodeProvider();
-
-        self::assertTrue($provider->isValid('oji-east'));
-        self::assertTrue($provider->isValid('mohawk'));
-        self::assertFalse($provider->isValid('klingon'));
-        self::assertFalse($provider->isValid(''));
-        self::assertFalse($provider->isValid('OJI-EAST'), 'Validation is case-sensitive.');
-    }
-
-    #[Test]
-    public function all_exposes_display_names_and_iso_codes(): void
-    {
-        $all = (new DialectCodeProvider())->all();
-
         $byCode = [];
-        foreach ($all as $row) {
+        foreach ((new DialectCodeProvider())->all() as $row) {
             $byCode[$row['code']] = $row;
         }
 
         self::assertArrayHasKey('oji-east', $byCode);
+        self::assertSame('oj-ojg', $byCode['oji-east']['tag']);
         self::assertSame('Eastern Ojibwe', $byCode['oji-east']['display_name']);
         self::assertSame('ojg', $byCode['oji-east']['iso_639_3']);
-        self::assertNotSame('', $byCode['oji-east']['name'], 'The endonym is present.');
+    }
+
+    #[Test]
+    public function dialect_is_derived_from_a_community_or_dialect_tag(): void
+    {
+        $p = new DialectCodeProvider();
+
+        self::assertSame('oji-east', $p->dialectCodeForTag('oj-x-sagamok'));
+        self::assertSame('oji-east', $p->dialectCodeForTag('oj-ojg'));
+        self::assertNull($p->dialectCodeForTag('oj'), 'The bare language derives no grouping.');
+        self::assertNull($p->dialectCodeForTag('oj-x-sagamok2'), 'An unmapped community derives no grouping.');
+
+        $grouping = $p->dialectFor('oj-x-sagamok');
+        self::assertNotNull($grouping);
+        self::assertSame('Nishnaabemwin', $grouping['name']);
+        self::assertSame('Eastern Ojibwe', $grouping['display_name']);
+    }
+
+    #[Test]
+    public function label_reads_as_grouping_and_community(): void
+    {
+        $p = new DialectCodeProvider();
+
+        self::assertSame('Nishnaabemwin (Sagamok)', $p->label('oj-x-sagamok'));
+        self::assertSame('Nishnaabemwin (Serpent River)', $p->label('oj-x-serpent-river'));
+        self::assertSame('Eastern Ojibwe', $p->label('oj-ojg'));
+        self::assertSame('Anishinaabemowin', $p->label('oj'));
     }
 }

--- a/tests/App/Unit/Language/LanguageTagTest.php
+++ b/tests/App/Unit/Language/LanguageTagTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language;
+
+use App\Language\LanguageTag;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LanguageTag::class)]
+final class LanguageTagTest extends TestCase
+{
+    /** @var list<string> */
+    private const array SUBTAGS = ['ojg', 'otw', 'ojb'];
+
+    #[Test]
+    public function it_parses_the_bare_language(): void
+    {
+        $tag = LanguageTag::parse('oj', self::SUBTAGS);
+
+        self::assertNotNull($tag);
+        self::assertSame('oj', $tag->language);
+        self::assertNull($tag->dialectSubtag);
+        self::assertNull($tag->community);
+        self::assertSame('oj', $tag->canonical);
+    }
+
+    #[Test]
+    public function it_parses_a_community_tag(): void
+    {
+        $tag = LanguageTag::parse('oj-x-sagamok', self::SUBTAGS);
+
+        self::assertNotNull($tag);
+        self::assertNull($tag->dialectSubtag);
+        self::assertSame('sagamok', $tag->community);
+        self::assertSame('oj-x-sagamok', $tag->canonical);
+    }
+
+    #[Test]
+    public function it_parses_a_dialect_and_a_dialect_plus_community_tag(): void
+    {
+        $dialect = LanguageTag::parse('oj-ojg', self::SUBTAGS);
+        self::assertNotNull($dialect);
+        self::assertSame('ojg', $dialect->dialectSubtag);
+        self::assertNull($dialect->community);
+
+        $both = LanguageTag::parse('oj-otw-x-sagamok', self::SUBTAGS);
+        self::assertNotNull($both);
+        self::assertSame('otw', $both->dialectSubtag);
+        self::assertSame('sagamok', $both->community);
+        self::assertSame('oj-otw-x-sagamok', $both->canonical);
+    }
+
+    #[Test]
+    public function it_is_case_insensitive_and_canonicalizes_to_lowercase(): void
+    {
+        $tag = LanguageTag::parse('OJ-X-SAGAMOK', self::SUBTAGS);
+
+        self::assertNotNull($tag);
+        self::assertSame('oj-x-sagamok', $tag->canonical);
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function malformedProvider(): array
+    {
+        return [
+            ['oji-east'],   // the old custom code, not a tag
+            ['klingon'],    // wrong language
+            [''],           // empty
+            ['oj-x'],       // dangling private-use singleton
+            ['x'],          // bare private-use singleton
+            ['oj-zz'],      // unknown dialect subtag
+            ['oj-x-toolongsubtag'],  // private-use subtag over 8 chars
+            ['oj-ojg-otw'], // more than one subtag before -x-
+        ];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('malformedProvider')]
+    public function it_rejects_malformed_tags(string $raw): void
+    {
+        self::assertNull(LanguageTag::parse($raw, self::SUBTAGS));
+    }
+}


### PR DESCRIPTION
Closes #898. Milestone #66. App-side only (a framework change is confirmed not required). The TM is empty, so this is a pre-data contract fix with **no data migration**.

## What changed
- **C1 (`language_tag`)**: renamed `translation_memory` / `tm_gap_log` field `dialect_code` -> `language_tag`, holding the full BCP 47 tag (`oj-x-sagamok`); `language_code` stays `oj`. TM key is `source_hash` + `language_tag`. `TranslationMemoryService` fallback order: **exact tag -> same derived dialect grouping -> tag-agnostic** (`oj`/empty). A dialect-only code is never stored or keyed on.
- **C2 (derive, don't store)**: `App\Language\LanguageTag` parses/validates a BCP 47 tag; `ConfigSeeder::communityDialects()` maps community -> grouping; `DialectCodeProvider::dialectFor()` / `dialectCodeForTag()` / `label()` derive on read. `oj-x-sagamok` -> Nishnaabemwin / Eastern Ojibwe, label **"Nishnaabemwin (Sagamok)"**.
- **C3 (`/api/lang` tag-aware)**: `LanguageApiController` validates a BCP 47 tag (`tag=`, with `dialect=` as a back-compat alias); **422 on a malformed tag**; `DialectCodeProvider` and `/api/lang/dialects` return tags; responses carry the tag, derived dialect, and label.
- **C4 (corpus tag)**: `example_sentence` gains a `language_tag` provenance field (empty default) so Sagamok corpus is tagged `oj-x-sagamok`; new TM rows carry it. **No corpus data loaded** (Phase 0 consent gate holds) — field/default wiring only.
- **DOC**: added a "Language tags" section to the tracker as the single ecosystem contract (Minoo, Anokii, rhtcircle, CMS), with the three-layer fallback, TM community granularity, derive-not-store groupings, the Nishnaabemwin `otw`+`ojg` note, and the private-use length caveat.

## A BCP 47 detail worth flagging
Private-use subtags are at most 8 chars each, so only short-slug communities are mapped (`sagamok`, `serpent-river`, `garden-river`). Long-slug nations (mississauga, thessalon, batchewana, atikameksheng, wahnapitae) need an assigned short community code before they can be tagged; I left them unmapped rather than mint codes — that's an ecosystem data decision, deferred. `sagamok` fits as-is.

## Tests and gates (all green)
- `LanguageTagTest` (parse + reject, dataprovider of malformed inputs).
- `DialectCodeProviderTest` (tag validation, `codes()` drops the old codes, derive grouping, labels).
- `LanguageApiTest`: exact `oj-x-sagamok`, **fallback to `oj`**, **dialect-derived grouping** (serpent-river resolves a Sagamok query, both oji-east), fuzzy, logged miss keyed on the full tag, consent gating, **422 on `oji-east`** (old code now malformed).
- Updated entity + module tests to `language_tag`.
- `MinooUnit` 488 (2 env skips), `MinooIntegration` 124, `composer phpstan` (level 5) clean, cs-fixer clean, pre-commit hooks pass.

No deploy, Pi untouched, fnpi-waaseyaa untouched. No em dashes.