### PR TITLE
feat(#906): demand-ranked English translation backlog (tm_backlog)

### DIFF
--- a/config/translation_backlog_seed.json
+++ b/config/translation_backlog_seed.json
@@ -1,0 +1,1993 @@
+{
+    "provenance": "seed-crawl-2026-06-25",
+    "generated_from": "recon out.json (4796 distinct, >= 2 sites)",
+    "recon_report": "Projects/Minoo/docs/translation-seed-crawler-recon-2026-06-25.md",
+    "stats": {
+        "considered": 4796,
+        "below_floor": 4474,
+        "dropped_noise": 37,
+        "excluded_ojibwe": 3,
+        "kept": 282
+    },
+    "excluded_anishinaabemowin": [
+        "Niigaaniin",
+        "Anishinaabemowin",
+        "Aanii"
+    ],
+    "rows": [
+        {
+            "english_text": "Contact",
+            "concept_key": "contact",
+            "demand_sites": 16,
+            "demand_total": 494,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Education",
+            "concept_key": "education",
+            "demand_sites": 16,
+            "demand_total": 431,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Contact Us",
+            "concept_key": "contact",
+            "demand_sites": 15,
+            "demand_total": 298,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Governance",
+            "concept_key": "governance",
+            "demand_sites": 13,
+            "demand_total": 451,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Home",
+            "concept_key": "home",
+            "demand_sites": 13,
+            "demand_total": 426,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Administration",
+            "concept_key": "administration",
+            "demand_sites": 13,
+            "demand_total": 382,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Public Works",
+            "concept_key": "public works",
+            "demand_sites": 12,
+            "demand_total": 299,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Finance",
+            "concept_key": "finance",
+            "demand_sites": 11,
+            "demand_total": 207,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Password",
+            "concept_key": "password",
+            "demand_sites": 11,
+            "demand_total": 90,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "About",
+            "concept_key": "about",
+            "demand_sites": 10,
+            "demand_total": 292,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Economic Development",
+            "concept_key": "economic development",
+            "demand_sites": 10,
+            "demand_total": 225,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Housing",
+            "concept_key": "housing",
+            "demand_sites": 10,
+            "demand_total": 209,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Login",
+            "concept_key": "login",
+            "demand_sites": 10,
+            "demand_total": 112,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "News",
+            "concept_key": "news",
+            "demand_sites": 9,
+            "demand_total": 274,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Membership",
+            "concept_key": "membership",
+            "demand_sites": 9,
+            "demand_total": 177,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Search",
+            "concept_key": "search",
+            "demand_sites": 9,
+            "demand_total": 170,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Log in",
+            "concept_key": "log in",
+            "demand_sites": 9,
+            "demand_total": 139,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Departments",
+            "concept_key": "departments",
+            "demand_sites": 8,
+            "demand_total": 246,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Employment",
+            "concept_key": "employment",
+            "demand_sites": 8,
+            "demand_total": 246,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Events",
+            "concept_key": "events",
+            "demand_sites": 8,
+            "demand_total": 238,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Staff Directory",
+            "concept_key": "staff directory",
+            "demand_sites": 8,
+            "demand_total": 127,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community",
+            "concept_key": "community",
+            "demand_sites": 7,
+            "demand_total": 213,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Communications",
+            "concept_key": "communications",
+            "demand_sites": 7,
+            "demand_total": 210,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Ontario Works",
+            "concept_key": "ontario works",
+            "demand_sites": 7,
+            "demand_total": 185,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Health",
+            "concept_key": "health",
+            "demand_sites": 7,
+            "demand_total": 168,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Lands & Resources",
+            "concept_key": "lands and resources",
+            "demand_sites": 7,
+            "demand_total": 162,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Social Services",
+            "concept_key": "social services",
+            "demand_sites": 7,
+            "demand_total": 143,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Employment Opportunities",
+            "concept_key": "employment opportunities",
+            "demand_sites": 7,
+            "demand_total": 130,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Chief and Council",
+            "concept_key": "chief and council",
+            "demand_sites": 7,
+            "demand_total": 103,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "About Us",
+            "concept_key": "about",
+            "demand_sites": 7,
+            "demand_total": 96,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Chief & Council",
+            "concept_key": "chief and council",
+            "demand_sites": 7,
+            "demand_total": 86,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Email",
+            "concept_key": "email",
+            "demand_sites": 7,
+            "demand_total": 72,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Submit",
+            "concept_key": "submit",
+            "demand_sites": 7,
+            "demand_total": 31,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Local Businesses",
+            "concept_key": "local businesses",
+            "demand_sites": 6,
+            "demand_total": 148,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Lands",
+            "concept_key": "lands",
+            "demand_sites": 6,
+            "demand_total": 133,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Infrastructure",
+            "concept_key": "infrastructure",
+            "demand_sites": 6,
+            "demand_total": 125,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Facebook",
+            "concept_key": "facebook",
+            "demand_sites": 6,
+            "demand_total": 122,
+            "category": "other"
+        },
+        {
+            "english_text": "Fire Department",
+            "concept_key": "fire department",
+            "demand_sites": 6,
+            "demand_total": 106,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Username",
+            "concept_key": "username",
+            "demand_sites": 6,
+            "demand_total": 64,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Remember Me",
+            "concept_key": "remember me",
+            "demand_sites": 6,
+            "demand_total": 61,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Health Services",
+            "concept_key": "health services",
+            "demand_sites": 6,
+            "demand_total": 48,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Download",
+            "concept_key": "download",
+            "demand_sites": 6,
+            "demand_total": 35,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "History",
+            "concept_key": "history",
+            "demand_sites": 5,
+            "demand_total": 153,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Business Directory",
+            "concept_key": "business directory",
+            "demand_sites": 5,
+            "demand_total": 140,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Privacy Policy",
+            "concept_key": "privacy policy",
+            "demand_sites": 5,
+            "demand_total": 100,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Robinson Huron Treaty",
+            "concept_key": "robinson huron treaty",
+            "demand_sites": 5,
+            "demand_total": 85,
+            "category": "other"
+        },
+        {
+            "english_text": "Our History",
+            "concept_key": "history",
+            "demand_sites": 5,
+            "demand_total": 67,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Leadership",
+            "concept_key": "leadership",
+            "demand_sites": 5,
+            "demand_total": 66,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Programs & Services",
+            "concept_key": "programs and services",
+            "demand_sites": 5,
+            "demand_total": 65,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Phone",
+            "concept_key": "phone",
+            "demand_sites": 5,
+            "demand_total": 46,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Upcoming Events",
+            "concept_key": "upcoming events",
+            "demand_sites": 5,
+            "demand_total": 9,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Vision",
+            "concept_key": "vision",
+            "demand_sites": 5,
+            "demand_total": 7,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Services",
+            "concept_key": "services",
+            "demand_sites": 4,
+            "demand_total": 129,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Post-Secondary",
+            "concept_key": "post-secondary",
+            "demand_sites": 4,
+            "demand_total": 123,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Job Postings",
+            "concept_key": "job postings",
+            "demand_sites": 4,
+            "demand_total": 121,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Organizational Chart",
+            "concept_key": "organizational chart",
+            "demand_sites": 4,
+            "demand_total": 110,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Send",
+            "concept_key": "send",
+            "demand_sites": 4,
+            "demand_total": 109,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Human Resources",
+            "concept_key": "human resources",
+            "demand_sites": 4,
+            "demand_total": 105,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Business",
+            "concept_key": "business",
+            "demand_sites": 4,
+            "demand_total": 102,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Members Portal",
+            "concept_key": "members portal",
+            "demand_sites": 4,
+            "demand_total": 102,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Newsletters",
+            "concept_key": "newsletters",
+            "demand_sites": 4,
+            "demand_total": 101,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Finance and Administration",
+            "concept_key": "finance and administration",
+            "demand_sites": 4,
+            "demand_total": 89,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Committees",
+            "concept_key": "committees",
+            "demand_sites": 4,
+            "demand_total": 85,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Library",
+            "concept_key": "library",
+            "demand_sites": 4,
+            "demand_total": 85,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Members Only",
+            "concept_key": "members only",
+            "demand_sites": 4,
+            "demand_total": 83,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Citizenship",
+            "concept_key": "citizenship",
+            "demand_sites": 4,
+            "demand_total": 64,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Programs",
+            "concept_key": "programs",
+            "demand_sites": 4,
+            "demand_total": 46,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Forgot your password",
+            "concept_key": "forgot your password",
+            "demand_sites": 4,
+            "demand_total": 44,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "First Name",
+            "concept_key": "first name",
+            "demand_sites": 4,
+            "demand_total": 24,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Last Name",
+            "concept_key": "last name",
+            "demand_sites": 4,
+            "demand_total": 24,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Subscribe",
+            "concept_key": "subscribe",
+            "demand_sites": 4,
+            "demand_total": 24,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "USERNAME OR EMAIL",
+            "concept_key": "username or email",
+            "demand_sites": 4,
+            "demand_total": 24,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Mission",
+            "concept_key": "mission",
+            "demand_sites": 4,
+            "demand_total": 23,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Latest News",
+            "concept_key": "latest news",
+            "demand_sites": 4,
+            "demand_total": 5,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Careers",
+            "concept_key": "careers",
+            "demand_sites": 3,
+            "demand_total": 104,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Recreation",
+            "concept_key": "recreation",
+            "demand_sites": 3,
+            "demand_total": 102,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Information",
+            "concept_key": "community information",
+            "demand_sites": 3,
+            "demand_total": 82,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Laws & Policies",
+            "concept_key": "laws and policies",
+            "demand_sites": 3,
+            "demand_total": 82,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Government",
+            "concept_key": "government",
+            "demand_sites": 3,
+            "demand_total": 81,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Land Code",
+            "concept_key": "land code",
+            "demand_sites": 3,
+            "demand_total": 81,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Newsletter",
+            "concept_key": "newsletter",
+            "demand_sites": 3,
+            "demand_total": 67,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Employment & Training",
+            "concept_key": "employment and training",
+            "demand_sites": 3,
+            "demand_total": 62,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Resources",
+            "concept_key": "resources",
+            "demand_sites": 3,
+            "demand_total": 62,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Water Treatment Plant",
+            "concept_key": "water treatment plant",
+            "demand_sites": 3,
+            "demand_total": 62,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Cannabis",
+            "concept_key": "cannabis",
+            "demand_sites": 3,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Members",
+            "concept_key": "members",
+            "demand_sites": 3,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "News & Events",
+            "concept_key": "news and events",
+            "demand_sites": 3,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Tourism",
+            "concept_key": "tourism",
+            "demand_sites": 3,
+            "demand_total": 60,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Housing Department",
+            "concept_key": "housing department",
+            "demand_sites": 3,
+            "demand_total": 46,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Language",
+            "concept_key": "language",
+            "demand_sites": 3,
+            "demand_total": 44,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Services",
+            "concept_key": "community services",
+            "demand_sites": 3,
+            "demand_total": 43,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Development",
+            "concept_key": "community development",
+            "demand_sites": 3,
+            "demand_total": 42,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Email Address *",
+            "concept_key": "email address",
+            "demand_sites": 3,
+            "demand_total": 42,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Map",
+            "concept_key": "map",
+            "demand_sites": 3,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Updates",
+            "concept_key": "updates",
+            "demand_sites": 3,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Anishinabek Nation Governance Agreement",
+            "concept_key": "anishinabek nation governance agreement",
+            "demand_sites": 3,
+            "demand_total": 40,
+            "category": "other"
+        },
+        {
+            "english_text": "Member Login",
+            "concept_key": "member login",
+            "demand_sites": 3,
+            "demand_total": 38,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Health & Social Services",
+            "concept_key": "health and social services",
+            "demand_sites": 3,
+            "demand_total": 25,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Captcha",
+            "concept_key": "captcha",
+            "demand_sites": 3,
+            "demand_total": 24,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Election Code",
+            "concept_key": "election code",
+            "demand_sites": 3,
+            "demand_total": 23,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Anishinabek Police Service",
+            "concept_key": "anishinabek police service",
+            "demand_sites": 3,
+            "demand_total": 22,
+            "category": "other"
+        },
+        {
+            "english_text": "Medical Transportation",
+            "concept_key": "medical transportation",
+            "demand_sites": 3,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Mississauga First Nation",
+            "concept_key": "mississauga first nation",
+            "demand_sites": 3,
+            "demand_total": 22,
+            "category": "other"
+        },
+        {
+            "english_text": "Serpent River First Nation",
+            "concept_key": "serpent river first nation",
+            "demand_sites": 3,
+            "demand_total": 22,
+            "category": "other"
+        },
+        {
+            "english_text": "THESSALON FIRST NATION",
+            "concept_key": "thessalon first nation",
+            "demand_sites": 3,
+            "demand_total": 22,
+            "category": "other"
+        },
+        {
+            "english_text": "Register",
+            "concept_key": "register",
+            "demand_sites": 3,
+            "demand_total": 7,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Name",
+            "concept_key": "name",
+            "demand_sites": 3,
+            "demand_total": 5,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Anishinabek Educational Institute",
+            "concept_key": "anishinabek educational institute",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "other"
+        },
+        {
+            "english_text": "Forgot Password",
+            "concept_key": "forgot password",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Indigenous Bursaries Search Tool",
+            "concept_key": "indigenous bursaries search tool",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Indigenous Student Bursary",
+            "concept_key": "indigenous student bursary",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Message",
+            "concept_key": "message",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Ontario Student Assistance Program (OSAP",
+            "concept_key": "ontario student assistance program (osap",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Our Mission",
+            "concept_key": "mission",
+            "demand_sites": 3,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Cannabis Law",
+            "concept_key": "cannabis law",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Chiefs of Ontario",
+            "concept_key": "chiefs of ontario",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Day",
+            "concept_key": "day",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Event Views Navigation",
+            "concept_key": "event views navigation",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Indigenous Services Canada",
+            "concept_key": "indigenous services canada",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "other"
+        },
+        {
+            "english_text": "Location",
+            "concept_key": "location",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Post Secondary Policy",
+            "concept_key": "post secondary policy",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Select date",
+            "concept_key": "select date",
+            "demand_sites": 3,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Subject",
+            "concept_key": "subject",
+            "demand_sites": 2,
+            "demand_total": 108,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Follow",
+            "concept_key": "follow",
+            "demand_sites": 2,
+            "demand_total": 88,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Band Representative",
+            "concept_key": "band representative",
+            "demand_sites": 2,
+            "demand_total": 84,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Adult Education",
+            "concept_key": "adult education",
+            "demand_sites": 2,
+            "demand_total": 81,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "COVID-19",
+            "concept_key": "covid-19",
+            "demand_sites": 2,
+            "demand_total": 80,
+            "category": "other"
+        },
+        {
+            "english_text": "Land Laws",
+            "concept_key": "land laws",
+            "demand_sites": 2,
+            "demand_total": 80,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Our Story",
+            "concept_key": "story",
+            "demand_sites": 2,
+            "demand_total": 74,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Land",
+            "concept_key": "land",
+            "demand_sites": 2,
+            "demand_total": 69,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Treaties",
+            "concept_key": "treaties",
+            "demand_sites": 2,
+            "demand_total": 69,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Elders Program",
+            "concept_key": "elders program",
+            "demand_sites": 2,
+            "demand_total": 64,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Profile",
+            "concept_key": "community profile",
+            "demand_sites": 2,
+            "demand_total": 63,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Jordan’s Principle",
+            "concept_key": "jordan’s principle",
+            "demand_sites": 2,
+            "demand_total": 63,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Renewable Energy",
+            "concept_key": "renewable energy",
+            "demand_sites": 2,
+            "demand_total": 63,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Emergency Services",
+            "concept_key": "emergency services",
+            "demand_sites": 2,
+            "demand_total": 62,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Address Update",
+            "concept_key": "address update",
+            "demand_sites": 2,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Culture & Heritage",
+            "concept_key": "culture and heritage",
+            "demand_sites": 2,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Estates",
+            "concept_key": "estates",
+            "demand_sites": 2,
+            "demand_total": 61,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Health",
+            "concept_key": "community health",
+            "demand_sites": 2,
+            "demand_total": 60,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Communities",
+            "concept_key": "communities",
+            "demand_sites": 2,
+            "demand_total": 59,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Members Area",
+            "concept_key": "members area",
+            "demand_sites": 2,
+            "demand_total": 57,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Gallery",
+            "concept_key": "gallery",
+            "demand_sites": 2,
+            "demand_total": 52,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Health Centre",
+            "concept_key": "health centre",
+            "demand_sites": 2,
+            "demand_total": 45,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Ontario Works Program",
+            "concept_key": "ontario works program",
+            "demand_sites": 2,
+            "demand_total": 45,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Our Community",
+            "concept_key": "community",
+            "demand_sites": 2,
+            "demand_total": 45,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Centre",
+            "concept_key": "community centre",
+            "demand_sites": 2,
+            "demand_total": 43,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Newsletter",
+            "concept_key": "community newsletter",
+            "demand_sites": 2,
+            "demand_total": 43,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Administration & Finance",
+            "concept_key": "administration and finance",
+            "demand_sites": 2,
+            "demand_total": 42,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Safety",
+            "concept_key": "community safety",
+            "demand_sites": 2,
+            "demand_total": 42,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Strategic Plan",
+            "concept_key": "strategic plan",
+            "demand_sites": 2,
+            "demand_total": 42,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Infrastructure",
+            "concept_key": "community infrastructure",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Employment Assistance",
+            "concept_key": "employment assistance",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Environment",
+            "concept_key": "environment",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Historical Documents",
+            "concept_key": "historical documents",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Land Management",
+            "concept_key": "land management",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Links & Resources",
+            "concept_key": "links and resources",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Operations",
+            "concept_key": "operations",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Post-Secondary Education Assistance Policy",
+            "concept_key": "post-secondary education assistance policy",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "The Land",
+            "concept_key": "the land",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Youth",
+            "concept_key": "youth",
+            "demand_sites": 2,
+            "demand_total": 41,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Archives",
+            "concept_key": "archives",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Economic & Business Development",
+            "concept_key": "economic and business development",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Instagram",
+            "concept_key": "instagram",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "other"
+        },
+        {
+            "english_text": "LinkedIn",
+            "concept_key": "linkedin",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "ORP.ca",
+            "concept_key": "orp.ca",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Youtube",
+            "concept_key": "youtube",
+            "demand_sites": 2,
+            "demand_total": 40,
+            "category": "other"
+        },
+        {
+            "english_text": "Waaseyaa",
+            "concept_key": "waaseyaa",
+            "demand_sites": 2,
+            "demand_total": 39,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Design de Plume",
+            "concept_key": "design de plume",
+            "demand_sites": 2,
+            "demand_total": 38,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Elections",
+            "concept_key": "elections",
+            "demand_sites": 2,
+            "demand_total": 38,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Terms of Use",
+            "concept_key": "terms of use",
+            "demand_sites": 2,
+            "demand_total": 37,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Our Team",
+            "concept_key": "team",
+            "demand_sites": 2,
+            "demand_total": 36,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Education Department",
+            "concept_key": "education department",
+            "demand_sites": 2,
+            "demand_total": 33,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Visit website",
+            "concept_key": "visit website",
+            "demand_sites": 2,
+            "demand_total": 26,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Create an account",
+            "concept_key": "create an account",
+            "demand_sites": 2,
+            "demand_total": 25,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Health Nurse",
+            "concept_key": "community health nurse",
+            "demand_sites": 2,
+            "demand_total": 24,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Healthy Babies, Healthy Children",
+            "concept_key": "healthy babies, healthy children",
+            "demand_sites": 2,
+            "demand_total": 24,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Wellness Centre",
+            "concept_key": "wellness centre",
+            "demand_sites": 2,
+            "demand_total": 24,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Energy",
+            "concept_key": "energy",
+            "demand_sites": 2,
+            "demand_total": 23,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Members Portal Login",
+            "concept_key": "members portal login",
+            "demand_sites": 2,
+            "demand_total": 23,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Name *",
+            "concept_key": "name",
+            "demand_sites": 2,
+            "demand_total": 23,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Agim",
+            "concept_key": "agim",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "BATCHEWANA FIRST NATION",
+            "concept_key": "batchewana first nation",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "other"
+        },
+        {
+            "english_text": "Crossword",
+            "concept_key": "crossword",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Housing Policy",
+            "concept_key": "housing policy",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Matcher",
+            "concept_key": "matcher",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "News and Events",
+            "concept_key": "news and events",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Photo Gallery",
+            "concept_key": "photo gallery",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Shkoda",
+            "concept_key": "shkoda",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Site map",
+            "concept_key": "site map",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Waste Transfer Station",
+            "concept_key": "waste transfer station",
+            "demand_sites": 2,
+            "demand_total": 22,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "ANGA",
+            "concept_key": "anga",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Address",
+            "concept_key": "address",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Child & Family Services",
+            "concept_key": "child and family services",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Child and Family Services",
+            "concept_key": "child and family services",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Email Address",
+            "concept_key": "email address",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Emergency preparedness",
+            "concept_key": "emergency preparedness",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "First Name*",
+            "concept_key": "first name",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Home & Community Care",
+            "concept_key": "home and community care",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Information",
+            "concept_key": "information",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Journey",
+            "concept_key": "journey",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Last Name*",
+            "concept_key": "last name",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Mental Health & Addictions",
+            "concept_key": "mental health and addictions",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Portal Login",
+            "concept_key": "portal login",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Quick Links",
+            "concept_key": "quick links",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Tenders",
+            "concept_key": "tenders",
+            "demand_sites": 2,
+            "demand_total": 21,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Dictionary",
+            "concept_key": "dictionary",
+            "demand_sites": 2,
+            "demand_total": 18,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Purpose",
+            "concept_key": "purpose",
+            "demand_sites": 2,
+            "demand_total": 8,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Steven Bennett",
+            "concept_key": "steven bennett",
+            "demand_sites": 2,
+            "demand_total": 8,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Games",
+            "concept_key": "games",
+            "demand_sites": 2,
+            "demand_total": 7,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Contact Information",
+            "concept_key": "contact information",
+            "demand_sites": 2,
+            "demand_total": 5,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Email *",
+            "concept_key": "email",
+            "demand_sites": 2,
+            "demand_total": 5,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "View Calendar",
+            "concept_key": "view calendar",
+            "demand_sites": 2,
+            "demand_total": 5,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Anishinabek Education System",
+            "concept_key": "anishinabek education system",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "other"
+        },
+        {
+            "english_text": "Google Calendar",
+            "concept_key": "google calendar",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Lands & Membership",
+            "concept_key": "lands and membership",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Mission Statement",
+            "concept_key": "mission statement",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Outlook 365",
+            "concept_key": "outlook 365",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Outlook Live",
+            "concept_key": "outlook live",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Start learning",
+            "concept_key": "start learning",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "iCalendar",
+            "concept_key": "icalendar",
+            "demand_sites": 2,
+            "demand_total": 4,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Activities",
+            "concept_key": "activities",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Council",
+            "concept_key": "council",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Financial Administration Law",
+            "concept_key": "financial administration law",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Month",
+            "concept_key": "month",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Outcomes Student Portal",
+            "concept_key": "outcomes student portal",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Tim Hortons",
+            "concept_key": "tim hortons",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Today",
+            "concept_key": "today",
+            "demand_sites": 2,
+            "demand_total": 3,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "2026 Election",
+            "concept_key": "2026 election",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Additional assistance for students",
+            "concept_key": "additional assistance for students",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Anishinabek Nation",
+            "concept_key": "anishinabek nation",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "other"
+        },
+        {
+            "english_text": "Anishinabek News Job Board",
+            "concept_key": "anishinabek news job board",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "other"
+        },
+        {
+            "english_text": "April 2, 2026",
+            "concept_key": "april 2, 2026",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Assembly of First Nations",
+            "concept_key": "assembly of first nations",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "other"
+        },
+        {
+            "english_text": "Atikameksheng Anishnawbek",
+            "concept_key": "atikameksheng anishnawbek",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Background",
+            "concept_key": "background",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "CHIEF",
+            "concept_key": "chief",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "CULTURE & LANGUAGE",
+            "concept_key": "culture and language",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Calendar of Events",
+            "concept_key": "calendar of events",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Category",
+            "concept_key": "category",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Coming Soon",
+            "concept_key": "coming soon",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Committee Policy",
+            "concept_key": "committee policy",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Community Calendar",
+            "concept_key": "community calendar",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Conflict of Interest Policy",
+            "concept_key": "conflict of interest policy",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Consent",
+            "concept_key": "consent",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Current Opportunities",
+            "concept_key": "current opportunities",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Email*",
+            "concept_key": "email",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "global-ui"
+        },
+        {
+            "english_text": "Enter Keyword. Search for Events by Keyword",
+            "concept_key": "enter keyword. search for events by keyword",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Events Search and Views Navigation",
+            "concept_key": "events search and views navigation",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Export .ics file",
+            "concept_key": "export .ics file",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Export Outlook .ics file",
+            "concept_key": "export outlook .ics file",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "External Job Opportunities",
+            "concept_key": "external job opportunities",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Family Well-Being",
+            "concept_key": "family well-being",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Finance Department",
+            "concept_key": "finance department",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Find Events",
+            "concept_key": "find events",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Forms",
+            "concept_key": "forms",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Garden River First Nation",
+            "concept_key": "garden river first nation",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "other"
+        },
+        {
+            "english_text": "Housing Application",
+            "concept_key": "housing application",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Income support",
+            "concept_key": "income support",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Kina Gbezhgomi Child and Family Services",
+            "concept_key": "kina gbezhgomi child and family services",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "MONTHLY NEWSLETTER",
+            "concept_key": "monthly newsletter",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Matrimonial Real Property Law",
+            "concept_key": "matrimonial real property law",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Member Portal",
+            "concept_key": "member portal",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Membership Application",
+            "concept_key": "membership application",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Mental Health and Addictions",
+            "concept_key": "mental health and addictions",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Nogdawindamin Family and Community Services",
+            "concept_key": "nogdawindamin family and community services",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "OUR VISION",
+            "concept_key": "vision",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Ontario Indigenous Travel Grant",
+            "concept_key": "ontario indigenous travel grant",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Other information",
+            "concept_key": "other information",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Our Values",
+            "concept_key": "values",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Password Reset",
+            "concept_key": "password reset",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Political Office",
+            "concept_key": "political office",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Public Works Department",
+            "concept_key": "public works department",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Registration",
+            "concept_key": "registration",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Reset password",
+            "concept_key": "reset password",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Resource Guide for Students with Disabilities",
+            "concept_key": "resource guide for students with disabilities",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Risk Management Policy",
+            "concept_key": "risk management policy",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Subscribe to calendar",
+            "concept_key": "subscribe to calendar",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Summary",
+            "concept_key": "summary",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Tangible Capital Assets Policy",
+            "concept_key": "tangible capital assets policy",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "The Name",
+            "concept_key": "the name",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        },
+        {
+            "english_text": "Tips for Funding Post-Secondary Education",
+            "concept_key": "tips for funding post-secondary education",
+            "demand_sites": 2,
+            "demand_total": 2,
+            "category": "governance-nav"
+        }
+    ]
+}

--- a/docs/security/sql-entity-query-access-check-bypass-audit.md
+++ b/docs/security/sql-entity-query-access-check-bypass-audit.md
@@ -94,6 +94,8 @@ These sites never have an end-user `AccountInterface` available, or run after th
 | `src/Http/Controller/Auth/AuthController.php` | 84 | `submitLogin` user lookup by mail (issue #900). Pre-session authentication: the visitor is anonymous and lacks `access user profiles`, so an access-checked query returns no user (framework `UserAccessPolicy` denies anonymous view since alpha.249). The credential check immediately below is the real gate. Matches `bin/seed-test-user`. | 2026-06-25 |
 | `src/Http/Controller/Auth/AuthController.php` | 169 | `submitRegister` duplicate-email check. Same pre-session anonymous context; must detect an existing account regardless of the anonymous viewer to avoid creating a duplicate and to drive the no-enumeration check-email flow. | 2026-06-25 |
 | `src/Http/Controller/Auth/AuthController.php` | 249 | `submitForgotPassword` user lookup. Same pre-session anonymous context; the reset path must find the account to mail a token, and never reveals existence to the caller. | 2026-06-25 |
+| `src/Seed/TranslationBacklogSeeder.php` | 56 | `tm_backlog` upsert dedup (issue #906). Trusted CLI/script seed of the admin-only English demand backlog; no request account exists. The backlog carries a lifecycle-string status (`awaiting_translation`) that keeps it admin-only, never exposed publicly. | 2026-06-25 |
+| `src/Language/Backlog/BacklogBoard.php` | 39 | `tm_backlog` read for the staff-only /admin/anokii/language board (issue #906). The route's `requireRole(admin,elder_coordinator)` is the access boundary; the backlog is never exposed on /api/lang or any public route. Mirrors `PipelineCounts`. | 2026-06-25 |
 
 ### Conditional fallback — set account when available, bypass otherwise
 

--- a/migrations/20260625_120000_create_tm_backlog_table.php
+++ b/migrations/20260625_120000_create_tm_backlog_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Create the translation-backlog table (issue #906): tm_backlog, a content
+ * entity holding the demand-ranked English worklist seeded from the public
+ * website recon.
+ *
+ * Content-entity schema is the framework _data CLOB shape; all field values live
+ * in the _data JSON blob, never in dedicated columns. The label key column is
+ * english_text. The :memory: test kernel auto-creates this from the entity
+ * definition; this migration gives production the same table.
+ */
+return new class () extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        if (!$schema->hasTable('tm_backlog')) {
+            $schema->getConnection()->executeStatement('
+                CREATE TABLE tm_backlog (
+                    tbid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid CLOB,
+                    bundle CLOB,
+                    english_text CLOB,
+                    langcode CLOB,
+                    _data CLOB
+                )
+            ');
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        if ($schema->hasTable('tm_backlog')) {
+            $schema->getConnection()->executeStatement('DROP TABLE tm_backlog');
+        }
+    }
+};

--- a/scripts/build_translation_backlog_seed.php
+++ b/scripts/build_translation_backlog_seed.php
@@ -1,0 +1,57 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Dev generator (issue #906): turn the 2026-06-25 recon output into the committed
+ * translation-backlog seed dataset.
+ *
+ * Reads the recon ranked output (default: the recon scratch dir, NOT in this
+ * repo), applies App\Language\Backlog\BacklogBuilder, and writes
+ * config/translation_backlog_seed.json. Run once on a machine that has the recon
+ * output; the resulting JSON is committed so seeding is reproducible without the
+ * raw crawl. The seeder never re-derives - it only reads the committed file.
+ *
+ * Run: php scripts/build_translation_backlog_seed.php [path/to/out.json]
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use App\Language\Backlog\BacklogBuilder;
+
+$reconPath = $argv[1] ?? 'C:/Users/jones/minoo-recon/out.json';
+if (!is_file($reconPath)) {
+    fwrite(STDERR, "Recon output not found: {$reconPath}\n");
+    exit(1);
+}
+
+$recon = json_decode((string) file_get_contents($reconPath), true);
+if (!is_array($recon) || !isset($recon['ranked']) || !is_array($recon['ranked'])) {
+    fwrite(STDERR, "Malformed recon output (no 'ranked' array): {$reconPath}\n");
+    exit(1);
+}
+
+$built = (new BacklogBuilder())->build($recon['ranked']);
+
+$out = [
+    'provenance' => 'seed-crawl-2026-06-25',
+    'generated_from' => 'recon out.json (' . count($recon['ranked']) . ' distinct, >= 2 sites)',
+    'recon_report' => 'Projects/Minoo/docs/translation-seed-crawler-recon-2026-06-25.md',
+    'stats' => $built['stats'],
+    'excluded_anishinaabemowin' => $built['excluded_anishinaabemowin'],
+    'rows' => $built['rows'],
+];
+
+$dest = dirname(__DIR__) . '/config/translation_backlog_seed.json';
+file_put_contents($dest, json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
+
+fwrite(STDERR, sprintf(
+    "Wrote %s\n  kept=%d  below_floor=%d  dropped_noise=%d  excluded_ojibwe=%d\n  excluded: %s\n",
+    $dest,
+    $built['stats']['kept'],
+    $built['stats']['below_floor'],
+    $built['stats']['dropped_noise'],
+    $built['stats']['excluded_ojibwe'],
+    implode(', ', $built['excluded_anishinaabemowin']),
+));

--- a/scripts/seed_translation_backlog.php
+++ b/scripts/seed_translation_backlog.php
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Seed the translation backlog (tm_backlog) on production (issue #906).
+ *
+ * Production's ConsoleKernel is broken (#493), so this boots the HttpKernel via
+ * reflection (the scripts/populate_featured.php pattern) and runs the same
+ * idempotent {@see App\Seed\TranslationBacklogSeeder}. Re-runnable.
+ *
+ * Run: php scripts/seed_translation_backlog.php
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use App\Seed\TranslationBacklogData;
+use App\Seed\TranslationBacklogSeeder;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+$projectRoot = dirname(__DIR__);
+$kernel = new HttpKernel($projectRoot);
+$boot = new ReflectionMethod(AbstractKernel::class, 'boot');
+$boot->invoke($kernel);
+
+$seeder = new TranslationBacklogSeeder($kernel->getEntityTypeManager());
+$rows = TranslationBacklogData::load($projectRoot);
+$result = $seeder->seed($rows);
+
+printf(
+    "tm_backlog seeded: %d created, %d updated, %d total.\n",
+    $result['created'],
+    $result['updated'],
+    $result['total'],
+);
+foreach ($result['by_category'] as $category => $count) {
+    printf("  %-14s %d\n", $category, $count);
+}

--- a/src/Access/Language/LanguageAccessPolicy.php
+++ b/src/Access/Language/LanguageAccessPolicy.php
@@ -10,14 +10,15 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 
-#[PolicyAttribute(entityType: ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log'])]
+#[PolicyAttribute(entityType: ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log', 'tm_backlog'])]
 final class LanguageAccessPolicy implements AccessPolicyInterface
 {
     // translation_memory is published + consent-gated like the other content
-    // (public when status is 1 and consent_public is on). tm_gap_log carries a
-    // lifecycle string status (open|queued_for_speaker|resolved), so the integer
-    // status-1 view gate below never opens it: gap data stays admin-only.
-    private const ENTITY_TYPES = ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log'];
+    // (public when status is 1 and consent_public is on). tm_gap_log and
+    // tm_backlog carry a lifecycle string status (open|...; awaiting_translation),
+    // so the integer status-1 view gate below never opens them: gap data and the
+    // English demand backlog stay admin-only.
+    private const ENTITY_TYPES = ['dictionary_entry', 'example_sentence', 'word_part', 'dialect_region', 'speaker', 'translation_memory', 'tm_gap_log', 'tm_backlog'];
 
     public function appliesTo(string $entityTypeId): bool
     {

--- a/src/Console/SeedTranslationBacklogHandler.php
+++ b/src/Console/SeedTranslationBacklogHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use App\Seed\TranslationBacklogData;
+use App\Seed\TranslationBacklogSeeder;
+use Waaseyaa\CLI\Command\SymfonyCommandIO;
+
+/**
+ * `bin/waaseyaa lang:seed-backlog` (#906): idempotent seed of the demand-ranked
+ * English translation backlog from the committed dataset.
+ *
+ * Dev convenience only - production's ConsoleKernel is broken (#493), so the
+ * prod path is `scripts/seed_translation_backlog.php` (HttpKernel reflection),
+ * which calls the same {@see TranslationBacklogSeeder}.
+ */
+final class SeedTranslationBacklogHandler
+{
+    public function __construct(
+        private readonly TranslationBacklogSeeder $seeder,
+        private readonly string $projectRoot,
+    ) {
+    }
+
+    public function execute(SymfonyCommandIO $io): int
+    {
+        $rows = TranslationBacklogData::load($this->projectRoot);
+        $result = $this->seeder->seed($rows);
+
+        $io->writeln(sprintf(
+            'tm_backlog seeded: %d created, %d updated, %d total.',
+            $result['created'],
+            $result['updated'],
+            $result['total'],
+        ));
+        foreach ($result['by_category'] as $category => $count) {
+            $io->writeln(sprintf('  %-14s %d', $category, $count));
+        }
+
+        return 0;
+    }
+}

--- a/src/Entity/Language/TmBacklog.php
+++ b/src/Entity/Language/TmBacklog.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Language;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+/**
+ * A translation-backlog entry: one English surface string awaiting an
+ * Anishinaabemowin translation, with its cross-site demand signal (issue #906).
+ *
+ * This is the ungated, English-only worklist seeded from the public website
+ * recon (provenance `seed-crawl-2026-06-25`). It is distinct from its two
+ * neighbours on purpose: {@see TranslationMemory} *holds* an actual translation
+ * keyed on a community `language_tag`, and {@see TmGapLog} is shaped for organic
+ * runtime lookup misses (`lookup_type`, `best_fuzzy_score`). Neither cleanly
+ * holds "English demand awaiting translation", so this is its own lightweight
+ * type. A backlog row graduates INTO `translation_memory` once a speaker
+ * supplies the translation for its `target_tag`.
+ *
+ * `status` is the lifecycle string `awaiting_translation` (later: `translated`),
+ * so the LanguageAccessPolicy integer-status-1 view gate never opens it - the
+ * backlog stays admin-only, the same mechanism that keeps tm_gap_log admin-only.
+ * It is never exposed on /api/lang or any public route.
+ */
+final class TmBacklog extends ContentEntityBase
+{
+    protected string $entityTypeId = 'tm_backlog';
+
+    protected array $entityKeys = [
+        'id' => 'tbid',
+        'uuid' => 'uuid',
+        'label' => 'english_text',
+    ];
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $defaults = [
+            'target_tag' => 'oj-x-sagamok',
+            'status' => 'awaiting_translation',
+            'demand_sites' => 0,
+            'demand_total' => 0,
+            'created_at' => 0,
+            'updated_at' => 0,
+        ];
+        foreach ($defaults as $key => $value) {
+            if (!array_key_exists($key, $values)) {
+                $values[$key] = $value;
+            }
+        }
+
+        parent::__construct(
+            $values,
+            $entityTypeId ?: $this->entityTypeId,
+            $entityKeys ?: $this->entityKeys,
+            $fieldDefinitions,
+        );
+    }
+}

--- a/src/Http/Controller/Anokii/LanguageWorkspaceController.php
+++ b/src/Http/Controller/Anokii/LanguageWorkspaceController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controller\Anokii;
 
 use App\Anokii\Pipeline\PipelineCounts;
 use App\Http\View\AnokiiShellContext;
+use App\Language\Backlog\BacklogBoard;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
@@ -36,6 +37,7 @@ final class LanguageWorkspaceController
     public function index(AccountInterface $account, HttpRequest $request): Response
     {
         $snapshot = (new PipelineCounts($this->entityTypeManager))->compute();
+        $backlog = (new BacklogBoard($this->entityTypeManager))->summarize();
 
         $html = $this->twig->render('pages/anokii/index.html.twig', AnokiiShellContext::build($account, 'home', [
             'path' => $request->getPathInfo(),
@@ -43,6 +45,7 @@ final class LanguageWorkspaceController
             'counts' => $snapshot['counts'],
             'total' => $snapshot['total'],
             'do_next' => $snapshot['do_next'],
+            'backlog' => $backlog,
         ]));
 
         return new Response($html);

--- a/src/Language/Backlog/BacklogBoard.php
+++ b/src/Language/Backlog/BacklogBoard.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Backlog;
+
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * The staff-only read model for the translation backlog board (issue #906),
+ * rendered into the /admin/anokii/language overview. Returns the awaiting rows
+ * ranked by demand (distinct sites, then total occurrences) and grouped by
+ * concept_key so surface variants sit together.
+ *
+ * Read-only and admin-only: the route's requireRole(admin,elder_coordinator) is
+ * the access boundary, so the query uses accessCheck(false) (see the bypass
+ * audit doc). Nothing here is exposed on /api/lang or any public route.
+ */
+final class BacklogBoard
+{
+    public function __construct(private readonly EntityTypeManager $entityTypeManager)
+    {
+    }
+
+    /**
+     * @return array{
+     *   total: int,
+     *   by_category: array<string, int>,
+     *   concepts: list<array{concept_key: string, demand_sites: int, demand_total: int, category: string, forms: list<array{english_text: string, demand_sites: int, demand_total: int, category: string}>}>
+     * }
+     */
+    public function summarize(): array
+    {
+        $empty = ['total' => 0, 'by_category' => [], 'concepts' => []];
+        if (!$this->entityTypeManager->hasDefinition('tm_backlog')) {
+            return $empty;
+        }
+
+        $storage = $this->entityTypeManager->getStorage('tm_backlog');
+        $ids = $storage->getQuery()
+            ->accessCheck(false)
+            ->condition('status', 'awaiting_translation')
+            ->execute();
+        if ($ids === []) {
+            return $empty;
+        }
+
+        $byCategory = [];
+        $groups = [];
+        $total = 0;
+        foreach ($storage->loadMultiple($ids) as $row) {
+            $text = (string) $row->get('english_text');
+            if ($text === '') {
+                continue;
+            }
+            ++$total;
+            $category = (string) ($row->get('category') ?? 'other');
+            $byCategory[$category] = ($byCategory[$category] ?? 0) + 1;
+            $concept = (string) ($row->get('concept_key') ?? $text);
+            $sites = (int) $row->get('demand_sites');
+            $totalCount = (int) $row->get('demand_total');
+
+            $groups[$concept] ??= ['concept_key' => $concept, 'demand_sites' => 0, 'demand_total' => 0, 'category' => $category, 'forms' => []];
+            $groups[$concept]['forms'][] = ['english_text' => $text, 'demand_sites' => $sites, 'demand_total' => $totalCount, 'category' => $category];
+            $groups[$concept]['demand_sites'] = max($groups[$concept]['demand_sites'], $sites);
+            $groups[$concept]['demand_total'] = max($groups[$concept]['demand_total'], $totalCount);
+        }
+
+        foreach ($groups as &$group) {
+            usort($group['forms'], static fn (array $a, array $b): int => $b['demand_sites'] <=> $a['demand_sites']
+                ?: $b['demand_total'] <=> $a['demand_total']
+                ?: strcmp($a['english_text'], $b['english_text']));
+            // The concept's headline category is its strongest form's category.
+            $group['category'] = $group['forms'][0]['category'];
+        }
+        unset($group);
+
+        $concepts = array_values($groups);
+        usort($concepts, static fn (array $a, array $b): int => $b['demand_sites'] <=> $a['demand_sites']
+            ?: $b['demand_total'] <=> $a['demand_total']
+            ?: strcmp($a['concept_key'], $b['concept_key']));
+
+        ksort($byCategory);
+
+        return ['total' => $total, 'by_category' => $byCategory, 'concepts' => $concepts];
+    }
+}

--- a/src/Language/Backlog/BacklogBuilder.php
+++ b/src/Language/Backlog/BacklogBuilder.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Backlog;
+
+/**
+ * Turns the recon ranked output into the curated backlog dataset (issue #906),
+ * applying {@see BacklogRuleSet}: keep strings on >= MIN_SITES distinct sites,
+ * hard-drop theme/date noise, exclude already-Anishinaabemowin strings (logging
+ * them), cluster surface forms under a concept_key, and categorise each row.
+ *
+ * Pure: takes the ranked rows in, returns the dataset out. The dev generator
+ * ({@see \scripts\build_translation_backlog_seed.php}) feeds it the recon
+ * out.json and writes the committed seed file; the seeder never re-derives.
+ */
+final class BacklogBuilder
+{
+    /**
+     * @param list<array<string, mixed>> $ranked Recon ranked rows (untrusted JSON shape)
+     *
+     * @return array{
+     *   rows: list<array{english_text: string, concept_key: string, demand_sites: int, demand_total: int, category: string}>,
+     *   excluded_anishinaabemowin: list<string>,
+     *   stats: array{considered: int, below_floor: int, dropped_noise: int, excluded_ojibwe: int, kept: int}
+     * }
+     */
+    public function build(array $ranked): array
+    {
+        $rows = [];
+        $excluded = [];
+        $belowFloor = 0;
+        $droppedNoise = 0;
+
+        foreach ($ranked as $r) {
+            $text = trim((string) ($r['string'] ?? ''));
+            $sites = (int) ($r['distinct_sites'] ?? 0);
+            $total = (int) ($r['total'] ?? 0);
+
+            if ($text === '') {
+                continue;
+            }
+            if ($sites < BacklogRuleSet::MIN_SITES) {
+                ++$belowFloor;
+                continue;
+            }
+            if (BacklogRuleSet::shouldDrop($text)) {
+                ++$droppedNoise;
+                continue;
+            }
+            if (BacklogRuleSet::isAnishinaabemowin($text)) {
+                $excluded[] = $text;
+                continue;
+            }
+
+            $rows[] = [
+                'english_text' => $text,
+                'concept_key' => BacklogRuleSet::conceptKey($text),
+                'demand_sites' => $sites,
+                'demand_total' => $total,
+                'category' => BacklogRuleSet::categoryFor($text),
+            ];
+        }
+
+        // Primary rank: distinct sites; secondary: total occurrences.
+        usort($rows, static fn (array $a, array $b): int => $b['demand_sites'] <=> $a['demand_sites']
+            ?: $b['demand_total'] <=> $a['demand_total']
+            ?: strcmp($a['english_text'], $b['english_text']));
+
+        return [
+            'rows' => $rows,
+            'excluded_anishinaabemowin' => $excluded,
+            'stats' => [
+                'considered' => count($ranked),
+                'below_floor' => $belowFloor,
+                'dropped_noise' => $droppedNoise,
+                'excluded_ojibwe' => count($excluded),
+                'kept' => count($rows),
+            ],
+        ];
+    }
+}

--- a/src/Language/Backlog/BacklogRuleSet.php
+++ b/src/Language/Backlog/BacklogRuleSet.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Backlog;
+
+/**
+ * The inclusion + cleanup + clustering + categorisation rules for the translation
+ * backlog (issue #906), encoding section 5 of the 2026-06-25 recon report. Pure
+ * and side-effect-free so the policy is unit-tested in isolation; the generator
+ * ({@see \App\Language\Backlog\BacklogBuilder}) applies it to the recon output.
+ *
+ * Everything here is rule-based only - no lemmatiser. Casefold is the dedupe key;
+ * concept_key clusters surface variants while each surface form stays its own row.
+ */
+final class BacklogRuleSet
+{
+    /** Cross-site demand floor: below this is each nation's own program/place names. */
+    public const int MIN_SITES = 2;
+
+    /**
+     * Theme chrome / generic link text / artifacts to HARD-DROP (report §5). Bare
+     * month/date strings are dropped separately by {@see self::isDateNoise()}.
+     *
+     * @var list<string>
+     */
+    private const array HARD_DROP = [
+        'skip to content', 'page load link', 'go to top', 'toggle navigation',
+        'click here', 'read more', 'learn more', 'load more', 'search for', 'here',
+        'close', 'next', 'previous', 'overview', 'list', 'recent posts',
+        'email protected',
+    ];
+
+    /**
+     * Generic application chrome: kept in the backlog (it still needs translating)
+     * but tagged category=global-ui so its cross-site count is not read as
+     * band-governance demand (report §5).
+     *
+     * @var list<string>
+     */
+    private const array GLOBAL_UI = [
+        'search', 'login', 'log in', 'password', 'username', 'submit', 'send',
+        'download', 'subscribe', 'email', 'phone', 'first name', 'last name',
+        'remember me', 'forgot your password', 'members portal', 'members only',
+    ];
+
+    /**
+     * Anishinaabemowin lexicon used by the classifier. A string is EXCLUDED from
+     * the English backlog when every content token is in this set (i.e. the whole
+     * string is already in the language) - greetings, program words, autonyms.
+     * Mixed strings that merely embed an autonym ("Anishinabek Nation Governance
+     * Agreement") are English proper nouns and are kept as category=other.
+     *
+     * @var array<string, true>
+     */
+    private const array OJIBWE_LEXICON = [
+        'aanii' => true, 'aaniin' => true, 'boozhoo' => true, 'biindigen' => true,
+        'niigaaniin' => true, 'anishinaabemowin' => true, 'nbisiing' => true,
+        'mino' => true, 'bimaadiziwin' => true, 'maadiziwin' => true, 'giizhigad' => true,
+        'anishinaabe' => true, 'anishinaabeg' => true, 'anishnawbek' => true,
+        'miigwech' => true, 'miigwetch' => true, 'gichi' => true, 'gchi' => true,
+        'manidoo' => true, 'nokomis' => true, 'mishomis' => true, 'ahaaw' => true,
+        'baamaapii' => true, 'miikaan' => true, 'kendaaswin' => true, 'kinoomaage' => true,
+        'naaknigewin' => true, 'gakina' => true, 'mnis' => true, 'edbendaagzijig' => true,
+        'binojiinh' => true, 'gamik' => true, 'ogemah' => true,
+    ];
+
+    /**
+     * Substrings that mark a string as a proper noun / named institution rather
+     * than generic nav - categorised "other" (kept, but not counted as nav demand).
+     *
+     * @var list<string>
+     */
+    private const array PROPER_NOUN_MARKERS = [
+        'first nation', 'treaty', 'anishinabek', 'police service', 'facebook',
+        'twitter', 'instagram', 'youtube', 'covid', 'canada',
+    ];
+
+    /** English stopwords ignored when deciding if a string is wholly Anishinaabemowin. */
+    private const array STOPWORDS = ['and', 'the', 'of', 'a', 'an', 'to', 'in', 'for', 'our', 'us'];
+
+    /** Drop the string entirely (theme noise, date strings, empties). */
+    public static function shouldDrop(string $s): bool
+    {
+        $key = self::fold($s);
+        if ($key === '') {
+            return true;
+        }
+
+        return in_array($key, self::HARD_DROP, true) || self::isDateNoise($key);
+    }
+
+    /** A string already in Anishinaabemowin (every content token is in the lexicon). */
+    public static function isAnishinaabemowin(string $s): bool
+    {
+        $tokens = self::contentTokens($s);
+        if ($tokens === []) {
+            return false;
+        }
+        foreach ($tokens as $t) {
+            if (!isset(self::OJIBWE_LEXICON[$t])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** governance-nav | global-ui | other. Assumes the string already passed drop/Ojibwe filters. */
+    public static function categoryFor(string $s): string
+    {
+        if (in_array(self::fold($s), self::GLOBAL_UI, true)) {
+            return 'global-ui';
+        }
+        $key = self::fold($s);
+        foreach (self::PROPER_NOUN_MARKERS as $marker) {
+            if (str_contains($key, $marker)) {
+                return 'other';
+            }
+        }
+
+        return 'governance-nav';
+    }
+
+    /**
+     * Cluster key for ranking: normalise & <-> and, strip a leading "Our" / trailing
+     * "Us", drop required-field markers, casefold. Surface forms keep their own row;
+     * this groups them (e.g. "Contact" + "Contact Us", "Chief & Council" + "Chief and
+     * Council", "History" + "Our History").
+     */
+    public static function conceptKey(string $s): string
+    {
+        $k = self::fold($s);
+        $k = str_replace(' & ', ' and ', $k);
+        $k = str_replace('&', ' and ', $k);
+        $k = preg_replace('/\s+/', ' ', $k) ?? $k;
+        $k = trim($k);
+        if (str_starts_with($k, 'our ')) {
+            $k = substr($k, 4);
+        }
+        if (str_ends_with($k, ' us')) {
+            $k = substr($k, 0, -3);
+        }
+
+        return trim($k);
+    }
+
+    /** Casefold + collapse whitespace + strip surrounding punctuation/markers. */
+    public static function fold(string $s): string
+    {
+        $s = str_replace('*', '', $s);
+        $s = preg_replace('/\(\s*required\s*\)/i', '', $s) ?? $s;
+        $s = preg_replace('/\s+/', ' ', $s) ?? $s;
+        $s = trim($s, " \t\r\n.,;:!?\"'");
+
+        return mb_strtolower(trim($s));
+    }
+
+    /** Bare month / month-year / relative-date strings (calendar widgets). */
+    private static function isDateNoise(string $key): bool
+    {
+        $months = 'january|february|march|april|may|june|july|august|september|october|november|december';
+
+        return preg_match('/^(' . $months . ')(\s+\d{4})?$/', $key) === 1
+            || preg_match('/^\d{1,2}\s+(' . $months . ')/', $key) === 1;
+    }
+
+    /**
+     * Lower-cased content tokens with stopwords and non-letters removed.
+     *
+     * @return list<string>
+     */
+    private static function contentTokens(string $s): array
+    {
+        $clean = preg_replace('/[^\p{L}\s-]/u', ' ', mb_strtolower($s)) ?? '';
+        $out = [];
+        foreach (preg_split('/[\s-]+/', $clean, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $tok) {
+            if (!in_array($tok, self::STOPWORDS, true)) {
+                $out[] = $tok;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Provider/AppCommandServiceProvider.php
+++ b/src/Provider/AppCommandServiceProvider.php
@@ -8,11 +8,13 @@ use App\Console\AnokiiBackfillStatusHandler;
 use App\Console\IngestCorpusHandler;
 use App\Console\MailTestHandler;
 use App\Console\ProcessReelsHandler;
+use App\Console\SeedTranslationBacklogHandler;
 use App\Ingestion\Corpus\CorpusIngestor;
 use App\Ingestion\Corpus\FfmpegReelFetcher;
 use App\Ingestion\Corpus\LlmWhiteboardReader;
 use App\Ingestion\Corpus\LocalFileReelFetcher;
 use App\Ingestion\Corpus\ReelProcessor;
+use App\Seed\TranslationBacklogSeeder;
 use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\CLI\Command\HandlerArgument;
 use Waaseyaa\CLI\Command\HandlerArgumentMode;
@@ -54,6 +56,13 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                     new FfmpegReelFetcher($corpusPath),
                     new LlmWhiteboardReader($this->resolve(ProviderInterface::class)),
                 ),
+            );
+        });
+
+        $this->singleton(SeedTranslationBacklogHandler::class, function (): SeedTranslationBacklogHandler {
+            return new SeedTranslationBacklogHandler(
+                $this->resolve(TranslationBacklogSeeder::class),
+                dirname(__DIR__, 2),
             );
         });
 
@@ -111,6 +120,12 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
                     description: 'Skip the vision LLM draft; advance with blank Ojibwe/English',
                 ),
             ],
+        );
+
+        yield new HandlerCommand(
+            name: 'lang:seed-backlog',
+            description: 'Idempotently seed the demand-ranked English translation backlog into tm_backlog (#906)',
+            handler: [SeedTranslationBacklogHandler::class, 'execute'],
         );
 
         yield new HandlerCommand(

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
+use App\Entity\Language\TmBacklog;
 use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
 use App\Language\Asr\AsrClient;
 use App\Language\Asr\UnavailableAsrClient;
 use App\Language\DialectCodeProvider;
 use App\Language\TranslationMemoryService;
+use App\Seed\TranslationBacklogSeeder;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 
@@ -54,6 +56,14 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
         // no transcription until the Phase 0 consent agreement exists and a real
         // worker-backed client replaces this binding. No public ASR surface (D8).
         $this->singleton(AsrClient::class, static fn (): AsrClient => new UnavailableAsrClient());
+
+        // The idempotent backlog seeder (#906): upserts the committed
+        // demand-ranked English seed into tm_backlog. Used by the dev console
+        // command and the prod reflection script.
+        $this->singleton(
+            TranslationBacklogSeeder::class,
+            fn (): TranslationBacklogSeeder => new TranslationBacklogSeeder($this->resolve(EntityTypeManager::class)),
+        );
 
         $this->entityType(new EntityType(
             id: 'translation_memory',
@@ -100,6 +110,32 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
                 'last_requested_at' => ['type' => 'timestamp', 'label' => 'Last Requested', 'weight' => 6],
                 'status' => ['type' => 'string', 'label' => 'Status', 'description' => 'open | queued_for_speaker | resolved.', 'weight' => 7, 'default' => 'open'],
                 'resolved_tm_id' => ['type' => 'integer', 'label' => 'Resolved Translation', 'description' => 'The translation_memory row that closed the gap, nullable.', 'weight' => 8],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
+                'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
+            ],
+        ));
+
+        // The demand-ranked English backlog (#906): the ungated worklist seeded
+        // from the public website recon. Registered unconditionally so the schema
+        // is consistent; admin-only via LanguageAccessPolicy (string status never
+        // satisfies the integer status-1 view gate). A row graduates into
+        // translation_memory once a speaker translates it.
+        $this->entityType(new EntityType(
+            id: 'tm_backlog',
+            label: 'Translation Backlog',
+            class: TmBacklog::class,
+            keys: ['id' => 'tbid', 'uuid' => 'uuid', 'label' => 'english_text'],
+            group: 'language',
+            _fieldDefinitions: [
+                'english_text' => ['type' => 'string', 'label' => 'English Text', 'description' => 'The English surface form awaiting translation.', 'weight' => 0],
+                'concept_key' => ['type' => 'string', 'label' => 'Concept Key', 'description' => 'Clustered key grouping surface variants (Contact / Contact Us).', 'weight' => 1],
+                'dedupe_key' => ['type' => 'string', 'label' => 'Dedupe Key', 'description' => 'sha256 of (english_text, target_tag); the upsert uniqueness key.', 'weight' => 2],
+                'demand_sites' => ['type' => 'integer', 'label' => 'Demand (distinct sites)', 'description' => 'Number of distinct sites the string appeared on (primary rank).', 'weight' => 3, 'default' => 0],
+                'demand_total' => ['type' => 'integer', 'label' => 'Demand (total)', 'description' => 'Total occurrences across all sites (secondary rank).', 'weight' => 4, 'default' => 0],
+                'category' => ['type' => 'string', 'label' => 'Category', 'description' => 'governance-nav | global-ui | other.', 'weight' => 5],
+                'target_tag' => ['type' => 'string', 'label' => 'Target Tag', 'description' => 'First translation target (default oj-x-sagamok, Sagamok is the core).', 'weight' => 6, 'default' => 'oj-x-sagamok'],
+                'status' => ['type' => 'string', 'label' => 'Status', 'description' => 'awaiting_translation | translated. String status keeps the backlog admin-only.', 'weight' => 7, 'default' => 'awaiting_translation'],
+                'provenance' => ['type' => 'string', 'label' => 'Provenance', 'description' => 'Where the demand came from, e.g. seed-crawl-2026-06-25.', 'weight' => 8],
                 'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
                 'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
             ],

--- a/src/Seed/TranslationBacklogData.php
+++ b/src/Seed/TranslationBacklogData.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+/**
+ * Loads the committed translation-backlog seed dataset
+ * (`config/translation_backlog_seed.json`, issue #906). The dataset is the
+ * curated, demand-ranked output of the 2026-06-25 recon; it ships in the repo so
+ * production seeds the same rows the dev run produced, without the raw recon
+ * crawl ever being present on the server.
+ */
+final class TranslationBacklogData
+{
+    public const string SEED_FILE = 'config/translation_backlog_seed.json';
+
+    /**
+     * @return list<array{english_text: string, concept_key: string, demand_sites: int, demand_total: int, category: string}>
+     */
+    public static function load(string $projectRoot): array
+    {
+        $path = rtrim($projectRoot, '/\\') . '/' . self::SEED_FILE;
+        if (!is_file($path)) {
+            throw new \RuntimeException("Translation backlog seed file not found: {$path}");
+        }
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (!is_array($decoded) || !isset($decoded['rows']) || !is_array($decoded['rows'])) {
+            throw new \RuntimeException("Malformed translation backlog seed file: {$path}");
+        }
+
+        /** @var list<array{english_text: string, concept_key: string, demand_sites: int, demand_total: int, category: string}> */
+        return array_values($decoded['rows']);
+    }
+}

--- a/src/Seed/TranslationBacklogSeeder.php
+++ b/src/Seed/TranslationBacklogSeeder.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Idempotent upsert of the curated translation backlog into `tm_backlog`
+ * (issue #906). Reads the committed seed dataset
+ * (`config/translation_backlog_seed.json`, produced by the dev generator) and
+ * writes one row per English surface form, keyed unique on
+ * (english_text, target_tag).
+ *
+ * Re-runnable: an existing row is updated in place (demand counts, concept,
+ * category refreshed) rather than duplicated, so seeding prod after a re-crawl
+ * never doubles the backlog. Rows that staff have already graduated to
+ * `translated` are left at their lifecycle status.
+ *
+ * Reads/writes use accessCheck(false): seeding is a trusted admin/CLI operation,
+ * not a request-scoped read (see the bypass audit doc).
+ */
+final class TranslationBacklogSeeder
+{
+    public const string PROVENANCE = 'seed-crawl-2026-06-25';
+    public const string DEFAULT_TARGET_TAG = 'oj-x-sagamok';
+
+    public function __construct(private readonly EntityTypeManager $entityTypeManager)
+    {
+    }
+
+    /**
+     * @param list<array{english_text: string, concept_key: string, demand_sites: int, demand_total: int, category: string}> $rows
+     *
+     * @return array{created: int, updated: int, total: int, by_category: array<string, int>}
+     */
+    public function seed(array $rows, string $targetTag = self::DEFAULT_TARGET_TAG): array
+    {
+        $storage = $this->entityTypeManager->getStorage('tm_backlog');
+        $now = time();
+        $created = 0;
+        $updated = 0;
+        $byCategory = [];
+
+        foreach ($rows as $row) {
+            $text = trim((string) $row['english_text']);
+            if ($text === '') {
+                continue;
+            }
+            $category = (string) $row['category'];
+            $byCategory[$category] = ($byCategory[$category] ?? 0) + 1;
+            $dedupeKey = self::dedupeKey($text, $targetTag);
+
+            $existingIds = $storage->getQuery()
+                ->accessCheck(false)
+                ->condition('dedupe_key', $dedupeKey)
+                ->execute();
+
+            $fields = [
+                'english_text' => $text,
+                'concept_key' => (string) $row['concept_key'],
+                'demand_sites' => (int) $row['demand_sites'],
+                'demand_total' => (int) $row['demand_total'],
+                'category' => $category,
+                'target_tag' => $targetTag,
+                'dedupe_key' => $dedupeKey,
+                'provenance' => self::PROVENANCE,
+                'updated_at' => $now,
+            ];
+
+            if ($existingIds !== []) {
+                $entity = $storage->load((int) reset($existingIds));
+                if ($entity !== null) {
+                    foreach ($fields as $key => $value) {
+                        $entity->set($key, $value);
+                    }
+                    $storage->save($entity);
+                    ++$updated;
+                    continue;
+                }
+            }
+
+            $fields['status'] = 'awaiting_translation';
+            $fields['created_at'] = $now;
+            $storage->save($storage->create($fields));
+            ++$created;
+        }
+
+        return [
+            'created' => $created,
+            'updated' => $updated,
+            'total' => $created + $updated,
+            'by_category' => $byCategory,
+        ];
+    }
+
+    /** Stable unique key for (english_text, target_tag). */
+    public static function dedupeKey(string $englishText, string $targetTag): string
+    {
+        return hash('sha256', mb_strtolower(trim($englishText)) . '|' . $targetTag);
+    }
+}

--- a/templates/pages/anokii/index.html.twig
+++ b/templates/pages/anokii/index.html.twig
@@ -29,6 +29,21 @@
   .ov-stage .ov-label{ display:block; margin-top:6px; color:var(--anokii-shell-muted); font-size:13.5px; }
   .ov-stage .ov-go{ display:block; margin-top:10px; color:var(--anokii-shell-accent); font-size:13px; font-weight:600; }
   .ov-empty{ padding:28px; border:1px dashed var(--anokii-shell-line); border-radius:12px; color:var(--anokii-shell-muted); }
+  .bk-head{ margin:34px 0 12px; display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; }
+  .bk-head h2{ font-size:1.2rem; }
+  .bk-head .bk-sub{ color:var(--anokii-shell-muted); font-size:13.5px; }
+  .bk-tags{ display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px; }
+  .bk-tag{ font-size:12.5px; border:1px solid var(--anokii-shell-line); border-radius:999px; padding:3px 10px; color:var(--anokii-shell-muted); }
+  .bk-table{ width:100%; border-collapse:collapse; font-size:14px; }
+  .bk-table th, .bk-table td{ text-align:left; padding:8px 10px; border-bottom:1px solid var(--anokii-shell-line); }
+  .bk-table th{ color:var(--anokii-shell-muted); font-weight:600; font-size:12.5px; text-transform:uppercase; letter-spacing:.03em; }
+  .bk-table td.bk-n{ text-align:right; font-variant-numeric:tabular-nums; width:1%; white-space:nowrap; }
+  .bk-concept{ font-weight:600; }
+  .bk-form{ color:var(--anokii-shell-muted); }
+  .bk-cat{ font-size:11.5px; border-radius:6px; padding:1px 7px; border:1px solid var(--anokii-shell-line); }
+  .bk-cat.governance-nav{ color:var(--anokii-shell-accent); border-color:color-mix(in oklab, var(--anokii-shell-accent) 50%, var(--anokii-shell-line)); }
+  .bk-cat.global-ui{ color:var(--anokii-shell-muted); }
+  .bk-cat.other{ color:var(--anokii-shell-muted); opacity:.8; }
 {% endblock %}
 
 {% block brand %}
@@ -75,4 +90,35 @@
       </a>
     {% endfor %}
   </div>
+
+  {% set bk = backlog|default({'total': 0, 'concepts': [], 'by_category': {}}) %}
+  {% if bk.total > 0 %}
+    <div class="bk-head">
+      <h2>Translation backlog</h2>
+      <span class="bk-sub">{{ bk.total }} English string{{ bk.total == 1 ? '' : 's' }} awaiting translation, ranked by cross-site demand. Each graduates into the translation memory once a speaker translates it.</span>
+    </div>
+    <div class="bk-tags">
+      {% for cat, n in bk.by_category %}<span class="bk-tag">{{ cat }}: {{ n }}</span>{% endfor %}
+    </div>
+    <table class="bk-table">
+      <thead>
+        <tr><th>Concept / surface forms</th><th>Category</th><th class="bk-n">Sites</th><th class="bk-n">Total</th></tr>
+      </thead>
+      <tbody>
+        {% for c in bk.concepts %}
+          {% for f in c.forms %}
+            <tr>
+              <td>
+                {%- if loop.first %}<span class="bk-concept">{{ f.english_text }}</span>
+                {%- else %}<span class="bk-form">↳ {{ f.english_text }}</span>{% endif -%}
+              </td>
+              <td><span class="bk-cat {{ f.category }}">{{ f.category }}</span></td>
+              <td class="bk-n">{{ f.demand_sites }}</td>
+              <td class="bk-n">{{ f.demand_total }}</td>
+            </tr>
+          {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endblock %}

--- a/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
+++ b/tests/App/Integration/Entity/LanguageModuleEntitiesTest.php
@@ -65,4 +65,30 @@ final class LanguageModuleEntitiesTest extends HttpKernelTestCase
         self::assertSame(3, $loaded->get('request_count'));
         self::assertSame('open', $loaded->get('status'), 'Default lifecycle status persists.');
     }
+
+    #[Test]
+    public function tm_backlog_round_trips_with_its_defaults(): void
+    {
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('tm_backlog');
+
+        $backlog = $storage->create([
+            'english_text' => 'Economic Development',
+            'concept_key' => 'economic development',
+            'demand_sites' => 10,
+            'demand_total' => 225,
+            'category' => 'governance-nav',
+            'provenance' => 'seed-crawl-2026-06-25',
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $storage->save($backlog);
+
+        $loaded = $storage->load($backlog->id());
+        self::assertNotNull($loaded);
+        self::assertSame('Economic Development', $loaded->get('english_text'));
+        self::assertSame('governance-nav', $loaded->get('category'));
+        self::assertSame(10, (int) $loaded->get('demand_sites'));
+        self::assertSame('oj-x-sagamok', $loaded->get('target_tag'), 'Default first target persists.');
+        self::assertSame('awaiting_translation', $loaded->get('status'), 'Default lifecycle status persists.');
+    }
 }

--- a/tests/App/Integration/Language/TranslationBacklogTest.php
+++ b/tests/App/Integration/Language/TranslationBacklogTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Language;
+
+use App\Language\Backlog\BacklogBoard;
+use App\Seed\TranslationBacklogSeeder;
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The translation backlog seeds idempotently into tm_backlog and reads back as a
+ * ranked, concept-grouped, admin-only board (issue #906). Boots the real kernel,
+ * so it also proves LanguageModuleServiceProvider registers tm_backlog and the
+ * :memory: table auto-creates from the entity definition.
+ */
+#[CoversClass(TranslationBacklogSeeder::class)]
+#[CoversClass(BacklogBoard::class)]
+final class TranslationBacklogTest extends HttpKernelTestCase
+{
+    /**
+     * @return list<array{english_text: string, concept_key: string, demand_sites: int, demand_total: int, category: string}>
+     */
+    private static function rows(): array
+    {
+        return [
+            ['english_text' => 'Contact', 'concept_key' => 'contact', 'demand_sites' => 16, 'demand_total' => 494, 'category' => 'governance-nav'],
+            ['english_text' => 'Contact Us', 'concept_key' => 'contact', 'demand_sites' => 15, 'demand_total' => 298, 'category' => 'governance-nav'],
+            ['english_text' => 'Search', 'concept_key' => 'search', 'demand_sites' => 9, 'demand_total' => 170, 'category' => 'global-ui'],
+        ];
+    }
+
+    #[Test]
+    public function it_seeds_rows_with_the_backlog_contract(): void
+    {
+        $seeder = new TranslationBacklogSeeder(self::$kernel->getEntityTypeManager());
+        $result = $seeder->seed(self::rows());
+
+        self::assertSame(3, $result['created']);
+        self::assertSame(0, $result['updated']);
+        self::assertSame(['governance-nav' => 2, 'global-ui' => 1], $result['by_category']);
+
+        $storage = self::$kernel->getEntityTypeManager()->getStorage('tm_backlog');
+        $ids = $storage->getQuery()->accessCheck(false)->condition('english_text', 'Contact')->execute();
+        self::assertNotEmpty($ids);
+        $row = $storage->load((int) reset($ids));
+        self::assertNotNull($row);
+        self::assertSame('oj-x-sagamok', $row->get('target_tag'), 'Sagamok is the default first target.');
+        self::assertSame('awaiting_translation', $row->get('status'));
+        self::assertSame('seed-crawl-2026-06-25', $row->get('provenance'));
+        self::assertSame(16, (int) $row->get('demand_sites'));
+    }
+
+    #[Test]
+    public function re_seeding_upserts_and_never_duplicates(): void
+    {
+        $etm = self::$kernel->getEntityTypeManager();
+        $seeder = new TranslationBacklogSeeder($etm);
+
+        $seeder->seed(self::rows());
+        // Re-run with a refreshed demand count for one row.
+        $rows = self::rows();
+        $rows[0]['demand_sites'] = 18;
+        $second = $seeder->seed($rows);
+
+        self::assertSame(0, $second['created'], 'No new rows on re-seed.');
+        self::assertSame(3, $second['updated']);
+
+        $storage = $etm->getStorage('tm_backlog');
+        $all = $storage->getQuery()->accessCheck(false)->execute();
+        self::assertCount(3, $all, 'Idempotent: still exactly three rows.');
+
+        $ids = $storage->getQuery()->accessCheck(false)->condition('english_text', 'Contact')->execute();
+        self::assertSame(18, (int) $storage->load((int) reset($ids))->get('demand_sites'), 'Demand refreshed in place.');
+    }
+
+    #[Test]
+    public function the_board_ranks_by_demand_and_groups_by_concept(): void
+    {
+        $etm = self::$kernel->getEntityTypeManager();
+        (new TranslationBacklogSeeder($etm))->seed(self::rows());
+
+        $board = (new BacklogBoard($etm))->summarize();
+
+        self::assertSame(3, $board['total']);
+        self::assertSame(['global-ui' => 1, 'governance-nav' => 2], $board['by_category']);
+        // Two concepts: "contact" (Contact + Contact Us) ranks above "search".
+        self::assertSame('contact', $board['concepts'][0]['concept_key']);
+        self::assertCount(2, $board['concepts'][0]['forms']);
+        self::assertSame('Contact', $board['concepts'][0]['forms'][0]['english_text'], 'Strongest form first.');
+        self::assertSame('search', $board['concepts'][1]['concept_key']);
+    }
+}

--- a/tests/App/Unit/Access/Language/LanguageAccessPolicyTest.php
+++ b/tests/App/Unit/Access/Language/LanguageAccessPolicyTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Access\Language;
 
 use App\Access\Language\LanguageAccessPolicy;
 use App\Entity\Language\DictionaryEntry;
+use App\Entity\Language\TmBacklog;
 use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,7 +29,20 @@ final class LanguageAccessPolicyTest extends TestCase
         $this->assertTrue($policy->appliesTo('speaker'));
         $this->assertTrue($policy->appliesTo('translation_memory'));
         $this->assertTrue($policy->appliesTo('tm_gap_log'));
+        $this->assertTrue($policy->appliesTo('tm_backlog'));
         $this->assertFalse($policy->appliesTo('node'));
+    }
+
+    #[Test]
+    public function backlog_is_admin_only_never_public(): void
+    {
+        $policy = new LanguageAccessPolicy();
+        // The awaiting_translation lifecycle status never satisfies the integer
+        // status-1 view gate, so the English demand backlog stays admin-only.
+        $backlog = new TmBacklog(['english_text' => 'Contact', 'status' => 'awaiting_translation']);
+
+        $this->assertFalse($policy->access($backlog, 'view', $this->anonymous())->isAllowed());
+        $this->assertTrue($policy->access($backlog, 'view', $this->admin())->isAllowed());
     }
 
     #[Test]

--- a/tests/App/Unit/Language/Backlog/BacklogBuilderTest.php
+++ b/tests/App/Unit/Language/Backlog/BacklogBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language\Backlog;
+
+use App\Language\Backlog\BacklogBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BacklogBuilder::class)]
+final class BacklogBuilderTest extends TestCase
+{
+    /**
+     * @return list<array{string: string, distinct_sites: int, total: int}>
+     */
+    private static function sample(): array
+    {
+        return [
+            ['string' => 'Contact', 'distinct_sites' => 9, 'total' => 200],
+            ['string' => 'Contact Us', 'distinct_sites' => 7, 'total' => 100],
+            ['string' => 'Search', 'distinct_sites' => 5, 'total' => 80],   // global-ui
+            ['string' => 'Niigaaniin', 'distinct_sites' => 4, 'total' => 60], // anishinaabemowin -> excluded
+            ['string' => 'Skip to content', 'distinct_sites' => 8, 'total' => 150], // noise -> dropped
+            ['string' => 'June 2026', 'distinct_sites' => 3, 'total' => 40], // date noise -> dropped
+            ['string' => 'Their Own Program', 'distinct_sites' => 1, 'total' => 5], // below floor
+        ];
+    }
+
+    #[Test]
+    public function it_keeps_only_cross_site_strings_and_logs_exclusions(): void
+    {
+        $out = (new BacklogBuilder())->build(self::sample());
+
+        self::assertSame(['Niigaaniin'], $out['excluded_anishinaabemowin']);
+        self::assertSame(7, $out['stats']['considered']);
+        self::assertSame(1, $out['stats']['below_floor']);
+        self::assertSame(2, $out['stats']['dropped_noise']);
+        self::assertSame(1, $out['stats']['excluded_ojibwe']);
+        self::assertSame(3, $out['stats']['kept']);
+
+        $texts = array_column($out['rows'], 'english_text');
+        self::assertSame(['Contact', 'Contact Us', 'Search'], $texts, 'Ranked by demand_sites desc.');
+    }
+
+    #[Test]
+    public function it_clusters_and_categorises_kept_rows(): void
+    {
+        $rows = (new BacklogBuilder())->build(self::sample())['rows'];
+        $byText = [];
+        foreach ($rows as $r) {
+            $byText[$r['english_text']] = $r;
+        }
+
+        self::assertSame($byText['Contact']['concept_key'], $byText['Contact Us']['concept_key']);
+        self::assertSame('governance-nav', $byText['Contact']['category']);
+        self::assertSame('global-ui', $byText['Search']['category']);
+    }
+}

--- a/tests/App/Unit/Language/Backlog/BacklogRuleSetTest.php
+++ b/tests/App/Unit/Language/Backlog/BacklogRuleSetTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language\Backlog;
+
+use App\Language\Backlog\BacklogRuleSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BacklogRuleSet::class)]
+final class BacklogRuleSetTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function dropCases(): iterable
+    {
+        yield 'theme chrome' => ['Skip to content', true];
+        yield 'divi artifact' => ['Page load link', true];
+        yield 'generic link text' => ['Read more', true];
+        yield 'bare here' => ['here', true];
+        yield 'cloudflare email' => ['email protected', true];
+        yield 'month-year' => ['June 2026', true];
+        yield 'bare month' => ['May', true];
+        yield 'day month' => ['12 March', true];
+        yield 'real nav kept' => ['Contact', false];
+        yield 'governance kept' => ['Economic Development', false];
+    }
+
+    #[Test]
+    #[DataProvider('dropCases')]
+    public function it_hard_drops_theme_and_date_noise(string $input, bool $dropped): void
+    {
+        self::assertSame($dropped, BacklogRuleSet::shouldDrop($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function ojibweCases(): iterable
+    {
+        yield 'greeting' => ['Aanii', true];
+        yield 'program word' => ['Niigaaniin', true];
+        yield 'language name' => ['Anishinaabemowin', true];
+        yield 'two ojibwe words' => ['Mino Bimaadiziwin', true];
+        yield 'feast day' => ['Anishinaabe Giizhigad', true];
+        yield 'embedded autonym is english proper noun' => ['Anishinabek Nation Governance Agreement', false];
+        yield 'plain english' => ['Contact', false];
+    }
+
+    #[Test]
+    #[DataProvider('ojibweCases')]
+    public function it_classifies_wholly_anishinaabemowin_strings(string $input, bool $isOjibwe): void
+    {
+        self::assertSame($isOjibwe, BacklogRuleSet::isAnishinaabemowin($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function categoryCases(): iterable
+    {
+        yield 'chrome is global-ui' => ['Search', 'global-ui'];
+        yield 'login is global-ui' => ['Log in', 'global-ui'];
+        yield 'nav is governance' => ['Public Works', 'governance-nav'];
+        yield 'services is governance' => ['Ontario Works', 'governance-nav'];
+        yield 'social is other' => ['Facebook', 'other'];
+        yield 'treaty is other' => ['Robinson Huron Treaty', 'other'];
+        yield 'nation name is other' => ['Mississauga First Nation', 'other'];
+    }
+
+    #[Test]
+    #[DataProvider('categoryCases')]
+    public function it_categorises_governance_global_ui_and_other(string $input, string $category): void
+    {
+        self::assertSame($category, BacklogRuleSet::categoryFor($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function conceptCases(): iterable
+    {
+        yield 'trailing Us folds' => ['Contact Us', 'contact'];
+        yield 'plain stays' => ['Contact', 'contact'];
+        yield 'ampersand to and' => ['Chief & Council', 'chief and council'];
+        yield 'and stays' => ['Chief and Council', 'chief and council'];
+        yield 'leading Our folds' => ['Our History', 'history'];
+        yield 'required marker stripped' => ['First Name*', 'first name'];
+    }
+
+    #[Test]
+    #[DataProvider('conceptCases')]
+    public function it_clusters_surface_forms_under_a_concept_key(string $input, string $concept): void
+    {
+        self::assertSame($concept, BacklogRuleSet::conceptKey($input));
+    }
+
+    #[Test]
+    public function contact_and_contact_us_share_a_concept(): void
+    {
+        self::assertSame(BacklogRuleSet::conceptKey('Contact'), BacklogRuleSet::conceptKey('Contact Us'));
+    }
+}


### PR DESCRIPTION
Closes #906. Milestone #69. Builds the ungated, English-only translation worklist from the 2026-06-25 website recon (report: `Projects/Minoo/docs/translation-seed-crawler-recon-2026-06-25.md`). Staff-gated; nothing public; **no prod deploy in this PR** (seeding prod is a separate explicit step).

## Data model (schema-fit decision)
New lightweight **`tm_backlog`** entity = English demand awaiting translation, with its cross-site demand signal. I considered the two neighbours and neither fits:
- `translation_memory` *is* the translation (requires a `translation`, keyed on a community `language_tag`).
- `tm_gap_log` is shaped for organic runtime lookup misses (`lookup_type`, `best_fuzzy_score`, `request_count`).

A backlog row **graduates into `translation_memory`** once a speaker translates it. Its `status` is the lifecycle string `awaiting_translation`, so the existing `LanguageAccessPolicy` integer-status-1 view gate never opens it — the backlog stays **admin-only**, the same mechanism that keeps `tm_gap_log` admin-only. Registered unconditionally in `LanguageModuleServiceProvider`; migration mirrors the `translation_memory` `_data` CLOB shape.

Fields: `english_text`, `concept_key`, `dedupe_key`, `demand_sites`, `demand_total`, `category` (governance-nav | global-ui | other), `target_tag` (default `oj-x-sagamok`), `status`, `provenance` (`seed-crawl-2026-06-25`), timestamps. Unique on (english_text, target_tag).

## Inclusion + cleanup (recon §5, rule-based, in `BacklogRuleSet`)
- Include strings on **>= 2 distinct sites** (the 93% single-site tail is each nation's own program/place names, out of scope).
- **Cluster** surface forms under a `concept_key` (`&`<->`and`, fold leading "Our" / trailing "Us", strip required markers) while keeping each surface form its own row.
- **Hard-drop** theme/date/`email-protected` noise.
- **Tag** global-ui chrome (`Search`/`Login`/`Password`/...) `category=global-ui` so its cross-site count isn't read as nation demand.
- **Exclude** already-Anishinaabemowin strings via a small lexicon classifier (logged). No nation's Anishinaabemowin translations are harvested (OCAP, out of scope).

## Surface
Ranked, concept-grouped table at **/admin/anokii/language** behind `LanguageAccessPolicy` (admin / elder_coordinator), via `BacklogBoard`. **Not** exposed on `/api/lang` or any public route. `accessCheck(false)` reads documented in the bypass-audit doc.

## Seeder (idempotent)
Upsert keyed unique on (english_text, target_tag) via `dedupe_key`. `lang:seed-backlog` console command (dev); `scripts/seed_translation_backlog.php` boots HttpKernel via reflection (prod, since ConsoleKernel is broken #493). The curated dataset ships committed (`config/translation_backlog_seed.json`, generated by `scripts/build_translation_backlog_seed.php`) so prod seeds the same rows without the raw crawl.

**Seeded in dev (in-memory): 282 rows — governance-nav 243, global-ui 21, other 18.** 3 Anishinaabemowin terms excluded: Niigaaniin, Anishinaabemowin, Aanii.

## Tests / gates
`BacklogRuleSet` (drop/global-ui/Ojibwe/category/concept), `BacklogBuilder` (>=2 floor, exclusion logging, ranking), `TmBacklog` round-trip + defaults, policy admin-only, seeder idempotency + board ranking/grouping. **MinooUnit 525** (2 env skips), **MinooIntegration 133**, **phpstan** level 5, **schema:check** — all green.

No prod deploy; no public route; no em dashes.