### PR TITLE
compliance: OPD content under CC BY-NC-SA 3.0 across all surfaces (#914)

### DIFF
--- a/migrations/20260625_130000_mark_opd_license_and_dialect.php
+++ b/migrations/20260625_130000_mark_opd_license_and_dialect.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Mark the Ojibwe People's Dictionary rows with their licence and dialect (#914).
+ *
+ * The 21,721 dictionary_entry rows imported from the Ojibwe People's Dictionary
+ * (University of Minnesota) are licensed CC BY-NC-SA 3.0 and are Southwestern
+ * (Minnesota) Ojibwe. They were imported tagged plain 'oj' and with no licence
+ * field. This stamps:
+ *   - license       = "CC BY-NC-SA 3.0"  (so the ShareAlike obligation is
+ *                       recorded in the data and attaches only to OPD rows)
+ *   - language_code = "oj-sw"            (Southwestern Ojibwe; the UI then
+ *                       distinguishes them from Sagamok Nishnaabemwin)
+ *
+ * The match is the OPD fingerprint established in the audit: attribution_source
+ * begins "Ojibwe People" OR the attribution_url points at ojibwe.lib.umn.edu.
+ * Steven Bennett's Sagamok community corpus (attribution_source = 'corpus') is
+ * never touched: it is not OPD content, so it must NOT carry the BY-NC-SA
+ * licence or the Southwestern label. The corpus exclusion is stated explicitly
+ * as a belt-and-suspenders guard even though the corpus has no umn.edu URL.
+ *
+ * Values live in the _data JSON blob, so json_set is used. Idempotent: re-running
+ * sets the same values. No row is created or deleted.
+ */
+return new class () extends Migration {
+    private const OPD_MATCH =
+        "(json_extract(_data, '\$.attribution_source') LIKE 'Ojibwe People%'
+          OR json_extract(_data, '\$.attribution_url') LIKE '%ojibwe.lib.umn.edu%')
+         AND json_extract(_data, '\$.attribution_source') != 'corpus'";
+
+    public function up(SchemaBuilder $schema): void
+    {
+        $schema->getConnection()->executeStatement(
+            "UPDATE dictionary_entry
+             SET _data = json_set(_data, '\$.license', 'CC BY-NC-SA 3.0', '\$.language_code', 'oj-sw')
+             WHERE " . self::OPD_MATCH,
+        );
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // Drop the licence marker and restore the original plain 'oj' tag.
+        $schema->getConnection()->executeStatement(
+            "UPDATE dictionary_entry
+             SET _data = json_set(json_remove(_data, '\$.license'), '\$.language_code', 'oj')
+             WHERE " . self::OPD_MATCH,
+        );
+    }
+};

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -315,7 +315,8 @@ return [
     'language.empty_heading' => 'No dictionary entries yet',
     'language.empty_body' => 'Anishinaabemowin words, meanings, and example sentences will appear here as speakers and language learners contribute. Language carries a worldview that translation alone cannot.',
     'language.explore_teachings' => 'Explore Teachings',
-    'language.copyright' => 'Dictionary content is copyrighted by The Ojibwe People\'s Dictionary and used under CC BY-NC-SA 4.0.',
+    // OPD (Ojibwe People's Dictionary) is licensed CC BY-NC-SA 3.0. Render with |raw (it carries links). Shown on every surface that displays OPD dictionary content.
+    'language.copyright' => 'Southwestern Ojibwe dictionary content is copyrighted by <a href="https://ojibwe.lib.umn.edu" rel="external noopener">The Ojibwe People\'s Dictionary</a> and used under <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" rel="external noopener license">CC BY-NC-SA 3.0</a>. Its use here does not imply endorsement by The Ojibwe People\'s Dictionary or the University of Minnesota.',
     'language.detail_back' => 'Language',
     'language.not_found' => 'Entry Not Found',
     'language.not_found_message' => 'We couldn\'t find this dictionary entry. It may have been removed or the link may be outdated.',

--- a/src/Http/Controller/Language/LanguageApiController.php
+++ b/src/Http/Controller/Language/LanguageApiController.php
@@ -25,6 +25,24 @@ final class LanguageApiController
 {
     use JsonResponseTrait;
 
+    /**
+     * Redistribution terms carried in every /api/lang envelope. Southwestern
+     * Ojibwe dictionary content originates from the Ojibwe People's Dictionary
+     * and is licensed CC BY-NC-SA 3.0: downstream consumers must keep it
+     * non-commercial, attribute the source, and share derivatives alike. The
+     * Sagamok community corpus is not OPD content and carries its own terms.
+     *
+     * @var array<string, mixed>
+     */
+    private const USAGE_NOTICE = [
+        'noncommercial' => true,
+        'notice' => 'Southwestern Ojibwe dictionary content is copyrighted by The Ojibwe People\'s Dictionary and used under CC BY-NC-SA 3.0. Redistribution must remain non-commercial, credit the source, and carry this licence. Sagamok community corpus content is not OPD content and carries its own terms.',
+        'attribution' => 'The Ojibwe People\'s Dictionary',
+        'source_url' => 'https://ojibwe.lib.umn.edu',
+        'license' => 'CC BY-NC-SA 3.0',
+        'license_url' => 'https://creativecommons.org/licenses/by-nc-sa/3.0/',
+    ];
+
     public function __construct(
         private readonly DialectCodeProvider $dialects,
         private readonly TranslationMemoryService $translationMemory,
@@ -41,6 +59,7 @@ final class LanguageApiController
         return $this->json([
             'language' => ['tag' => 'oj', 'label' => $this->dialects->label('oj')],
             'dialects' => $this->dialects->all(),
+            'usage' => self::USAGE_NOTICE,
         ]);
     }
 
@@ -69,6 +88,11 @@ final class LanguageApiController
             ], 422);
         }
 
