### PR TITLE
feat(#904): URL-based reel import in the Anokii Ingest workflow (yt-dlp)

### DIFF
--- a/src/Anokii/Ingest/FetchResult.php
+++ b/src/Anokii/Ingest/FetchResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Ingest;
+
+/**
+ * The outcome of a {@see MediaFetcher} fetch (issue #904): either the media was
+ * staged (ok) or it failed with a user-facing reason (a private/login-walled
+ * reel, an unsupported host, or yt-dlp being unavailable). A value object so the
+ * Ingest controller branches on `ok` and surfaces `error` inline, never a 500.
+ */
+final readonly class FetchResult
+{
+    private function __construct(
+        public bool $ok,
+        public string $error,
+    ) {
+    }
+
+    public static function success(): self
+    {
+        return new self(true, '');
+    }
+
+    public static function failure(string $error): self
+    {
+        return new self(false, $error);
+    }
+}

--- a/src/Anokii/Ingest/MediaFetcher.php
+++ b/src/Anokii/Ingest/MediaFetcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Ingest;
+
+/**
+ * The seam for fetching reel media from a URL into the corpus staging area
+ * (issue #904).
+ *
+ * PHP cannot extract Facebook / Instagram / YouTube media directly, so the
+ * default implementation shells out to yt-dlp as a backend process (the same
+ * worker-separation used for ASR). Kept behind this interface so the extractor is
+ * swappable by binding, and so tests can substitute a fake and never hit the
+ * network. Implementations fail closed: an unavailable extractor or an
+ * unfetchable URL returns a {@see FetchResult} failure, never an exception that
+ * would surface as a 500.
+ */
+interface MediaFetcher
+{
+    /**
+     * Whether media fetching is available on this install (the backend extractor
+     * is installed and runnable).
+     */
+    public function isAvailable(): bool;
+
+    /**
+     * Fetch the media at $url into $destPath. Returns a non-ok result rather than
+     * throwing for the expected failure cases (private reel, unsupported host,
+     * extractor missing).
+     */
+    public function fetch(string $url, string $destPath): FetchResult;
+}

--- a/src/Anokii/Ingest/YtDlpMediaFetcher.php
+++ b/src/Anokii/Ingest/YtDlpMediaFetcher.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Anokii\Ingest;
+
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+/**
+ * yt-dlp-backed {@see MediaFetcher} (issue #904).
+ *
+ * yt-dlp (open source) handles Facebook / Instagram / YouTube extraction, which
+ * PHP cannot do directly, so this shells out to it as a backend process. The
+ * binary is resolved from the `YT_DLP_BIN` env or PATH, so the extractor is
+ * swappable without code changes. Fails closed: when yt-dlp is missing or the URL
+ * cannot be fetched it returns a clear {@see FetchResult} failure, never throws.
+ *
+ * Deploy note: yt-dlp must be installed on the Pi for production import to work.
+ */
+final class YtDlpMediaFetcher implements MediaFetcher
+{
+    /** Hard ceiling on a single fetch (seconds). */
+    private const int FETCH_TIMEOUT = 180;
+
+    /** Ceiling on the availability probe (seconds). */
+    private const int PROBE_TIMEOUT = 15;
+
+    public function __construct(private readonly string $binary = '')
+    {
+    }
+
+    public function isAvailable(): bool
+    {
+        try {
+            $process = new Process([$this->bin(), '--version']);
+            $process->setTimeout(self::PROBE_TIMEOUT);
+            $process->run();
+
+            return $process->isSuccessful();
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    public function fetch(string $url, string $destPath): FetchResult
+    {
+        if (!$this->isAvailable()) {
+            return FetchResult::failure('Media import is unavailable: yt-dlp is not installed on this server. Drop the file instead.');
+        }
+
+        try {
+            $process = new Process([
+                $this->bin(),
+                '--no-playlist',
+                '--no-warnings',
+                '--quiet',
+                '-f', 'mp4/best',
+                '-o', $destPath,
+                $url,
+            ]);
+            $process->setTimeout(self::FETCH_TIMEOUT);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                return FetchResult::failure($this->explain($process->getErrorOutput() . "\n" . $process->getOutput()));
+            }
+            if (!is_file($destPath) || filesize($destPath) === 0) {
+                return FetchResult::failure('Fetched no media; the reel may be private or login-walled.');
+            }
+
+            return FetchResult::success();
+        } catch (ProcessTimedOutException) {
+            return FetchResult::failure('Import timed out fetching the media. Try a shorter clip or drop the file.');
+        } catch (\Throwable $e) {
+            return FetchResult::failure('Could not fetch the media: ' . $e->getMessage());
+        }
+    }
+
+    private function bin(): string
+    {
+        if ($this->binary !== '') {
+            return $this->binary;
+        }
+
+        return getenv('YT_DLP_BIN') ?: 'yt-dlp';
+    }
+
+    /**
+     * Turn yt-dlp stderr into a short, user-facing reason.
+     */
+    private function explain(string $stderr): string
+    {
+        $s = strtolower($stderr);
+        if (str_contains($s, 'private') || str_contains($s, 'log in') || str_contains($s, 'login') || str_contains($s, 'sign in')) {
+            return 'That reel is private or login-walled and cannot be fetched.';
+        }
+        if (str_contains($s, 'unsupported url') || str_contains($s, 'no video') || str_contains($s, 'unable to extract')) {
+            return 'Unsupported or unavailable link; no video could be extracted.';
+        }
+
+        return 'Could not fetch that reel; it may be unavailable or unsupported.';
+    }
+}

--- a/src/Http/Controller/Anokii/IngestController.php
+++ b/src/Http/Controller/Anokii/IngestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controller\Anokii;
 
+use App\Anokii\Ingest\MediaFetcher;
 use App\Anokii\Pipeline\PipelineCounts;
 use App\Anokii\Pipeline\PipelineStage;
 use App\Anokii\Pipeline\PipelineStageResolver;
@@ -56,9 +57,18 @@ final class IngestController
      */
     private const array ALLOWED_EXT = ['mp4', 'mov', 'm4v', 'webm'];
 
+    /**
+     * Hosts the URL import accepts. A reel link must be on one of these (or a
+     * subdomain); anything else is rejected before the fetcher is called.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_HOSTS = ['facebook.com', 'fb.watch', 'fb.com', 'instagram.com', 'youtube.com', 'youtu.be'];
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly Environment $twig,
+        private readonly MediaFetcher $mediaFetcher,
     ) {
     }
 
@@ -133,9 +143,11 @@ final class IngestController
     }
 
     /**
-     * Keep the Facebook-URL ingest path: register a draft row for a reel URL. The
-     * media is produced when its source video is staged and the worker (or
-     * `ingest:corpus`) runs — the same operator prerequisite as the CLI path.
+     * URL import (#904): fetch a reel from a Facebook / Instagram / YouTube link
+     * via {@see MediaFetcher} (yt-dlp) into the same staging area an upload uses,
+     * then create the same ingested draft. Fails closed with an inline message,
+     * never a 500: a bad URL, an unsupported host, an unavailable extractor, or an
+     * unfetchable (private / login-walled) reel all return a handled error.
      */
     public function url(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
@@ -144,11 +156,45 @@ final class IngestController
         if ($url === '' || !preg_match('#^https?://#i', $url)) {
             return $this->json(['ok' => false, 'error' => 'A valid http(s) URL is required.'], 422);
         }
+        if (!$this->isAllowedHost($url)) {
+            return $this->json(['ok' => false, 'error' => 'Unsupported host. Paste a Facebook, Instagram, or YouTube link.'], 422);
+        }
+        if (!$this->mediaFetcher->isAvailable()) {
+            return $this->json(['ok' => false, 'error' => 'Media import is unavailable on this server (yt-dlp not installed). Drop the file instead.'], 503);
+        }
 
-        $id = 'fb-' . bin2hex(random_bytes(4));
+        $id = 'fetch-' . bin2hex(random_bytes(5));
+        $dir = $this->corpusPath() . '/source-videos';
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            return $this->json(['ok' => false, 'error' => 'Could not prepare the staging area.'], 503);
+        }
+
+        $result = $this->mediaFetcher->fetch($url, $dir . '/' . $id . '.mp4');
+        if (!$result->ok) {
+            return $this->json(['ok' => false, 'error' => $result->error], 422);
+        }
+
         $esid = $this->createDraft($id, $url, '');
 
         return $this->json(['ok' => true, 'esid' => $esid, 'corpus_id' => $id, 'pipeline_status' => PipelineStage::INGESTED]);
+    }
+
+    /**
+     * Whether the URL's host is one of the allowed reel sources (or a subdomain).
+     */
+    private function isAllowedHost(string $url): bool
+    {
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        if ($host === '') {
+            return false;
+        }
+        foreach (self::ALLOWED_HOSTS as $allowed) {
+            if ($host === $allowed || str_ends_with($host, '.' . $allowed)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Provider/AnokiiServiceProvider.php
+++ b/src/Provider/AnokiiServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Provider;
 
 use Anokii\Config\DistributionConfig;
+use App\Anokii\Ingest\MediaFetcher;
+use App\Anokii\Ingest\YtDlpMediaFetcher;
 use Twig\Environment;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
@@ -60,6 +62,10 @@ final class AnokiiServiceProvider extends AppCoreServiceProvider
                 dirname(__DIR__, 2) . '/config/anokii.yaml',
             ),
         );
+
+        // The reel-import media fetcher (#904), resolved by the Ingest controller.
+        // yt-dlp-backed and fail-closed; swap the binding to change the extractor.
+        $this->singleton(MediaFetcher::class, static fn (): MediaFetcher => new YtDlpMediaFetcher());
     }
 
     public function boot(): void

--- a/templates/pages/anokii/ingest.html.twig
+++ b/templates/pages/anokii/ingest.html.twig
@@ -58,8 +58,8 @@
     <p id="ig-hint" class="ig-meta" style="margin-top:12px;">You can select several at once. Uploads run in parallel.</p>
 
     <form class="ig-url" id="ig-urlform" autocomplete="off">
-      <input type="url" id="ig-urlinput" placeholder="…or paste a Facebook reel URL" aria-label="Facebook reel URL">
-      <button type="submit">Add URL</button>
+      <input type="url" id="ig-urlinput" placeholder="…or paste a Facebook, Instagram, or YouTube reel URL" aria-label="Reel URL">
+      <button type="submit">Import</button>
     </form>
   </div>
 
@@ -196,13 +196,13 @@
     var url = input.value.trim();
     if (!url) return;
     var row = makeRow(url);
-    setState(row, 'Registering…');
+    setState(row, 'Importing…');
     fetch(urlUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
       body: JSON.stringify({ url: url })
     }).then(function (r) { return r.json(); }).then(function (res) {
-      if (res.ok && res.esid) { setState(row, 'Queued (stage source video, then run the worker)'); input.value = ''; }
+      if (res.ok && res.esid) { setState(row, 'Imported, awaiting transcription'); input.value = ''; }
       else { setState(row, res.error || 'Failed', 'err'); }
     }).catch(function () { setState(row, 'Failed', 'err'); });
   });

