### PR TITLE
feat(#912): dynamic lessons — render published/curated entries by lesson_slug

### DIFF
--- a/config/lesson1.php
+++ b/config/lesson1.php
@@ -3,59 +3,20 @@
 declare(strict_types=1);
 
 /**
- * Lesson 1: Kitchen. Curation metadata ONLY.
+ * Lesson 1: Kitchen - metadata only (#912).
  *
- * This file holds the presentation order, section groupings, and the
- * human-reviewed English glosses from
- * research/elder-and-teacher-input/steven-lesson-1-review.md (Steven Bennett's
- * Lesson 1 review). It is safe to commit: it contains no Anishinaabemowin and
- * no audio or whiteboard media.
+ * Lessons are now dynamic: the cards are the published, public, curated corpus
+ * rows assigned to this lesson's slug (lesson_slug = 'the-kitchen'), grouped by
+ * lesson_group and ordered by lesson_weight, rendered by {@see App\Lesson\LessonAssembler}.
+ * The Anishinaabemowin is read verbatim from the corpus at runtime; the English
+ * is the curated dictionary_entry gloss. This file holds no item list, no
+ * Anishinaabemowin, and no media.
  *
- * The Anishinaabemowin for each card is read at runtime, verbatim, from the
- * migrated corpus (example_sentence rows keyed by source_sentence_id
- * "corpus:<id>"), so the community-controlled orthography is never committed to
- * this repository and is never altered. Audio and whiteboard thumbnails are
- * streamed from the corpus directory by LessonController::media().
+ * The 16 original kitchen cards were migrated into the dynamic model (the
+ * human-reviewed glosses from research/elder-and-teacher-input/steven-lesson-1-review.md
+ * became their dictionary_entry definitions) so the page renders unchanged.
  */
 return [
     'title' => 'Lesson 1: Kitchen',
     'slug' => 'the-kitchen',
-    'groups' => [
-        [
-            'label' => 'Dishes and containers',
-            'items' => [
-                ['id' => 'sb-005', 'english' => 'bowl'],
-                ['id' => 'sb-017', 'english' => 'soup bowl'],
-                ['id' => 'sb-020', 'english' => 'plate'],
-                ['id' => 'sb-006', 'english' => 'cup, glass'],
-            ],
-        ],
-        [
-            'label' => 'Utensils',
-            'items' => [
-                ['id' => 'sb-028', 'english' => 'spoon'],
-                ['id' => 'sb-027', 'english' => 'knife'],
-                ['id' => 'sb-001', 'english' => 'butter knife'],
-                ['id' => 'sb-016', 'english' => 'fork'],
-                ['id' => 'sb-019', 'english' => 'dipper'],
-            ],
-        ],
-        [
-            'label' => 'Cookware',
-            'items' => [
-                ['id' => 'sb-003', 'english' => 'pot'],
-                ['id' => 'sb-031', 'english' => 'cooking pot'],
-                ['id' => 'sb-033', 'english' => 'frying pan'],
-            ],
-        ],
-        [
-            'label' => 'Furniture and appliances',
-            'items' => [
-                ['id' => 'sb-022', 'english' => 'table'],
-                ['id' => 'sb-009', 'english' => 'cupboard'],
-                ['id' => 'sb-011', 'english' => 'stove'],
-                ['id' => 'sb-015', 'english' => 'refrigerator'],
-            ],
-        ],
-    ],
 ];

--- a/scripts/migrate_kitchen_to_dynamic.php
+++ b/scripts/migrate_kitchen_to_dynamic.php
@@ -1,0 +1,104 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * One-off prod data migration (#912): move the 16 hardcoded Lesson 1 (Kitchen)
+ * items into the dynamic lesson model so /lessons/the-kitchen renders unchanged.
+ *
+ * For each kitchen corpus row it: promotes it to a dictionary_entry (verbatim
+ * Ojibwe), overrides the definition with the human-reviewed config gloss
+ * (so "stoue"->"stove", "pot or pail"->"pot", case fixes), publishes both
+ * entities (status + consent_public = 1, pipeline_status = published), and
+ * assigns lesson_slug=the-kitchen with the section label + order.
+ *
+ * Idempotent: re-running re-asserts the same state. Boots HttpKernel via
+ * reflection (prod ConsoleKernel is broken #493).
+ *
+ * Run: php scripts/migrate_kitchen_to_dynamic.php
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use App\Ingestion\Curation\UtterancePromoter;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+// [corpus id, curated English gloss, section label, order] - from config/lesson1.php.
+$kitchen = [
+    ['sb-005', 'bowl', 'Dishes and containers', 0],
+    ['sb-017', 'soup bowl', 'Dishes and containers', 1],
+    ['sb-020', 'plate', 'Dishes and containers', 2],
+    ['sb-006', 'cup, glass', 'Dishes and containers', 3],
+    ['sb-028', 'spoon', 'Utensils', 4],
+    ['sb-027', 'knife', 'Utensils', 5],
+    ['sb-001', 'butter knife', 'Utensils', 6],
+    ['sb-016', 'fork', 'Utensils', 7],
+    ['sb-019', 'dipper', 'Utensils', 8],
+    ['sb-003', 'pot', 'Cookware', 9],
+    ['sb-031', 'cooking pot', 'Cookware', 10],
+    ['sb-033', 'frying pan', 'Cookware', 11],
+    ['sb-022', 'table', 'Furniture and appliances', 12],
+    ['sb-009', 'cupboard', 'Furniture and appliances', 13],
+    ['sb-011', 'stove', 'Furniture and appliances', 14],
+    ['sb-015', 'refrigerator', 'Furniture and appliances', 15],
+];
+
+$kernel = new HttpKernel('/app');
+(new ReflectionMethod(AbstractKernel::class, 'boot'))->invoke($kernel);
+$etm = $kernel->getEntityTypeManager();
+$es = $etm->getStorage('example_sentence');
+$de = $etm->getStorage('dictionary_entry');
+$promoter = new UtterancePromoter($etm);
+
+// Index existing corpus rows by id.
+$byId = [];
+foreach ($es->loadMultiple($es->getQuery()->accessCheck(false)->condition('source_sentence_id', 'corpus:sb-%', 'LIKE')->execute()) as $row) {
+    $byId[str_replace('corpus:', '', (string) $row->get('source_sentence_id'))] = $row;
+}
+
+$now = time();
+$done = 0;
+$missing = [];
+foreach ($kitchen as [$id, $gloss, $group, $weight]) {
+    $row = $byId[$id] ?? null;
+    if ($row === null) {
+        $missing[] = $id;
+        continue;
+    }
+    $esid = (int) $row->id();
+
+    // Promote (idempotent) -> dictionary_entry with verbatim Ojibwe word.
+    $promotion = $promoter->promote($esid);
+    if ($promotion === null) {
+        $missing[] = "$id (no ojibwe?)";
+        continue;
+    }
+    $deid = $promotion->dictionaryEntryId;
+
+    // Curated gloss as the JSON-wrapped definition; publish the entry.
+    $entry = $de->load($deid);
+    $entry->set('definition', (string) json_encode([$gloss], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    $entry->set('status', 1);
+    $entry->set('consent_public', 1);
+    $entry->set('updated_at', $now);
+    $de->save($entry);
+
+    // Publish + assign the source row to the lesson.
+    $row = $es->load($esid);
+    $row->set('status', 1);
+    $row->set('consent_public', 1);
+    $row->set('pipeline_status', 'published');
+    $row->set('lesson_slug', 'the-kitchen');
+    $row->set('lesson_group', $group);
+    $row->set('lesson_weight', $weight);
+    $row->set('updated_at', $now);
+    $es->save($row);
+    ++$done;
+}
+
+echo "kitchen migrated: $done / " . count($kitchen) . "\n";
+if ($missing !== []) {
+    echo 'MISSING: ' . implode(', ', $missing) . "\n";
+}

--- a/src/Http/Controller/Lesson/LessonController.php
+++ b/src/Http/Controller/Lesson/LessonController.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controller\Lesson;
 
 use App\Http\View\LayoutTwigContext;
+use App\Lesson\LessonAssembler;
 use App\Lesson\LessonCatalog;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
-use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\SSR\Attribute\MapQuery;
 use Waaseyaa\SSR\Attribute\MapRoute;
@@ -45,6 +45,7 @@ final class LessonController
     /** Landing: the list of available lessons. */
     public function index(#[MapRoute] array $params, #[MapQuery] array $query, AccountInterface $account, HttpRequest $request): Response
     {
+        $assembler = new LessonAssembler($this->entityTypeManager);
         $lessons = [];
         foreach ($this->lessons() as $lesson) {
             $def = $this->lessonDefinition($lesson['config']);
@@ -53,7 +54,7 @@ final class LessonController
                 'title' => $def['title'],
                 'slug' => $lesson['slug'],
                 'url' => '/lessons/' . $lesson['slug'],
-                'count' => $this->lessonItemCount($def),
+                'count' => $assembler->assemble($lesson['slug'])['total'],
             ];
         }
 
@@ -79,44 +80,17 @@ final class LessonController
         }
 
         $def = $this->lessonDefinition($lesson['config']);
-        $corpus = $this->corpusRowsBySourceId();
-
-        $groups = [];
-        $total = 0;
-        foreach ($def['groups'] as $group) {
-            $items = [];
-            foreach ($group['items'] as $item) {
-                $row = $corpus['corpus:' . $item['id']] ?? null;
-                if (!$row instanceof EntityInterface) {
-                    // Corpus row not present: skip rather than invent a card.
-                    continue;
-                }
-                // Steven's teaching reel, when a web-optimized video exists for
-                // this row (#873). Cards without one fall back to thumb + audio.
-                $hasVideo = (string) ($row->get('video_url') ?? '') !== '';
-                $items[] = [
-                    'id' => $item['id'],
-                    // Anishinaabemowin, verbatim from the migrated corpus. Never altered.
-                    'ojibwe' => (string) $row->get('ojibwe_text'),
-                    'english' => $item['english'],
-                    'thumb' => '/lesson/media/thumb/' . $item['id'],
-                    'audio' => '/lesson/media/audio/' . $item['id'],
-                    'video' => $hasVideo ? '/lessons/media/video/' . $item['id'] : null,
-                    'source_url' => (string) $row->get('source_url'),
-                ];
-                ++$total;
-            }
-            if ($items !== []) {
-                $groups[] = ['label' => $group['label'], 'items' => $items];
-            }
-        }
+        // Cards come from the corpus rows ASSIGNED to this lesson (published,
+        // public, curated), grouped + ordered dynamically (#912). "Add to lesson"
+        // now actually surfaces a word here.
+        $assembled = (new LessonAssembler($this->entityTypeManager))->assemble($lesson['slug']);
 
         $html = $this->twig->render('pages/lesson/lesson1.html.twig', LayoutTwigContext::withAccount($account, [
             'path' => '/lessons/' . $lesson['slug'],
             'lesson_title' => $def['title'],
             'lesson_slug' => $lesson['slug'],
-            'groups' => $groups,
-            'total' => $total,
+            'groups' => $assembled['groups'],
+            'total' => $assembled['total'],
             'steven_url' => self::STEVEN_PROFILE_URL,
         ]));
 
@@ -151,28 +125,6 @@ final class LessonController
         ]);
     }
 
-    /** @return array<string, EntityInterface> keyed by source_sentence_id */
-    private function corpusRowsBySourceId(): array
-    {
-        $storage = $this->entityTypeManager->getStorage('example_sentence');
-        // Public surface: only published, consent-public corpus rows. Guard the
-        // empty set so loadMultiple([]) cannot dump the whole table.
-        $ids = $storage->getQuery()->accessCheck(false)
-            ->condition('status', 1)
-            ->condition('consent_public', 1)
-            ->execute();
-        if ($ids === []) {
-            return [];
-        }
-
-        $rows = [];
-        foreach ($storage->loadMultiple($ids) as $entity) {
-            $rows[(string) $entity->get('source_sentence_id')] = $entity;
-        }
-
-        return $rows;
-    }
-
     /**
      * The lesson registry, from the shared catalogue ({@see LessonCatalog}) so
      * the Anokii Curate "add to a lesson" action reads the same slugs.
@@ -197,42 +149,27 @@ final class LessonController
     }
 
     /**
-     * @param array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>} $def
-     */
-    private function lessonItemCount(array $def): int
-    {
-        $count = 0;
-        foreach ($def['groups'] as $group) {
-            $count += count($group['items']);
-        }
-
-        return $count;
-    }
-
-    /**
-     * @return array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>}
+     * Lesson metadata only (title + slug); items are dynamic now (#912).
+     *
+     * @return array{title: string, slug: string}
      */
     private function lessonDefinition(string $configFile): array
     {
-        /** @var array{title: string, groups: list<array{label: string, items: list<array{id: string, english: string}>}>} $def */
+        /** @var array{title: string, slug: string} $def */
         $def = require dirname(__DIR__, 4) . '/config/' . $configFile;
 
         return $def;
     }
 
-    /** Every lesson item id across all lessons (the media route's allowlist). @return list<string> */
+    /**
+     * Corpus ids servable through the lesson media endpoint: every published,
+     * public, curated row assigned to a known lesson (#912).
+     *
+     * @return list<string>
+     */
     private function allowedIds(): array
     {
-        $ids = [];
-        foreach ($this->lessons() as $lesson) {
-            foreach ($this->lessonDefinition($lesson['config'])['groups'] as $group) {
-                foreach ($group['items'] as $item) {
-                    $ids[] = $item['id'];
-                }
-            }
-        }
-
-        return $ids;
+        return (new LessonAssembler($this->entityTypeManager))->allowedMediaIds(LessonCatalog::slugs());
     }
 
     private function corpusPath(): string

--- a/src/Lesson/LessonAssembler.php
+++ b/src/Lesson/LessonAssembler.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lesson;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * Assembles a lesson page dynamically from the corpus (#912).
+ *
+ * A lesson renders the `example_sentence` rows assigned to its `lesson_slug`
+ * that are published, consent-public, and curated (have a `dictionary_entry`),
+ * grouped by `lesson_group` and ordered by `lesson_weight`. The Anishinaabemowin
+ * is read verbatim from each row; the English is the curated gloss from the
+ * linked `dictionary_entry` definition. Drafts / rough data never appear because
+ * the gate requires status=1, consent_public=1, and a dictionary_entry.
+ *
+ * The card shape matches `templates/pages/lesson/lesson1.html.twig`, so the
+ * renderer is unchanged. Replaces the old hardcoded config/lessonN.php item
+ * lists (which now hold only {title, slug}).
+ */
+final class LessonAssembler
+{
+    private const string MEDIA_THUMB = '/lesson/media/thumb/';
+    private const string MEDIA_AUDIO = '/lesson/media/audio/';
+    private const string MEDIA_VIDEO = '/lessons/media/video/';
+
+    /** Heading for cards added to a lesson without a section label. */
+    private const string DEFAULT_GROUP = 'More words';
+
+    public function __construct(private readonly EntityTypeManager $entityTypeManager)
+    {
+    }
+
+    /**
+     * @return array{groups: list<array{label: string, items: list<array{id: string, ojibwe: string, english: string, thumb: string, audio: string, video: string|null, source_url: string}>}>, total: int}
+     */
+    public function assemble(string $slug): array
+    {
+        $rows = $this->assignedRows($slug);
+        if ($rows === []) {
+            return ['groups' => [], 'total' => 0];
+        }
+
+        $entries = $this->entityTypeManager->getStorage('dictionary_entry');
+        $cards = [];
+        foreach ($rows as $row) {
+            $deid = (int) ($row->get('dictionary_entry_id') ?? 0);
+            $entry = $deid > 0 ? $entries->load($deid) : null;
+            if (!$entry instanceof EntityInterface) {
+                continue; // curated gate already required deid>0; defensive.
+            }
+            $id = str_replace('corpus:', '', (string) $row->get('source_sentence_id'));
+            $hasVideo = trim((string) ($row->get('video_url') ?? '')) !== '';
+            $cards[] = [
+                '_group' => trim((string) ($row->get('lesson_group') ?? '')),
+                '_weight' => (int) ($row->get('lesson_weight') ?? 0),
+                '_esid' => (int) $row->id(),
+                'id' => $id,
+                // Verbatim corpus Anishinaabemowin (ADR 0003), never altered.
+                'ojibwe' => (string) $row->get('ojibwe_text'),
+                'english' => $this->gloss((string) $entry->get('definition')),
+                'thumb' => self::MEDIA_THUMB . $id,
+                'audio' => self::MEDIA_AUDIO . $id,
+                'video' => $hasVideo ? self::MEDIA_VIDEO . $id : null,
+                'source_url' => (string) $row->get('source_url'),
+            ];
+        }
+
+        usort($cards, static fn (array $a, array $b): int => $a['_weight'] <=> $b['_weight'] ?: $a['_esid'] <=> $b['_esid']);
+
+        // Bucket consecutive (weight-ordered) cards into sections by label; a
+        // section appears at its lowest-weight card, so kitchen sections keep
+        // their config order.
+        $groups = [];
+        $byLabel = [];
+        foreach ($cards as $card) {
+            $label = $card['_group'] !== '' ? $card['_group'] : self::DEFAULT_GROUP;
+            unset($card['_group'], $card['_weight'], $card['_esid']);
+            if (!isset($byLabel[$label])) {
+                $byLabel[$label] = count($groups);
+                $groups[] = ['label' => $label, 'items' => []];
+            }
+            $groups[$byLabel[$label]]['items'][] = $card;
+        }
+
+        return ['groups' => $groups, 'total' => count($cards)];
+    }
+
+    /**
+     * Corpus media ids servable through the lesson media endpoint: every
+     * published+public+curated row assigned to a known lesson.
+     *
+     * @param list<string> $slugs
+     *
+     * @return list<string>
+     */
+    public function allowedMediaIds(array $slugs): array
+    {
+        $ids = [];
+        foreach ($slugs as $slug) {
+            foreach ($this->assignedRows($slug) as $row) {
+                $ids[] = str_replace('corpus:', '', (string) $row->get('source_sentence_id'));
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /** @return list<EntityInterface> */
+    private function assignedRows(string $slug): array
+    {
+        if ($slug === '') {
+            return [];
+        }
+        $storage = $this->entityTypeManager->getStorage('example_sentence');
+        // Public surface: only published, consent-public, curated rows assigned to
+        // this lesson. accessCheck(false) - the gate is status+consent, mirroring
+        // LessonController::corpusRowsBySourceId (see the bypass audit doc).
+        $ids = $storage->getQuery()->accessCheck(false)
+            ->condition('lesson_slug', $slug)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->condition('dictionary_entry_id', 0, '>')
+            ->execute();
+        if ($ids === []) {
+            return [];
+        }
+
+        return array_values($storage->loadMultiple($ids));
+    }
+
+    /** Decode a JSON-wrapped dictionary definition (e.g. ["cup, glass"]) to display text. */
+    private function gloss(string $definition): string
+    {
+        $decoded = json_decode($definition, true);
+        if (is_array($decoded)) {
+            return implode('; ', array_map(static fn (mixed $v): string => trim((string) $v), $decoded));
+        }
+
+        return trim($definition);
+    }
+}

--- a/src/Provider/Entity/EntityFoundationProvider.php
+++ b/src/Provider/Entity/EntityFoundationProvider.php
@@ -140,6 +140,11 @@ final class EntityFoundationProvider extends AppCoreServiceProvider
                 // Lessons are static config keyed by slug; this records the
                 // association set in the Curate tab. Lives in the _data blob.
                 'lesson_slug' => ['type' => 'string', 'label' => 'Lesson', 'description' => 'Slug of the lesson this utterance was curated into (e.g. the-kitchen).', 'weight' => 32],
+                // Dynamic lesson presentation (#912): a lesson renders its assigned,
+                // published+curated rows grouped by lesson_group and ordered by
+                // lesson_weight. Both live in the _data blob.
+                'lesson_group' => ['type' => 'string', 'label' => 'Lesson Section', 'description' => 'Section heading within the lesson (e.g. Utensils). Empty groups under a default heading.', 'weight' => 33],
+                'lesson_weight' => ['type' => 'integer', 'label' => 'Lesson Order', 'description' => 'Sort order within the lesson; lower first.', 'weight' => 34, 'default' => 0],
                 'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 40],
                 'updated_at' => ['type' => 'timestamp', 'label' => 'Updated', 'weight' => 41],
             ],

--- a/tests/App/Integration/Http/Language/DynamicLessonTest.php
+++ b/tests/App/Integration/Http/Language/DynamicLessonTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http\Language;
+
+use App\Tests\Integration\Http\HttpKernelTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Dynamic lessons (#912): /lessons/{slug} renders the published, public, curated
+ * example_sentence rows assigned to its lesson_slug - English from the curated
+ * dictionary_entry definition, grouped by lesson_group. Drafts / uncurated /
+ * unpublished assigned rows never appear.
+ */
+#[CoversNothing]
+final class DynamicLessonTest extends HttpKernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        $etm = self::$kernel->getEntityTypeManager();
+        $es = $etm->getStorage('example_sentence');
+        $de = $etm->getStorage('dictionary_entry');
+
+        // Curated definition deliberately DIFFERS from the raw english_text, to
+        // prove the lesson English comes from the curated dictionary_entry.
+        $entry = $de->create(['word' => 'Emkwaan', 'slug' => 'emkwaan', 'definition' => '["spoon"]', 'status' => 1, 'consent_public' => 1, 'created_at' => time(), 'updated_at' => time()]);
+        $de->save($entry);
+        $es->save($es->create([
+            'ojibwe_text' => 'Emkwaan', 'english_text' => 'spooon-raw-typo', 'source_sentence_id' => 'corpus:dyn-1',
+            'dictionary_entry_id' => (int) $entry->id(), 'lesson_slug' => 'the-kitchen', 'lesson_group' => 'Utensils',
+            'lesson_weight' => 5, 'status' => 1, 'consent_public' => 1, 'created_at' => time(), 'updated_at' => time(),
+        ]));
+
+        // Assigned + curated but UNPUBLISHED (status 0) -> must not appear.
+        $draftEntry = $de->create(['word' => 'Nokomis', 'slug' => 'nokomis-d', 'definition' => '["grandmother"]', 'status' => 0, 'consent_public' => 0, 'created_at' => time(), 'updated_at' => time()]);
+        $de->save($draftEntry);
+        $es->save($es->create([
+            'ojibwe_text' => 'DRAFTOJIBWE', 'english_text' => 'draft', 'source_sentence_id' => 'corpus:dyn-2',
+            'dictionary_entry_id' => (int) $draftEntry->id(), 'lesson_slug' => 'the-kitchen', 'lesson_group' => 'Utensils',
+            'lesson_weight' => 6, 'status' => 0, 'consent_public' => 0, 'created_at' => time(), 'updated_at' => time(),
+        ]));
+
+        // Assigned + published but NOT curated (no dictionary_entry) -> must not appear.
+        $es->save($es->create([
+            'ojibwe_text' => 'UNCURATEDOJIBWE', 'english_text' => 'uncurated', 'source_sentence_id' => 'corpus:dyn-3',
+            'lesson_slug' => 'the-kitchen', 'lesson_group' => 'Utensils', 'lesson_weight' => 7,
+            'status' => 1, 'consent_public' => 1, 'created_at' => time(), 'updated_at' => time(),
+        ]));
+    }
+
+    #[Test]
+    public function a_published_curated_assigned_word_appears_with_its_curated_gloss(): void
+    {
+        $body = (string) $this->send('GET', '/lessons/the-kitchen')->getContent();
+
+        self::assertStringContainsString('Emkwaan', $body, 'Verbatim Ojibwe renders.');
+        self::assertStringContainsString('spoon', $body, 'English is the curated dictionary gloss.');
+        self::assertStringNotContainsString('spooon-raw-typo', $body, 'Not the raw english_text.');
+        self::assertStringContainsString('Utensils', $body, 'Section heading renders.');
+    }
+
+    #[Test]
+    public function drafts_and_uncurated_assignments_never_appear(): void
+    {
+        $body = (string) $this->send('GET', '/lessons/the-kitchen')->getContent();
+
+        self::assertStringNotContainsString('DRAFTOJIBWE', $body, 'Unpublished assigned row is hidden.');
+        self::assertStringNotContainsString('UNCURATEDOJIBWE', $body, 'Uncurated assigned row is hidden.');
+    }
+
+    #[Test]
+    public function the_lesson_index_counts_only_visible_cards(): void
+    {
+        $response = $this->send('GET', '/lessons');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        // Exactly one card is visible for the-kitchen in this :memory: fixture.
+        self::assertStringContainsString('/lessons/the-kitchen', (string) $response->getContent());
+    }
+}

--- a/tests/App/Integration/Http/Language/LessonVideoTest.php
+++ b/tests/App/Integration/Http/Language/LessonVideoTest.php
@@ -34,7 +34,16 @@ final class LessonVideoTest extends HttpKernelTestCase
         self::$previousCorpusPath = $prev === false ? null : $prev;
         putenv('MINOO_CORPUS_PATH=' . self::$corpusDir);
 
-        $storage = self::$kernel->getEntityTypeManager()->getStorage('example_sentence');
+        $etm = self::$kernel->getEntityTypeManager();
+        $storage = $etm->getStorage('example_sentence');
+        $entries = $etm->getStorage('dictionary_entry');
+
+        // Lessons are dynamic (#912): a card shows only when its row is published,
+        // public, curated (has a dictionary_entry) and assigned to the lesson.
+        $deBowl = $entries->create(['word' => 'bowl-oji', 'slug' => 'bowl-oji', 'definition' => '["bowl"]', 'status' => 1, 'consent_public' => 1, 'created_at' => time(), 'updated_at' => time()]);
+        $entries->save($deBowl);
+        $deSoup = $entries->create(['word' => 'soup-bowl-oji', 'slug' => 'soup-bowl-oji', 'definition' => '["soup bowl"]', 'status' => 1, 'consent_public' => 1, 'created_at' => time(), 'updated_at' => time()]);
+        $entries->save($deSoup);
 
         // Has a reel (Lesson 1 card).
         $withVideo = $storage->create([
@@ -44,6 +53,10 @@ final class LessonVideoTest extends HttpKernelTestCase
             'thumbnail_url' => '/media/corpus/thumb/sb-005',
             'audio_url' => '/media/corpus/audio/sb-005',
             'video_url' => '/media/corpus/video/sb-005',
+            'dictionary_entry_id' => (int) $deBowl->id(),
+            'lesson_slug' => 'the-kitchen',
+            'lesson_group' => 'Dishes and containers',
+            'lesson_weight' => 0,
             'consent_public' => 1,
             'status' => 1,
             'created_at' => time(),
@@ -59,6 +72,10 @@ final class LessonVideoTest extends HttpKernelTestCase
             'thumbnail_url' => '/media/corpus/thumb/sb-017',
             'audio_url' => '/media/corpus/audio/sb-017',
             'video_url' => '',
+            'dictionary_entry_id' => (int) $deSoup->id(),
+            'lesson_slug' => 'the-kitchen',
+            'lesson_group' => 'Dishes and containers',
+            'lesson_weight' => 1,
             'consent_public' => 1,
             'status' => 1,
             'created_at' => time(),

--- a/tests/App/Unit/Http/Controller/Lesson/LessonControllerTest.php
+++ b/tests/App/Unit/Http/Controller/Lesson/LessonControllerTest.php
@@ -13,22 +13,32 @@ use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
 
 /**
  * Security-focused tests for the public lesson media endpoint: the kind/id
- * path allowlist (only thumb|audio for the 16 Lesson 1 ids, no traversal).
- * These run before any filesystem access, so they need no corpus directory or
- * database.
+ * path allowlist (only thumb|audio for corpus ids actually assigned to a lesson,
+ * no traversal). The allowlist is now dynamic (#912), so the ETM is mocked to
+ * return an empty assigned set: every probed id is therefore rejected.
  */
 #[CoversClass(LessonController::class)]
 final class LessonControllerTest extends TestCase
 {
     private function controller(): LessonController
     {
-        return new LessonController(
-            $this->createMock(EntityTypeManager::class),
-            new Environment(new ArrayLoader([])),
-        );
+        // Dynamic allowlist queries example_sentence; mock the chain to return no
+        // assigned rows so the allowlist is empty (every id below is rejected).
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
+        $query->method('condition')->willReturnSelf();
+        $query->method('execute')->willReturn([]);
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getStorage')->willReturn($storage);
+
+        return new LessonController($etm, new Environment(new ArrayLoader([])));
     }
 
     private function account(bool $admin): AccountInterface


### PR DESCRIPTION
Closes #912.

Lessons were hardcoded (config/lessonN.php) and the curate **Add to lesson** (`lesson_slug`) action was ignored. Now a lesson page renders the corpus rows **assigned to its lesson_slug** that are **published, public, and curated** — so Add to lesson actually surfaces a word.

## How
- **`App\Lesson\LessonAssembler`**: queries `example_sentence WHERE lesson_slug=slug AND status=1 AND consent_public=1 AND dictionary_entry_id>0`, grouped by `lesson_group`, ordered by `lesson_weight`. Card = Ojibwe verbatim from the row, **English from the linked dictionary_entry's curated definition**, media from the corpus. Drafts/uncurated/unpublished never appear.
- New `example_sentence` fields `lesson_group`, `lesson_weight` (_data CLOB, no schema migration). `LessonController` (show/index/allowedIds) drives off the assembler; the media allowlist is the assigned set. `config/lesson1.php` reduced to `{title, slug}`.
- **`scripts/migrate_kitchen_to_dynamic.php`** (one-off prod data migration): promotes the 16 kitchen rows, sets each dictionary_entry definition to the **human-reviewed config gloss** (stoue→stove, pot or pail→pot, case fixes), publishes them, and assigns `lesson_slug=the-kitchen` + the 4 sections + order — so the page renders byte-identical.

## HARD REQUIREMENT
/lessons/the-kitchen stays exactly intact (16 cards, English + Ojibwe, 4 sections). Verified on the live site after deploy + migration (see report). A freshly-assigned published+curated word now appears in its lesson.

Tests: `DynamicLessonTest` (appears-with-curated-gloss; drafts/uncurated hidden), `LessonVideoTest` updated, `LessonControllerTest` allowlist mocked. MinooUnit 528 (2 skips), MinooIntegration 138, phpstan level 5, schema:check, cs-fixer clean. No em dashes.