-        return $this->json($this->translationMemory->lookup($q, $tag, $account));
+        $result = $this->translationMemory->lookup($q, $tag, $account);
+        if (!isset($result['usage'])) {
+            $result['usage'] = self::USAGE_NOTICE;
+        }
+
+        return $this->json($result);
     }
 }

--- a/src/Http/Twig/LanguageTwigExtension.php
+++ b/src/Http/Twig/LanguageTwigExtension.php
@@ -15,10 +15,12 @@ use Twig\TwigFilter;
  *   renders it as readable text in every view, expanding the Ojibwe People's
  *   Dictionary abbreviations. Mirrors GameControllerTrait::cleanDefinition so
  *   the dictionary and the games show identical text.
- * - dialect_label: a truthful dialect name for an entry. Every current entry is
- *   from the Ojibwe People's Dictionary, which is Southwestern Ojibwe; future
- *   Nishnaabemwin (Eastern Ojibwe / Odawa) entries carry their own code. We
- *   never silently mix dialects, so the label is always shown.
+ * - dialect_label: a truthful dialect name for an entry. Ojibwe People's
+ *   Dictionary entries are Southwestern (Minnesota) Ojibwe; Steven's Sagamok
+ *   community corpus is Nishnaabemwin (the Eastern Ojibwe / Odawa continuum of
+ *   the north shore of Lake Huron). We never silently mix the two dialects, so
+ *   the label is always shown and the corpus is never folded into the OPD's
+ *   Southwestern label.
  */
 final class LanguageTwigExtension extends AbstractExtension
 {
@@ -66,11 +68,15 @@ final class LanguageTwigExtension extends AbstractExtension
         if (str_contains($source, 'ojibwe people') || $source === 'opd') {
             return 'Southwestern Ojibwe';
         }
+        if ($source === 'corpus' || str_contains($source, 'sagamok')) {
+            return 'Nishnaabemwin';
+        }
 
         return match (strtolower((string) $languageCode)) {
             'ojg', 'oj-e', 'oj-east' => 'Eastern Ojibwe',
             'otw', 'oj-odawa' => 'Odawa',
             'oj-sw', 'ciw' => 'Southwestern Ojibwe',
+            'oj-x', 'nis' => 'Nishnaabemwin',
             default => 'Anishinaabemowin',
         };
     }

