### PR TITLE
fix(#910): published corpus item now surfaces in the public Dictionary

### DIFF
--- a/src/Http/Controller/Anokii/CurateController.php
+++ b/src/Http/Controller/Anokii/CurateController.php
@@ -117,25 +117,43 @@ final class CurateController
             return $this->json(['ok' => false, 'error' => 'Not found.'], 404);
         }
 
+        // A published word must have a public dictionary_entry or it surfaces
+        // nowhere (#910). Auto-promote when it was not curated first; a row with
+        // no Anishinaabemowin word cannot become a dictionary entry, so refuse
+        // rather than publish into the void.
+        $deid = (int) ($sentence->get('dictionary_entry_id') ?? 0);
+        if ($deid === 0) {
+            if (trim((string) $sentence->get('ojibwe_text')) === '') {
+                return $this->json(['ok' => false, 'error' => 'Add the Anishinaabemowin word before publishing.'], 422);
+            }
+            $promotion = (new UtterancePromoter($this->entityTypeManager))->promote($esid);
+            if ($promotion === null) {
+                return $this->json(['ok' => false, 'error' => 'Could not promote this utterance to a dictionary entry.'], 422);
+            }
+            $deid = $promotion->dictionaryEntryId;
+            // promote() mutated and saved the row; reload before publishing.
+            $sentence = $sentences->load($esid);
+            if (!$sentence instanceof EntityInterface) {
+                return $this->json(['ok' => false, 'error' => 'Not found.'], 404);
+            }
+        }
+
         $now = time();
         $this->publishEntity($sentence);
         $sentence->set('pipeline_status', PipelineStage::PUBLISHED);
         $sentence->set('updated_at', $now);
         $sentences->save($sentence);
 
