### PR TITLE
feat(#902): adopt the 21-nation community-code registry; drop oji-east/oji-ottawa

### DIFF
--- a/docs/anishinaabemowin-language-api-tracker.md
+++ b/docs/anishinaabemowin-language-api-tracker.md
@@ -206,10 +206,9 @@ config entity). All fields live in the `_data` JSON blob (see A.5).
 
   | code | display_name | iso_639_3 |
   |---|---|---|
-  | `oji-east` | Eastern Ojibwe (Nishnaabemwin) | ojg |
+  | `nishnaabemwin` | Eastern Ojibwe / Odawa, Nishnaabemwin (spans otw + ojg) | ojg |
   | `oji-northwest` | Northwestern Ojibwe | ojb |
   | `oji-plains` | Saulteaux / Plains Ojibwe | ojs |
-  | `oji-ottawa` | Ottawa / Odawa | otw |
   | `cree-plains` | Plains Cree | crk |
   | `cree-swampy` | Swampy Cree | csw |
   | `innu` | Innu | moe |
@@ -217,9 +216,44 @@ config entity). All fields live in the `_data` JSON blob (see A.5).
   | `inuvialuktun` | Inuvialuktun | ikt |
   | `mohawk` | Mohawk | moh |
 
-  For the RHT nations the relevant codes are `oji-east` (north shore of Lake Huron, the bulk of the
-  21) and `oji-ottawa` (Manitoulin / Odawa communities). Each row also carries `language_family`,
-  `iso_639_3`, and a `regions` list.
+  Superseded (#902): the `oji-east` and `oji-ottawa` codes are gone; all 21 RHT nations are the one
+  `nishnaabemwin` grouping (the Eastern Ojibwe / Odawa continuum, otw + ojg), DERIVED from each
+  nation's community tag, never stored. The community codes are the registry below.
+
+### Community code registry (the 21 RHT nations)
+
+Canonical `oj-x-<code>` per nation, the single ecosystem registry shared by Minoo and rhtcircle.
+BCP 47 private-use, multi-subtag where a single token would exceed 8 characters. Dialect grouping
+(Nishnaabemwin) is derived from these, never stored; no `oji-east`/`oji-ottawa`. **Provisional: every
+code is a working default subject to each nation's own confirmation (OCAP).** Seeded in
+`ConfigSeeder::communityDialects()`.
+
+| Nation | slug | tag |
+|---|---|---|
+| Batchewana First Nation of Ojibways | batchewana | `oj-x-batche-wana` |
+| Garden River First Nation | garden-river | `oj-x-garden-river` |
+| Thessalon First Nation | thessalon | `oj-x-thessa-lon` |
+| Mississauga First Nation | mississauga | `oj-x-missi-saugi` |
+| Serpent River First Nation | serpent-river | `oj-x-serpent-river` |
+| Sagamok Anishnawbek | sagamok | `oj-x-sagamok` |
+| Atikameksheng Anishnawbek | atikameksheng | `oj-x-atika-meksheng` |
+| Wahnapitae First Nation | wahnapitae | `oj-x-wahna-pitae` |
+| Nipissing First Nation | nipissing | `oj-x-nbisiing` |
+| Dokis First Nation | dokis | `oj-x-dokis` |
+| Henvey Inlet First Nation | henvey-inlet | `oj-x-henvey-inlet` |
+| Magnetawan First Nation | magnetawan | `oj-x-magneta-wan` |
+| Shawanaga First Nation | shawanaga | `oj-x-shawa-naga` |
+| Wasauksing First Nation | wasauksing | `oj-x-wasauk-sing` |
+| Aundeck Omni Kaning First Nation | aundeck-omni-kaning | `oj-x-aundeck-omni-kaning` |
+| Whitefish River First Nation | whitefish-river | `oj-x-white-fish-river` |
+| M'Chigeeng First Nation | mchigeeng | `oj-x-mchi-geeng` |
+| Sheguiandah First Nation | sheguiandah | `oj-x-shegui-andah` |
+| Sheshegwaning First Nation | sheshegwaning | `oj-x-shesheg-waning` |
+| Wiikwemkoong Unceded Territory | wiikwemkoong | `oj-x-wiikwem-koong` |
+| Zhiibaahaasing First Nation | zhiibaahaasing | `oj-x-zhiibaa-haasing` |
+
+Steven Bennett's corpus is Sagamok, tagged `oj-x-sagamok` (set on ingested drafts by
+`IngestController::createDraft`).
 - **Decision (2026-06-24):** make `dialect_region.code` / `ConfigSeeder::dialectRegions()` the
   canonical source of truth now, and correct the stale CLAUDE.md claim. Isolate dialect-code access
   behind a single seam (a `DialectCodeProvider` or equivalent, one place that returns the valid codes
@@ -501,8 +535,9 @@ Recon only, no code written. Findings:
   read path.
 - **Dialect codes (correction + decision):** `jonesrussell/indigenous-taxonomy` is NOT installed; the
   installed `waaseyaa/taxonomy` is a generic Term/Vocabulary framework with no dialect codes. The real
-  dialect contract is `ConfigSeeder::dialectRegions()` (10 codes; `oji-east` and `oji-ottawa` cover the
-  RHT nations). The CLAUDE.md "shared contract" claim is stale. Decided this pass: make
+  dialect contract is `ConfigSeeder::dialectRegions()` (the RHT nations were later consolidated under
+  one `nishnaabemwin` grouping, derived from the community code registry, in #902). The CLAUDE.md
+  "shared contract" claim is stale. Decided this pass: make
   `dialect_region.code` canonical now behind a single `DialectCodeProvider` seam (so the package can
   back it later without rewriting callers), correct the CLAUDE.md claim, defer publishing the package.
   NorthCloud cross-checked and defines no dialect codes (free-text `Language` only), so there is no

--- a/src/Http/Controller/Anokii/IngestController.php
+++ b/src/Http/Controller/Anokii/IngestController.php
@@ -203,6 +203,9 @@ final class IngestController
             'source_url' => $sourceUrl,
             'video_url' => '/admin/anokii/media/video/' . $id,
             'language_code' => 'oj',
+            // Steven's corpus is from Sagamok; provenance tag per the community
+            // code registry. Dialect grouping (Nishnaabemwin) is derived from this.
+            'language_tag' => 'oj-x-sagamok',
             'pipeline_status' => PipelineStage::INGESTED,
             'provenance' => (string) json_encode(['id' => $id, 'source_url' => $sourceUrl, 'original_filename' => $filename], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
             'consent_public' => 0,

--- a/src/Language/DialectCodeProvider.php
+++ b/src/Language/DialectCodeProvider.php
@@ -24,6 +24,16 @@ final class DialectCodeProvider
     private const string AUTONYM = 'Anishinaabemowin';
 
     /**
+     * Dialect middle subtags that derive a grouping spanning more than one ISO
+     * code, beyond the per-region iso_639_3. Nishnaabemwin is the Eastern Ojibwe /
+     * Odawa continuum (otw + ojg): ojg is the grouping's region iso, otw is added
+     * here so a tag like `oj-otw` derives the same grouping.
+     *
+     * @var array<string, string>
+     */
+    private const array SPANNING_SUBTAGS = ['otw' => 'nishnaabemwin'];
+
+    /**
      * Whether a tag is a well-formed Minoo BCP 47 tag.
      */
     public function isValid(string $tag): bool
@@ -55,7 +65,10 @@ final class DialectCodeProvider
      */
     public function dialectSubtags(): array
     {
-        return array_column(ConfigSeeder::dialectRegions(), 'iso_639_3');
+        return [
+            ...array_column(ConfigSeeder::dialectRegions(), 'iso_639_3'),
+            ...array_keys(self::SPANNING_SUBTAGS),
+        ];
     }
 
     /**
@@ -79,8 +92,8 @@ final class DialectCodeProvider
     }
 
     /**
-     * The dialect grouping code (e.g. `oji-east`) derived from a tag, or null for
-     * the bare language, a malformed tag, or a community with no confirmed
+     * The dialect grouping code (e.g. `nishnaabemwin`) derived from a tag, or null
+     * for the bare language, a malformed tag, or a community with no confirmed
      * membership. Derivation only; nothing is stored.
      */
     public function dialectCodeForTag(string $tag): ?string
@@ -91,6 +104,9 @@ final class DialectCodeProvider
         }
 
         if ($parsed->dialectSubtag !== null) {
+            if (isset(self::SPANNING_SUBTAGS[$parsed->dialectSubtag])) {
+                return self::SPANNING_SUBTAGS[$parsed->dialectSubtag];
+            }
             foreach (ConfigSeeder::dialectRegions() as $row) {
                 if ($row['iso_639_3'] === $parsed->dialectSubtag) {
                     return $row['code'];

--- a/src/Seed/ConfigSeeder.php
+++ b/src/Seed/ConfigSeeder.php
@@ -55,7 +55,11 @@ final class ConfigSeeder
     {
         return [
             [
-                'code' => 'oji-east',
+                // Nishnaabemwin is the Eastern Ojibwe / Odawa continuum spanning
+                // ISO otw + ojg. The 21 RHT nations derive this grouping from their
+                // community tag; it is never stored in the tag's place. (No
+                // oji-east / oji-ottawa codes; those were replaced by this.)
+                'code' => 'nishnaabemwin',
                 'name' => 'Nishnaabemwin',
                 'display_name' => 'Eastern Ojibwe',
                 'language_family' => 'algonquian',
@@ -79,15 +83,6 @@ final class ConfigSeeder
                 'language_family' => 'algonquian',
                 'iso_639_3' => 'ojs',
                 'regions' => ['canada:manitoba:southern', 'canada:saskatchewan'],
-                'boundary_geojson' => null,
-            ],
-            [
-                'code' => 'oji-ottawa',
-                'name' => 'Odaawaa',
-                'display_name' => 'Ottawa / Odawa',
-                'language_family' => 'algonquian',
-                'iso_639_3' => 'otw',
-                'regions' => ['canada:ontario:southern'],
                 'boundary_geojson' => null,
             ],
             [
@@ -148,34 +143,43 @@ final class ConfigSeeder
     }
 
     /**
-     * Community-to-dialect membership: maps a BCP 47 private-use community subtag
-     * (the `<community>` in `oj-x-<community>`) to its dialect grouping code in
-     * {@see dialectRegions()}. Used to DERIVE the dialect grouping on read (the
-     * stored language tag is the full community tag; the grouping is never stored
-     * in its place).
+     * Community-to-dialect membership: maps a BCP 47 private-use community code
+     * (the `<code>` in `oj-x-<code>`) to its dialect grouping in
+     * {@see dialectRegions()}. Used to DERIVE the dialect grouping on read; the
+     * stored tag is the full community tag, the grouping is never stored.
      *
-     * North shore of Lake Huron nations are Nishnaabemwin / Eastern Ojibwe
-     * (`oji-east`; consistent with the `canada:ontario:north-shore-huron` region
-     * on that dialect).
-     *
-     * Only communities whose slug is a valid BCP 47 private-use sequence (each
-     * hyphen-separated subtag at most 8 characters) appear here, since the tag is
-     * `oj-x-<community>`. Long-slug nations (e.g. mississauga, thessalon,
-     * batchewana, atikameksheng, wahnapitae) need an assigned short community code
-     * before they can be tagged; that is an ecosystem data decision, deferred, so
-     * they are left out rather than mapped to an unusable tag. Manitoulin and
-     * Georgian Bay communities also need per-community dialect confirmation. An
-     * unmapped community is still a well-formed tag; it just derives no grouping
-     * yet, rather than asserting a dialect the data does not support.
+     * These are the canonical codes for the 21 RHT nations (the registry recorded
+     * in the language-api tracker, "Community code registry"). Multi-subtag where
+     * a single token would exceed the BCP 47 private-use 8-char limit. Every code
+     * is provisional: a working default subject to each nation's own confirmation
+     * (OCAP). All 21 are Nishnaabemwin (the Eastern Ojibwe / Odawa continuum).
      *
      * @return array<string, string>
      */
     public static function communityDialects(): array
     {
         return [
-            'sagamok' => 'oji-east',
-            'serpent-river' => 'oji-east',
-            'garden-river' => 'oji-east',
+            'batche-wana' => 'nishnaabemwin',
+            'garden-river' => 'nishnaabemwin',
+            'thessa-lon' => 'nishnaabemwin',
+            'missi-saugi' => 'nishnaabemwin',
+            'serpent-river' => 'nishnaabemwin',
+            'sagamok' => 'nishnaabemwin',
+            'atika-meksheng' => 'nishnaabemwin',
+            'wahna-pitae' => 'nishnaabemwin',
+            'nbisiing' => 'nishnaabemwin',
+            'dokis' => 'nishnaabemwin',
+            'henvey-inlet' => 'nishnaabemwin',
+            'magneta-wan' => 'nishnaabemwin',
+            'shawa-naga' => 'nishnaabemwin',
+            'wasauk-sing' => 'nishnaabemwin',
+            'aundeck-omni-kaning' => 'nishnaabemwin',
+            'white-fish-river' => 'nishnaabemwin',
+            'mchi-geeng' => 'nishnaabemwin',
+            'shegui-andah' => 'nishnaabemwin',
+            'shesheg-waning' => 'nishnaabemwin',
+            'wiikwem-koong' => 'nishnaabemwin',
+            'zhiibaa-haasing' => 'nishnaabemwin',
         ];
     }
 }

--- a/tests/App/Integration/Http/Language/LanguageApiTest.php
+++ b/tests/App/Integration/Http/Language/LanguageApiTest.php
@@ -40,7 +40,7 @@ final class LanguageApiTest extends HttpKernelTestCase
         $seed(['source_en' => 'good morning', 'translation' => 'mino-gigizheb', 'language_tag' => 'oj-x-sagamok', 'confidence' => 60, 'needs_speaker_review' => 1]);
         // Tag-agnostic row (bare oj) for the fallback-to-oj case.
         $seed(['source_en' => 'water', 'translation' => 'nibi', 'language_tag' => 'oj']);
-        // Same dialect grouping (serpent-river is also oji-east) for the
+        // Same dialect grouping (serpent-river is also nishnaabemwin) for the
         // dialect-derived fallback: no Sagamok "fox" row exists.
         $seed(['source_en' => 'fox', 'translation' => 'waagosh', 'language_tag' => 'oj-x-serpent-river']);
         // Consent-gated Sagamok row: must never surface to anonymous callers.
@@ -66,8 +66,9 @@ final class LanguageApiTest extends HttpKernelTestCase
         foreach ($body['dialects'] as $row) {
             $byCode[$row['code']] = $row;
         }
-        self::assertSame('oj-ojg', $byCode['oji-east']['tag']);
-        self::assertArrayHasKey('oji-ottawa', $byCode);
+        self::assertSame('oj-ojg', $byCode['nishnaabemwin']['tag']);
+        self::assertArrayNotHasKey('oji-east', $byCode);
+        self::assertArrayNotHasKey('oji-ottawa', $byCode);
     }
 
     #[Test]
@@ -98,7 +99,7 @@ final class LanguageApiTest extends HttpKernelTestCase
     public function it_falls_back_to_the_same_dialect_grouping(): void
     {
         // "fox" exists only as serpent-river; both serpent-river and sagamok are
-        // oji-east, so a Sagamok query resolves it via the derived grouping.
+        // nishnaabemwin, so a Sagamok query resolves it via the derived grouping.
         $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'fox', 'tag' => 'oj-x-sagamok']));
 
         self::assertSame('exact', $body['match_type']);

--- a/tests/App/Unit/Entity/Language/DialectRegionTest.php
+++ b/tests/App/Unit/Entity/Language/DialectRegionTest.php
@@ -16,11 +16,11 @@ final class DialectRegionTest extends TestCase
     public function it_creates_with_code_and_name(): void
     {
         $region = new DialectRegion([
-            'code' => 'oji-east',
+            'code' => 'nishnaabemwin',
             'name' => 'Nishnaabemwin',
         ]);
 
-        $this->assertSame('oji-east', $region->id());
+        $this->assertSame('nishnaabemwin', $region->id());
         $this->assertSame('Nishnaabemwin', $region->label());
         $this->assertSame('dialect_region', $region->getEntityTypeId());
     }
@@ -29,7 +29,7 @@ final class DialectRegionTest extends TestCase
     public function it_defaults_optional_fields(): void
     {
         $region = new DialectRegion([
-            'code' => 'oji-east',
+            'code' => 'nishnaabemwin',
             'name' => 'Nishnaabemwin',
         ]);
 
@@ -46,7 +46,7 @@ final class DialectRegionTest extends TestCase
     {
         $geojson = '{"type":"Polygon","coordinates":[[[-81.0,46.0],[-80.0,46.0],[-80.0,47.0],[-81.0,47.0],[-81.0,46.0]]]}';
         $region = new DialectRegion([
-            'code' => 'oji-east',
+            'code' => 'nishnaabemwin',
             'name' => 'Nishnaabemwin',
             'display_name' => 'Eastern Ojibwe',
             'language_family' => 'algonquian',

--- a/tests/App/Unit/Language/Asr/UnavailableAsrClientTest.php
+++ b/tests/App/Unit/Language/Asr/UnavailableAsrClientTest.php
@@ -27,7 +27,7 @@ final class UnavailableAsrClientTest extends TestCase
     #[Test]
     public function transcribe_fails_closed_with_a_consent_gate_message(): void
     {
-        $result = (new UnavailableAsrClient())->transcribe('corpus:reel-1', 'oji-east');
+        $result = (new UnavailableAsrClient())->transcribe('corpus:reel-1', 'oj-x-sagamok');
 
         self::assertFalse($result->ok);
         self::assertSame('', $result->transcript);

--- a/tests/App/Unit/Language/DialectCodeProviderTest.php
+++ b/tests/App/Unit/Language/DialectCodeProviderTest.php
@@ -46,10 +46,12 @@ final class DialectCodeProviderTest extends TestCase
             $byCode[$row['code']] = $row;
         }
 
-        self::assertArrayHasKey('oji-east', $byCode);
-        self::assertSame('oj-ojg', $byCode['oji-east']['tag']);
-        self::assertSame('Eastern Ojibwe', $byCode['oji-east']['display_name']);
-        self::assertSame('ojg', $byCode['oji-east']['iso_639_3']);
+        self::assertArrayHasKey('nishnaabemwin', $byCode);
+        self::assertSame('oj-ojg', $byCode['nishnaabemwin']['tag']);
+        self::assertSame('Eastern Ojibwe', $byCode['nishnaabemwin']['display_name']);
+        self::assertSame('ojg', $byCode['nishnaabemwin']['iso_639_3']);
+        self::assertArrayNotHasKey('oji-east', $byCode, 'No oji-east grouping.');
+        self::assertArrayNotHasKey('oji-ottawa', $byCode, 'No oji-ottawa grouping.');
     }
 
     #[Test]
@@ -57,8 +59,9 @@ final class DialectCodeProviderTest extends TestCase
     {
         $p = new DialectCodeProvider();
 
-        self::assertSame('oji-east', $p->dialectCodeForTag('oj-x-sagamok'));
-        self::assertSame('oji-east', $p->dialectCodeForTag('oj-ojg'));
+        self::assertSame('nishnaabemwin', $p->dialectCodeForTag('oj-x-sagamok'));
+        self::assertSame('nishnaabemwin', $p->dialectCodeForTag('oj-ojg'));
+        self::assertSame('nishnaabemwin', $p->dialectCodeForTag('oj-otw'), 'Nishnaabemwin spans otw too.');
         self::assertNull($p->dialectCodeForTag('oj'), 'The bare language derives no grouping.');
         self::assertNull($p->dialectCodeForTag('oj-x-sagamok2'), 'An unmapped community derives no grouping.');
 

--- a/tests/App/Unit/Seed/ConfigSeederTest.php
+++ b/tests/App/Unit/Seed/ConfigSeederTest.php
@@ -89,8 +89,8 @@ final class ConfigSeederTest extends TestCase
 
         $this->assertNotEmpty($regions);
 
-        // First entry should be Eastern Ojibwe (home dialect)
-        $this->assertSame('oji-east', $regions[0]['code']);
+        // First entry should be Nishnaabemwin (the home grouping, Eastern Ojibwe)
+        $this->assertSame('nishnaabemwin', $regions[0]['code']);
         $this->assertSame('Nishnaabemwin', $regions[0]['name']);
         $this->assertSame('Eastern Ojibwe', $regions[0]['display_name']);
         $this->assertSame('algonquian', $regions[0]['language_family']);


### PR DESCRIPTION
Closes #902. Milestone #68. App-side; no deploy in this PR.

Adopts the canonical community-code registry (recorded in `Projects/Minoo/docs/.../tracker.md`, "Community code registry"): the 21 RHT nations as `oj-x-<code>`, multi-subtag where a single token would exceed BCP 47's 8-char private-use limit, every code provisional/OCAP. One registry shared by Minoo and rhtcircle.

## What changed
- **ConfigSeeder**: replaced `oji-east` + `oji-ottawa` with a single derived `nishnaabemwin` grouping (the Eastern Ojibwe / Odawa continuum, otw + ojg). `communityDialects()` maps all 21 community codes -> `nishnaabemwin`.
- **DialectCodeProvider**: derives the grouping from the community code or an otw/ojg dialect subtag (`SPANNING_SUBTAGS` so both otw and ojg derive `nishnaabemwin`); label still "Nishnaabemwin (Sagamok)". The TM already keys on the full BCP 47 tag (`language_tag`), so community granularity is retained.
- **`IngestController::createDraft`**: tags ingested corpus drafts `oj-x-sagamok` (Steven's corpus is Sagamok); grouping is derived, never stored.
- **Tracker**: mirrored the Community code registry into the code-repo doc; updated the A.3 table. No `oji-east`/`oji-ottawa` as live codes anywhere — the only remaining references are negative regression assertions confirming their removal.

## Tests and gates (green)
- Updated `DialectCodeProviderTest`, `LanguageApiTest`, `ConfigSeederTest`, `DialectRegionTest`, ASR test: `nishnaabemwin`/`oj-x-sagamok`, with assertions that `oji-east`/`oji-ottawa` are gone and that `oj-x-sagamok` and `oj-x-serpent-river` resolve to the same grouping.
- `MinooUnit` 488 (2 env skips), `MinooIntegration` 124, `composer phpstan` (level 5) clean, cs-fixer clean.

Note: the long-slug nations now have assigned multi-subtag codes (e.g. `oj-x-batche-wana`, `oj-x-missi-saugi`), resolving the deferral from the prior BCP 47 PR. Historical `docs/superpowers/*` planning snapshots (2026-03) still contain `oji-east` as archival record; left untouched.

No deploy, no public/anonymous route, fnpi/Pi untouched, no em dashes.