--- a/src/Provider/Entity/EntityFoundationProvider.php
+++ b/src/Provider/Entity/EntityFoundationProvider.php
@@ -90,6 +90,7 @@ final class EntityFoundationProvider extends AppCoreServiceProvider
                 'source_url' => ['type' => 'uri', 'label' => 'Source URL', 'weight' => 15],
                 'attribution_source' => ['type' => 'string', 'label' => 'Attribution Source', 'description' => 'Source identifier (e.g., ojibwe-peoples-dictionary).', 'weight' => 16],
                 'attribution_url' => ['type' => 'uri', 'label' => 'Attribution URL', 'description' => 'URL of the authoritative source.', 'weight' => 17],
+                'license' => ['type' => 'string', 'label' => 'License', 'description' => 'License the content is used under (e.g. "CC BY-NC-SA 3.0" for Ojibwe People\'s Dictionary rows). Empty for Sagamok community corpus, which carries no ShareAlike obligation.', 'weight' => 18],
                 'consent_public' => ['type' => 'boolean', 'label' => 'Public Consent', 'description' => 'Whether this content may be shown on public pages.', 'weight' => 28, 'default' => 1],
                 'consent_ai_training' => ['type' => 'boolean', 'label' => 'AI Training Consent', 'description' => 'Whether this content may be used for AI training. Default: no.', 'weight' => 29, 'default' => 0],
                 'status' => ['type' => 'boolean', 'label' => 'Published', 'weight' => 30, 'default' => 1],

--- a/templates/components/domain/language/opd-attribution.html.twig
+++ b/templates/components/domain/language/opd-attribution.html.twig
@@ -1,0 +1,10 @@
+{#
+  OPD attribution + license notice (#914). Include on every public surface that
+  shows Ojibwe People's Dictionary content (Southwestern Ojibwe): the dictionary
+  detail + browse, search, chat, and the games. CC BY-NC-SA 3.0 requires the
+  copyright credit, a link to the source, the license, and no implied endorsement.
+  The string carries links, so render it raw.
+#}
+<footer class="opd-attribution attribution">
+  <p>{{ trans('language.copyright')|raw }}</p>
+</footer>

--- a/templates/pages/chat/index.html.twig
+++ b/templates/pages/chat/index.html.twig
@@ -66,5 +66,7 @@
         <p class="chat__no-results">{{ trans('chat.no_results') }}</p>
       {% endif %}
     {% endif %}
+
+    {% include "components/domain/language/opd-attribution.html.twig" %}
   </div>
 {% endblock %}

--- a/templates/pages/games/agim.html.twig
+++ b/templates/pages/games/agim.html.twig
@@ -64,6 +64,8 @@
     <div class="visually-hidden" aria-live="polite" id="agim-announcer"></div>
 </div>
 
+{% include "components/domain/language/opd-attribution.html.twig" %}
+
 <script src="/js/games-common.js" defer></script>
 <script src="/js/agim.js" defer></script>
 {% endblock %}

--- a/templates/pages/games/crossword.html.twig
+++ b/templates/pages/games/crossword.html.twig
@@ -95,6 +95,8 @@
     <div class="visually-hidden" aria-live="polite" id="crossword-announcer"></div>
 </div>
 
+{% include "components/domain/language/opd-attribution.html.twig" %}
+
 <script src="/js/games-common.js" defer></script>
 <script src="/js/crossword.js" defer></script>
 {% endblock %}

--- a/templates/pages/games/shkoda.html.twig
+++ b/templates/pages/games/shkoda.html.twig
@@ -90,6 +90,8 @@
     <div class="visually-hidden" aria-live="polite" id="shkoda-announcer"></div>
 </div>
 
+{% include "components/domain/language/opd-attribution.html.twig" %}
+
 <script src="/js/games-common.js" defer></script>
 <script src="/js/shkoda.js" defer></script>
 {% endblock %}

--- a/templates/pages/language/index.html.twig
+++ b/templates/pages/language/index.html.twig
@@ -52,8 +52,6 @@
       } %}
     {% endif %}
 