-        // Publish the linked dictionary_entry too, so the word goes live.
-        $deid = (int) ($sentence->get('dictionary_entry_id') ?? 0);
-        if ($deid > 0) {
-            $entries = $this->entityTypeManager->getStorage('dictionary_entry');
-            $entry = $entries->load($deid);
-            if ($entry instanceof EntityInterface) {
-                $this->publishEntity($entry);
-                $entry->set('updated_at', $now);
-                $entries->save($entry);
-            }
+        // Publish the dictionary_entry too, so the word goes live in the Dictionary.
+        $entries = $this->entityTypeManager->getStorage('dictionary_entry');
+        $entry = $entries->load($deid);
+        if ($entry instanceof EntityInterface) {
+            $this->publishEntity($entry);
+            $entry->set('updated_at', $now);
+            $entries->save($entry);
         }
 
-        return $this->json(['ok' => true, 'esid' => $esid, 'pipeline_status' => PipelineStage::PUBLISHED]);
+        return $this->json(['ok' => true, 'esid' => $esid, 'dictionary_entry_id' => $deid, 'pipeline_status' => PipelineStage::PUBLISHED]);
     }
 
     /**

--- a/src/Ingestion/Curation/UtterancePromoter.php
+++ b/src/Ingestion/Curation/UtterancePromoter.php
@@ -54,7 +54,13 @@ final class UtterancePromoter
             // Verbatim — never normalized (ADR 0003).
             'word' => $word,
             'slug' => $this->slugify($word),
-            'definition' => $definition,
+            // JSON-wrapped to match every other dictionary_entry (e.g. ["spoon"]):
+            // the public Dictionary browse filters `definition LIKE '%"%'` and the
+            // detail view json_decodes it (#910). A raw string would be invisible
+            // in the browse and mis-render on the word page.
+            'definition' => $definition !== ''
+                ? (string) json_encode([$definition], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : '[]',
             'language_code' => 'oj',
             'source_url' => $sourceUrl,
             'attribution_source' => 'corpus',

--- a/tests/App/Integration/Http/Admin/AnokiiCurateTest.php
+++ b/tests/App/Integration/Http/Admin/AnokiiCurateTest.php
@@ -81,7 +81,10 @@ final class AnokiiCurateTest extends HttpKernelTestCase
         $entry = $etm->getStorage('dictionary_entry')->load($result->dictionaryEntryId);
         self::assertNotNull($entry);
         self::assertSame('Shoogan Mookman', (string) $entry->get('word'), 'Ojibwe stored verbatim.');
-        self::assertSame('butter knife', (string) $entry->get('definition'));
+        // JSON-wrapped like every other dictionary_entry, so the public Dictionary
+        // browse (definition LIKE '%"%') includes it and the detail view decodes it (#910).
+        self::assertSame('["butter knife"]', (string) $entry->get('definition'));
+        self::assertStringContainsString('"', (string) $entry->get('definition'), 'Passes the Dictionary browse filter.');
         // Consent + publication copied from the source sentence.
         self::assertSame(1, (int) $entry->get('consent_public'));
         self::assertSame(1, (int) $entry->get('status'));
@@ -155,6 +158,78 @@ final class AnokiiCurateTest extends HttpKernelTestCase
         self::assertTrue($payload['ok'] ?? false);
         self::assertGreaterThan(0, (int) ($payload['dictionary_entry_id'] ?? 0));
         self::assertSame((int) $payload['dictionary_entry_id'], (int) $sentences->load($esid)->get('dictionary_entry_id'));
+    }
+
+    #[Test]
+    public function publish_auto_promotes_and_makes_a_public_dictionary_entry(): void
+    {
+        $etm = self::$kernel->getEntityTypeManager();
+        $sentences = $etm->getStorage('example_sentence');
+        // Transcribed but NOT promoted (deid 0), not yet public.
+        $row = $sentences->create([
+            'ojibwe_text' => 'Emkwaan',
+            'english_text' => 'spoon',
+            'source_sentence_id' => 'corpus:sb-c4',
+            'consent_public' => 0,
+            'status' => 0,
+            'pipeline_status' => 'transcribed',
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($row);
+        $esid = (int) $row->id();
+
+        $ok = $this->sendPost(self::$adminUid, '/admin/anokii/curate/publish', ['esid' => (string) $esid]);
+        self::assertSame(Response::HTTP_OK, $ok->getStatusCode());
+        $payload = json_decode((string) $ok->getContent(), true);
+        self::assertTrue($payload['ok'] ?? false);
+        $deid = (int) ($payload['dictionary_entry_id'] ?? 0);
+        self::assertGreaterThan(0, $deid, 'Publish auto-promotes so a dictionary_entry exists.');
+
+        // The sentence is published and linked.
+        $sentence = $sentences->load($esid);
+        self::assertSame('published', (string) $sentence->get('pipeline_status'));
+        self::assertSame($deid, (int) $sentence->get('dictionary_entry_id'));
+
+        // The dictionary_entry is exactly what the public Dictionary browse selects:
+        // status 1, consent_public 1, JSON-wrapped definition (contains a quote).
+        $entries = $etm->getStorage('dictionary_entry');
+        $entry = $entries->load($deid);
+        self::assertSame(1, (int) $entry->get('status'));
+        self::assertSame(1, (int) $entry->get('consent_public'));
+        self::assertSame('["spoon"]', (string) $entry->get('definition'));
+
+        $browse = $entries->getQuery()->accessCheck(false)
+            ->condition('status', 1)->condition('consent_public', 1)
+            ->condition('definition', '%"%', 'LIKE')
+            ->condition('slug', (string) $entry->get('slug'))
+            ->execute();
+        self::assertContains($deid, array_map('intval', $browse), 'Published word appears in the public Dictionary browse.');
+    }
+
+    #[Test]
+    public function publish_refuses_a_word_with_no_anishinaabemowin(): void
+    {
+        $sentences = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $row = $sentences->create([
+            'ojibwe_text' => '',
+            'english_text' => 'open',
+            'source_sentence_id' => 'corpus:sb-c5',
+            'status' => 0,
+            'pipeline_status' => 'drafted',
+            'created_at' => time(),
+            'updated_at' => time(),
+        ]);
+        $sentences->save($row);
+        $esid = (int) $row->id();
+
+        $res = $this->sendPost(self::$adminUid, '/admin/anokii/curate/publish', ['esid' => (string) $esid]);
+        self::assertSame(422, $res->getStatusCode(), 'Cannot publish a word with no Anishinaabemowin into the void.');
+        self::assertStringContainsString('Anishinaabemowin', (string) $res->getContent());
+        // Unchanged: not published, no entry.
+        $after = $sentences->load($esid);
+        self::assertNotSame('published', (string) $after->get('pipeline_status'));
+        self::assertSame(0, (int) $after->get('dictionary_entry_id'));
     }
 
     private function sendAs(int $uid, string $method, string $uri): Response


### PR DESCRIPTION
Closes #910.

A curated corpus utterance published from the admin was meant to go live in the public Dictionary (`/language`) but appeared nowhere. **Two bugs** in curate -> publish -> public:

1. **Raw definition.** `UtterancePromoter` wrote `definition = english_text` (e.g. `spoon`), but dictionary_entries store definitions JSON-wrapped (`["spoon"]`) and the public Dictionary browse filters `definition LIKE '%\"%'`. So a promoted entry was excluded from the browse and mis-rendered on detail (json_decode). **Fixed: JSON-wrap.**
2. **Publish without a dictionary_entry.** `publish` only published an entry when `deid>0`; it never created one, yet the UI shows Publish on un-promoted rows. So an item reached `pipeline_status=published` with no entry and surfaced nowhere (prod **esid 35**: published, deid 0). **Fixed: publish auto-promotes** when not yet curated, and refuses (clear message) a row with no Anishinaabemowin word.

Net: clicking **Publish** on a transcribed corpus word now creates a published, JSON-wrapped, public `dictionary_entry` visible in the Dictionary + Search.

**Out of scope — product decision (reported, not built):** lessons are hardcoded `config/lesson1.php` (fixed sb-NNN list) and the `lesson_slug` 'Add to lesson' field is ignored by the renderer; surfacing published items in a *lesson* needs a product call.

Tests: `AnokiiCurateTest` updated (definition now JSON-wrapped) + publish auto-promotes-and-appears-in-Dictionary-browse + publish refuses a wordless item. MinooUnit 528 (2 env skips), MinooIntegration 135, phpstan level 5, cs-fixer clean. No public route added; no em dashes.