### PR TITLE
fix(#908): bind AnthropicProvider for corpus vision when ANTHROPIC_API_KEY is set

### DIFF
--- a/src/Language/Vision/LlmProviderFactory.php
+++ b/src/Language/Vision/LlmProviderFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language\Vision;
+
+use Waaseyaa\AI\Agent\Provider\AnthropicProvider;
+use Waaseyaa\AI\Agent\Provider\NullLlmProvider;
+use Waaseyaa\AI\Agent\Provider\ProviderInterface;
+
+/**
+ * Chooses the LLM provider for the corpus vision step (issue #908).
+ *
+ * The whiteboard reader ({@see \App\Ingestion\Corpus\LlmWhiteboardReader}, run by
+ * `anokii:process-reels` and `ingest:corpus`) resolves the framework
+ * `ProviderInterface`, which defaults to {@see NullLlmProvider}. Minoo
+ * deliberately does NOT register Anokii's `CoIntelligenceServiceProvider` (it
+ * would pull in graph entity types, RAG chat routes, and single-admin auth), and
+ * that provider is the only thing that otherwise rebinds the provider to
+ * Anthropic. So without a binding the vision step always gets the null provider
+ * and every upload drafts blank with `notes=vision_unavailable`.
+ *
+ * This factory is the narrow replacement: a real {@see AnthropicProvider} when a
+ * server-side `ANTHROPIC_API_KEY` is configured, and the framework default
+ * otherwise, so local dev and CI (no key) behave exactly as before.
+ */
+final class LlmProviderFactory
+{
+    /** Vision-capable, cost-appropriate model (matches the Anokii CoIntelligence default). */
+    public const string MODEL = 'claude-sonnet-4-6';
+
+    public static function make(?string $apiKey, string $model = self::MODEL): ProviderInterface
+    {
+        $apiKey = $apiKey !== null ? trim($apiKey) : '';
+
+        return $apiKey !== ''
+            ? new AnthropicProvider($apiKey, $model)
+            : new NullLlmProvider();
+    }
+}

--- a/src/Provider/AppCommandServiceProvider.php
+++ b/src/Provider/AppCommandServiceProvider.php
@@ -14,6 +14,7 @@ use App\Ingestion\Corpus\FfmpegReelFetcher;
 use App\Ingestion\Corpus\LlmWhiteboardReader;
 use App\Ingestion\Corpus\LocalFileReelFetcher;
 use App\Ingestion\Corpus\ReelProcessor;
+use App\Language\Vision\LlmProviderFactory;
 use App\Seed\TranslationBacklogSeeder;
 use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\CLI\Command\HandlerArgument;
@@ -34,6 +35,17 @@ class AppCommandServiceProvider extends AppCoreServiceProvider implements Provid
     public function register(): void
     {
         parent::register();
+
+        // Bind the corpus vision LLM provider (#908). The framework defaults
+        // ProviderInterface to NullLlmProvider; since Minoo does not register
+        // Anokii's CoIntelligenceServiceProvider, nothing else rebinds it. This
+        // gives the whiteboard reader a real Anthropic provider when a server-side
+        // ANTHROPIC_API_KEY is set, and leaves the framework default otherwise
+        // (so CI / keyless local dev is unchanged).
+        $this->singleton(
+            ProviderInterface::class,
+            static fn (): ProviderInterface => LlmProviderFactory::make(getenv('ANTHROPIC_API_KEY') ?: null),
+        );
 
         $this->singleton(MailTestHandler::class, function (): MailTestHandler {
             [$configured, $fromAddress] = $this->mailConfigSnapshot();

--- a/tests/App/Unit/Language/Vision/LlmProviderFactoryTest.php
+++ b/tests/App/Unit/Language/Vision/LlmProviderFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Language\Vision;
+
+use App\Language\Vision\LlmProviderFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\AI\Agent\Provider\AnthropicProvider;
+use Waaseyaa\AI\Agent\Provider\NullLlmProvider;
+
+#[CoversClass(LlmProviderFactory::class)]
+final class LlmProviderFactoryTest extends TestCase
+{
+    #[Test]
+    public function a_configured_key_selects_the_real_anthropic_provider(): void
+    {
+        self::assertInstanceOf(AnthropicProvider::class, LlmProviderFactory::make('sk-ant-test-key'));
+    }
+
+    #[Test]
+    public function no_key_falls_back_to_the_framework_null_provider(): void
+    {
+        self::assertInstanceOf(NullLlmProvider::class, LlmProviderFactory::make(null));
+    }
+
+    #[Test]
+    public function an_empty_or_whitespace_key_is_treated_as_unset(): void
+    {
+        self::assertInstanceOf(NullLlmProvider::class, LlmProviderFactory::make(''));
+        self::assertInstanceOf(NullLlmProvider::class, LlmProviderFactory::make('   '));
+    }
+}


### PR DESCRIPTION
Closes #908. Milestone #70.

The corpus vision step (`LlmWhiteboardReader`, run by `anokii:process-reels` / `ingest:corpus`) resolves the framework `ProviderInterface`, which defaults to `NullLlmProvider`. Minoo deliberately does **not** register Anokii's `CoIntelligenceServiceProvider` (avoids its graph entity types, RAG chat routes, single-admin auth), and that provider is the only thing that otherwise rebinds the provider to Anthropic. So even with `ANTHROPIC_API_KEY` set, vision got the null provider and every upload drafted blank with `notes=vision_unavailable`.

**Narrow fix:** `App\Language\Vision\LlmProviderFactory` returns a real `AnthropicProvider(claude-sonnet-4-6)` when a server-side `ANTHROPIC_API_KEY` is configured, else the framework default. `AppCommandServiceProvider` binds `ProviderInterface` through it. No key (CI / keyless local dev) behaves exactly as before, so existing tests are unaffected.

**Proven on prod** against a real extracted whiteboard keyframe: the model reads ojibwe + english correctly — only the binding was missing.

Tests: `LlmProviderFactoryTest` (key -> Anthropic; null/empty/whitespace -> Null). MinooUnit 528 (2 env skips), MinooIntegration 133, phpstan level 5, cs-fixer clean. No public surface; no em dashes.