--- a/tests/App/Integration/Http/Admin/AnokiiIngestTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiIngestTest.php
@@ -57,6 +57,7 @@ final class AnokiiIngestTest extends HttpKernelTestCase
         return new IngestController(
             self::$kernel->getEntityTypeManager(),
             SsrServiceProvider::getTwigEnvironment(),
+            new \App\Tests\Support\StubMediaFetcher(),
         );
     }
 
@@ -168,7 +169,7 @@ final class AnokiiIngestTest extends HttpKernelTestCase
         $payload = json_decode((string) $this->controller()->url([], [], $this->account(), $request)->getContent(), true);
 
         self::assertTrue($payload['ok']);
-        self::assertStringStartsWith('fb-', $payload['corpus_id']);
+        self::assertStringStartsWith('fetch-', $payload['corpus_id']);
         self::assertSame(PipelineStage::INGESTED, $payload['pipeline_status']);
     }
 

--- a/tests/App/Integration/Http/Admin/AnokiiUrlImportTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiUrlImportTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Admin;
+
+use App\Anokii\Ingest\FetchResult;
+use App\Http\Controller\Anokii\IngestController;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use App\Tests\Support\StubMediaFetcher;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\SSR\SsrServiceProvider;
+
+/**
+ * URL reel import in the Anokii Ingest workflow (#904). The MediaFetcher is
+ * stubbed, so CI never touches Facebook. A successful fetch creates the same
+ * ingested, Sagamok-tagged draft an upload would; every failure mode is a handled
+ * response, never a 500.
+ */
+#[CoversNothing]
+final class AnokiiUrlImportTest extends HttpKernelTestCase
+{
+    private static string $corpus;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$corpus = sys_get_temp_dir() . '/minoo-urlimport-' . bin2hex(random_bytes(4));
+        putenv('MINOO_CORPUS_PATH=' . self::$corpus);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('MINOO_CORPUS_PATH');
+        parent::tearDownAfterClass();
+    }
+
+    #[Test]
+    public function a_successful_fetch_creates_a_sagamok_tagged_awaiting_transcription_draft(): void
+    {
+        $response = $this->import('https://www.facebook.com/reel/123', new StubMediaFetcher());
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $body = $this->decode($response);
+        self::assertTrue($body['ok']);
+        self::assertSame('ingested', $body['pipeline_status']);
+
+        $row = self::$kernel->getEntityTypeManager()->getStorage('example_sentence')->load((int) $body['esid']);
+        self::assertNotNull($row);
+        self::assertSame('oj-x-sagamok', (string) $row->get('language_tag'), 'Tagged at Sagamok community granularity.');
+        self::assertSame('https://www.facebook.com/reel/123', (string) $row->get('source_url'), 'Source URL recorded for provenance.');
+        self::assertSame('ingested', (string) $row->get('pipeline_status'));
+        self::assertSame(0, (int) $row->get('status'), 'Awaiting transcription, not published.');
+
+        // Staged exactly where uploads land.
+        self::assertFileExists(self::$corpus . '/source-videos/' . $body['corpus_id'] . '.mp4');
+    }
+
+    #[Test]
+    public function an_unsupported_host_is_a_handled_422(): void
+    {
+        $response = $this->import('https://evil.example.com/reel/9', new StubMediaFetcher());
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('Unsupported host', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function a_non_http_url_is_a_handled_422(): void
+    {
+        self::assertSame(422, $this->import('not-a-url', new StubMediaFetcher())->getStatusCode());
+    }
+
+    #[Test]
+    public function an_unavailable_fetcher_is_handled_not_a_500(): void
+    {
+        $response = $this->import('https://youtu.be/abc123', new StubMediaFetcher(available: false));
+
+        self::assertSame(503, $response->getStatusCode());
+        self::assertStringContainsString('unavailable', (string) $response->getContent());
+    }
+
+    #[Test]
+    public function a_failed_fetch_surfaces_the_reason_not_a_500(): void
+    {
+        $response = $this->import(
+            'https://www.instagram.com/reel/xyz',
+            new StubMediaFetcher(result: FetchResult::failure('That reel is private or login-walled and cannot be fetched.')),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('private or login-walled', (string) $response->getContent());
+    }
+
+    private function import(string $url, StubMediaFetcher $fetcher): Response
+    {
+        $controller = new IngestController(
+            self::$kernel->getEntityTypeManager(),
+            SsrServiceProvider::getTwigEnvironment(),
+            $fetcher,
+        );
+
+        $request = new HttpRequest();
+        $request->initialize([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode(['url' => $url]));
+        $account = $this->createMock(AccountInterface::class);
+
+        return $controller->url([], [], $account, $request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        $decoded = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/tests/App/Support/StubMediaFetcher.php
+++ b/tests/App/Support/StubMediaFetcher.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support;
+
+use App\Anokii\Ingest\FetchResult;
+use App\Anokii\Ingest\MediaFetcher;
+
+/**
+ * A configurable {@see MediaFetcher} for tests: never touches the network. By
+ * default it is available and succeeds, writing a small placeholder file at the
+ * destination so the staged-file expectation holds. Pass an unavailable flag or a
+ * failure result to exercise the fail-closed paths.
+ */
+final class StubMediaFetcher implements MediaFetcher
+{
+    public function __construct(
+        private readonly bool $available = true,
+        private readonly ?FetchResult $result = null,
+        private readonly bool $createFile = true,
+    ) {
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->available;
+    }
+
+    public function fetch(string $url, string $destPath): FetchResult
+    {
+        $result = $this->result ?? FetchResult::success();
+        if ($result->ok && $this->createFile) {
+            @mkdir(dirname($destPath), 0o777, true);
+            @file_put_contents($destPath, 'stub-media');
+        }
+
+        return $result;
+    }
+}

--- a/tests/App/Unit/Anokii/Ingest/YtDlpMediaFetcherTest.php
+++ b/tests/App/Unit/Anokii/Ingest/YtDlpMediaFetcherTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Anokii\Ingest;
+
+use App\Anokii\Ingest\FetchResult;
+use App\Anokii\Ingest\YtDlpMediaFetcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(YtDlpMediaFetcher::class)]
+#[CoversClass(FetchResult::class)]
+final class YtDlpMediaFetcherTest extends TestCase
+{
+    #[Test]
+    public function it_is_unavailable_when_the_binary_does_not_resolve(): void
+    {
+        $fetcher = new YtDlpMediaFetcher(self::missingBinary());
+
+        self::assertFalse($fetcher->isAvailable());
+    }
+
+    #[Test]
+    public function fetch_fails_closed_when_the_extractor_is_missing(): void
+    {
+        $dest = sys_get_temp_dir() . '/minoo-ytdlp-test-' . bin2hex(random_bytes(4)) . '.mp4';
+        $result = (new YtDlpMediaFetcher(self::missingBinary()))->fetch('https://www.facebook.com/reel/123', $dest);
+
+        self::assertFalse($result->ok);
+        self::assertStringContainsString('yt-dlp is not installed', $result->error);
+        self::assertFileDoesNotExist($dest, 'A failed fetch stages nothing.');
+    }
+
+    #[Test]
+    public function the_result_value_object_distinguishes_success_from_failure(): void
+    {
+        self::assertTrue(FetchResult::success()->ok);
+        $failure = FetchResult::failure('nope');
+        self::assertFalse($failure->ok);
+        self::assertSame('nope', $failure->error);
+    }
+
+    /**
+     * A binary path guaranteed not to resolve, so the test never invokes a real
+     * extractor or the network.
+     */
+    private static function missingBinary(): string
+    {
+        return sys_get_temp_dir() . '/no-such-yt-dlp-' . bin2hex(random_bytes(6));
+    }
+}


### PR DESCRIPTION
Closes #904. Milestone #68. App-side; no deploy in this PR.

Makes the Ingest tab's URL field actually fetch media (it previously only registered a draft), so a staff member can paste a Facebook/Instagram/YouTube reel URL and Import instead of dropping a file.

## Design (pluggable, sovereign, fail-closed)
- **`App\Anokii\Ingest\MediaFetcher`** interface + **`FetchResult`** value object: the fetch seam.
- **`YtDlpMediaFetcher`**: shells out to yt-dlp (the worker-separation pattern, like the ASR stub), resolving the binary from `YT_DLP_BIN` or PATH so the extractor is swappable by binding. Returns a clear `FetchResult` failure (never throws) when yt-dlp is missing or a reel is private / login-walled / unsupported.

## Build
- **`IngestController::url()`**: validates the URL + a host allowlist (facebook, instagram, youtube), fetches into the same `MINOO_CORPUS_PATH/source-videos/<id>.mp4` staging area uploads use, then creates the same ingested draft, **tagged `oj-x-sagamok`** with the **source URL recorded** for provenance. Every failure (bad URL, unsupported host, unavailable extractor, unfetchable reel) is a handled **422/503, never a 500**.
- **`AnokiiServiceProvider`** binds `MediaFetcher -> YtDlpMediaFetcher`.
- **Ingest UI**: "Import" button + broadened placeholder; errors surface inline (existing JS).

## Consent guardrail
Ingest is staff-gated and internal; publishes nothing; no public/anonymous route added.

## Tests and gates (green)
- `YtDlpMediaFetcherTest` (unavailable + fail-closed, `FetchResult`); shared `StubMediaFetcher` (never hits the network).
- `AnokiiUrlImportTest`: a mocked success creates a Sagamok-tagged awaiting-transcription draft staged where uploads go; unsupported host, non-http URL, unavailable extractor, and a failed fetch are all handled, not 500s.
- `MinooUnit` 491 (2 env skips), `MinooIntegration` 129, `composer phpstan` (level 5) clean, cs-fixer clean.

## Deploy note (not executed here)
**yt-dlp must be installed on the Pi** for production import to work — please install it in the next deploy. Until then, `url()` fails closed with a clear "unavailable" message and uploads still work.

No public route, fnpi/Pi untouched, no em dashes.