-    <footer class="attribution">
-      <p>{{ trans('language.copyright') }}</p>
-    </footer>
+    {% include "components/domain/language/opd-attribution.html.twig" %}
   </div>
 {% endblock %}

--- a/templates/pages/language/search.html.twig
+++ b/templates/pages/language/search.html.twig
@@ -43,5 +43,7 @@
     {% endif %}
 
     <p><a href="{{ lang_url('/language') }}">{{ trans('language.browse_all') }}</a></p>
+
+    {% include "components/domain/language/opd-attribution.html.twig" %}
   </div>
 {% endblock %}

--- a/templates/pages/language/show.html.twig
+++ b/templates/pages/language/show.html.twig
@@ -64,7 +64,7 @@
               {% endif %}
             </p>
           {% endif %}
-          <p>{{ trans('language.copyright') }}</p>
+          <p>{{ trans('language.copyright')|raw }}</p>
         </footer>
       </div>{# .content-well #}
     </div>

--- a/templates/pages/static/matcher.html.twig
+++ b/templates/pages/static/matcher.html.twig
@@ -110,6 +110,8 @@
     <div class="visually-hidden" aria-live="polite" data-sr-announce></div>
 </div>
 
+{% include "components/domain/language/opd-attribution.html.twig" %}
+
 <script>
 (function() {
     'use strict';

--- a/tests/App/Integration/Http/Language/LanguageApiTest.php
+++ b/tests/App/Integration/Http/Language/LanguageApiTest.php
@@ -72,6 +72,25 @@ final class LanguageApiTest extends HttpKernelTestCase
     }
 
     #[Test]
+    public function dialects_endpoint_carries_the_opd_usage_notice(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/dialects'));
+
+        self::assertTrue($body['usage']['noncommercial']);
+        self::assertSame('CC BY-NC-SA 3.0', $body['usage']['license']);
+        self::assertSame('https://ojibwe.lib.umn.edu', $body['usage']['source_url']);
+    }
+
+    #[Test]
+    public function translate_response_carries_the_opd_usage_notice(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => 'water', 'tag' => 'oj']));
+
+        self::assertSame('CC BY-NC-SA 3.0', $body['usage']['license']);
+        self::assertTrue($body['usage']['noncommercial']);
+    }
+
+    #[Test]
     public function exact_community_tag_match_is_case_insensitive_and_carries_the_tag(): void
     {
         $body = $this->decode($this->send('GET', '/api/lang/translate', ['q' => '  Bear ', 'tag' => 'oj-x-sagamok']));

--- a/tests/App/Integration/Migration/OpdLicenseBackfillMigrationTest.php
+++ b/tests/App/Integration/Migration/OpdLicenseBackfillMigrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Migration;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * The OPD licence + dialect backfill (#914). The single property that matters
+ * for licence hygiene: the CC BY-NC-SA 3.0 ShareAlike obligation must attach to
+ * the Ojibwe People's Dictionary rows and ONLY those rows. Steven Bennett's
+ * Sagamok community corpus (attribution_source = 'corpus') must come through the
+ * migration untouched, so its licence stays empty and its dialect stays its own.
+ */
+#[CoversNothing]
+final class OpdLicenseBackfillMigrationTest extends TestCase
+{
+    private const MIGRATION = '/migrations/20260625_130000_mark_opd_license_and_dialect.php';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $this->connection = $db->getConnection();
+
+        // Minimal content-entity table: only `_data` is read by the migration.
+        $this->connection->executeStatement(
+            'CREATE TABLE dictionary_entry (
+                deid INTEGER PRIMARY KEY AUTOINCREMENT,
+                uuid CLOB, bundle CLOB, word CLOB, langcode CLOB, _data CLOB
+            )',
+        );
+
+        $this->insert('makwa', [
+            'attribution_source' => "Ojibwe People's Dictionary, University of Minnesota",
+            'attribution_url' => 'https://ojibwe.lib.umn.edu/main-entry/makwa-na',
+            'language_code' => 'oj',
+        ]);
+        // OPD row identified only by its URL fingerprint (source label absent).
+        $this->insert('nibi', [
+            'attribution_source' => '',
+            'attribution_url' => 'https://ojibwe.lib.umn.edu/main-entry/nibi-ni',
+            'language_code' => 'oj',
+        ]);
+        // Sagamok community corpus row: must NOT be licensed or relabelled.
+        $this->insert('giizhig', [
+            'attribution_source' => 'corpus',
+            'attribution_url' => 'https://www.facebook.com/groups/sagamok',
+            'language_code' => 'oj',
+        ]);
+    }
+
+    #[Test]
+    public function up_licenses_and_relabels_only_the_opd_rows(): void
+    {
+        $this->runUp();
+
+        self::assertSame('CC BY-NC-SA 3.0', $this->license('makwa'));
+        self::assertSame('oj-sw', $this->languageCode('makwa'));
+        self::assertSame('CC BY-NC-SA 3.0', $this->license('nibi'));
+        self::assertSame('oj-sw', $this->languageCode('nibi'));
+    }
+
+    #[Test]
+    public function up_never_touches_the_sagamok_corpus(): void
+    {
+        $this->runUp();
+
+        self::assertNull($this->license('giizhig'), 'Corpus row must carry no licence.');
+        self::assertSame('oj', $this->languageCode('giizhig'), 'Corpus dialect must be unchanged.');
+    }
+
+    #[Test]
+    public function down_restores_the_original_plain_oj_rows(): void
+    {
+        $this->runUp();
+        $this->runDown();
+
+        self::assertNull($this->license('makwa'));
+        self::assertSame('oj', $this->languageCode('makwa'));
+        // The corpus row was never modified either way.
+        self::assertNull($this->license('giizhig'));
+        self::assertSame('oj', $this->languageCode('giizhig'));
+    }
+
+    private function runUp(): void
+    {
+        $migration = require dirname(__DIR__, 4) . self::MIGRATION;
+        $migration->up(new SchemaBuilder($this->connection));
+    }
+
+    private function runDown(): void
+    {
+        $migration = require dirname(__DIR__, 4) . self::MIGRATION;
+        $migration->down(new SchemaBuilder($this->connection));
+    }
+
+    /**
+     * @param array<string, string> $data
+     */
+    private function insert(string $word, array $data): void
+    {
+        $this->connection->insert('dictionary_entry', [
+            'word' => $word,
+            '_data' => json_encode($data, JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    private function license(string $word): ?string
+    {
+        return $this->field($word, 'license');
+    }
+
+    private function languageCode(string $word): ?string
+    {
+        return $this->field($word, 'language_code');
+    }
+
+    private function field(string $word, string $key): ?string
+    {
+        $value = $this->connection->fetchOne(
+            "SELECT json_extract(_data, '$.' || ?) FROM dictionary_entry WHERE word = ?",
+            [$key, $word],
+        );
+
+        return $value === false ? null : $value;
+    }
+}

--- a/tests/App/Unit/Http/Twig/LanguageTwigExtensionTest.php
+++ b/tests/App/Unit/Http/Twig/LanguageTwigExtensionTest.php
@@ -72,6 +72,20 @@ final class LanguageTwigExtensionTest extends TestCase
     }
 
     #[Test]
+    public function dialectLabelMapsOjSwCodeToSouthwesternOjibwe(): void
+    {
+        self::assertSame('Southwestern Ojibwe', $this->ext->dialectLabel('oj-sw'));
+    }
+
+    #[Test]
+    public function dialectLabelMapsCorpusSourceToNishnaabemwin(): void
+    {
+        // Steven's Sagamok community corpus is Nishnaabemwin, never folded into
+        // the OPD's Southwestern Ojibwe label.
+        self::assertSame('Nishnaabemwin', $this->ext->dialectLabel('oj', 'corpus'));
+    }
+
+    #[Test]
     public function dialectLabelFallsBackToAnishinaabemowin(): void
     {
         self::assertSame('Anishinaabemowin', $this->ext->dialectLabel('oj'));


### PR DESCRIPTION
Closes #914.

The 21,721 `dictionary_entry` rows from the **Ojibwe People's Dictionary** (University of Minnesota) are Southwestern (Minnesota) Ojibwe and licensed **CC BY-NC-SA 3.0**. This brings Minoo into compliance with that licence. Steven Bennett's 17-row Sagamok community corpus (`attribution_source = 'corpus'`) is Nishnaabemwin and carries **no** ShareAlike obligation; it is never touched.

## Recon result (compliant vs missing, before this PR)

| Requirement | Before | This PR |
|---|---|---|
| 1. Attribution on every OPD surface | only browse + detail, and the copyright string was wrong (4.0) | shared `opd-attribution` partial on detail, browse, search, chat, and all four games; string fixed to 3.0 + source link + non-endorsement |
| 2. Licence marking in data | no `license` field | new `license` field; migration stamps OPD rows only |
| 3. Dialect label | OPD tagged plain `oj`, corpus showed generic "Anishinaabemowin" | OPD → `oj-sw` / "Southwestern Ojibwe"; corpus → "Nishnaabemwin" |
| 4. Scope check (audio/images) | n/a | `dictionary_entry` is text-only; no OPD media ingested -> **no takedown** |
| 5. NonCommercial / API redistribution | `/api/lang` had no notice | every response carries a `usage` notice (`license`, `noncommercial: true`, source) |

## Changes

- **Attribution** — `templates/components/domain/language/opd-attribution.html.twig`, included on the detail page, `/language` browse, `/language/search`, chat, and Crossword/Shkoda/Agim/Matcher. `language.copyright` corrected 4.0 → 3.0 with the source + licence links and an explicit non-endorsement line, rendered `|raw`.
- **Licence field** — `license` on `dictionary_entry`. Backfill migration `20260625_130000` sets `CC BY-NC-SA 3.0` + `language_code = oj-sw` on OPD rows, matched on the audited fingerprint (`attribution_source LIKE 'Ojibwe People%'` OR `attribution_url LIKE '%ojibwe.lib.umn.edu%'`) and **explicitly excluding** `corpus`. Reversible `down()`.
- **Dialect** — `dialect_label` maps OPD → "Southwestern Ojibwe" and corpus → "Nishnaabemwin", never folding the two.
- **API** — `/api/lang/dialects` and `/api/lang/translate` carry a `usage` envelope so downstream consumers know the content stays non-commercial and must carry the BY-NC-SA notice.

## Tests
- `dialect_label`: OPD → Southwestern, `oj-sw` → Southwestern, `corpus` → Nishnaabemwin.
- `/api/lang`: usage notice present on both endpoints.
- Migration test locks the **corpus-never-touched** invariant (licence stays empty, dialect stays `oj`) while OPD rows get licensed + relabelled; `down()` restores plain `oj`.

Full unit (530) + integration (143) suites and PHPStan level 5 are green locally. The backfill SQL was dry-run against a copy of the 21,721-row production DB: all OPD rows updated, corpus excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)