### PR TITLE
feat(api): /api/lang/lookup — own-corpus lexicon endpoint for rhtcircle (#916)

### DIFF
--- a/docs/anishinaabemowin-language-api-tracker.md
+++ b/docs/anishinaabemowin-language-api-tracker.md
@@ -78,6 +78,116 @@ rhtcircle, and the CMS all consume it. It is BCP 47, canonical everywhere.
   short community code before they can be tagged; that is an ecosystem data
   decision, deferred. `sagamok` fits as-is.
 
+## `/api/lang` surface (ecosystem contract)
+
+This is the canonical contract for the `/api/lang` JSON endpoints. rhtcircle and
+the RHT nations build against this section. All endpoints are `GET`, public read,
+no auth (for now), and **set no CORS header** — they are intended for
+**server-to-server** use (e.g. rhtcircle's PHP backend calling minoo.live), not
+browser cross-origin calls. JSON via `JsonResponseTrait::json()`. Routes are
+registered by `LanguageApiRouteProvider`, gated on the `language` module flag.
+
+Two lookups, kept distinct on purpose:
+
+- **`/api/lang/translate`** is the translation MEMORY (`translation_memory`):
+  English -> a community translation, ordered exact -> fuzzy -> gap-log-on-miss,
+  keyed on the full BCP 47 tag. It returns one best translation and logs misses.
+- **`/api/lang/lookup`** is the dictionary LEXICON (`dictionary_entry`, own corpus
+  only): a term in either direction -> community entries. It returns ALL matches
+  and never writes a gap-log row.
+
+OPD is **never served** through any `/api/lang` endpoint. The Ojibwe People's
+Dictionary (21,721 rows, Southwestern Ojibwe, CC BY-NC-SA 3.0) is a licensed
+external reference; an envelope may *link* to ojibwe.lib.umn.edu, but no OPD entry
+ever appears in a payload.
+
+### `GET /api/lang/dialects`
+
+Returns the language + the derived dialect groupings as BCP 47 tags, plus a
+`usage` notice. Unchanged by #916.
+
+### `GET /api/lang/translate?q=&tag=`
+
+Unchanged (issues #894/#898). `q` required (422 if missing). `tag` optional BCP 47
+(422 if malformed; `dialect` is a back-compat alias). Returns `match_type`
+(`exact`|`fuzzy`|`miss`), `translation`, `tag`, `dialect`, `label`, `confidence`,
+`needs_speaker_review`, `source`, `match_score` (fuzzy only), and a `usage` notice.
+
+### `GET /api/lang/lookup?q=&tag=&dir=` (#916)
+
+The own-corpus lexicon. Reads `dictionary_entry` **only** where
+`attribution_source = 'corpus'` (Minoo's own Sagamok Nishnaabemwin lexicon). That
+equality filter is also the OPD exclusion: every OPD row carries a different
+`attribution_source`, so no OPD content can surface. Consent-gated at the entity
+layer (anonymous callers see only `status = 1`, `consent_public = 1`).
+
+Parameters:
+- `q` (required) — the term. Missing/empty -> **422**.
+- `tag` (optional) — a BCP 47 tag. Malformed -> **422** (same validator as
+  `translate`). A well-formed tag that selects no community we hold (e.g. a
+  different dialect grouping like `oj-ojb`) is a **200 miss**, not a 422. The
+  corpus is `oj-x-sagamok`; a tag matches it when it is tag-agnostic (`oj`), the
+  corpus tag itself, or in the same derived dialect grouping (Nishnaabemwin).
+- `dir` (optional) — `en` (the term is English, match definitions) or `oj` (the
+  term is Anishinaabemowin, match the word). Omit to match both. Any other value
+  -> **422**.
+
+Response envelope:
+```jsonc
+{
+  "match_type": "exact",          // "exact" | "fuzzy" | "miss" | "invalid"
+  "query": "spoon",
+  "tag": null,                    // echoes the requested tag (or null)
+  "dir": null,                    // echoes the requested direction (or null)
+  "count": 1,
+  "matches": [
+    {
+      "word": "Emkwaan",          // Anishinaabemowin
+      "definition": ["spoon"],     // English sense(s), decoded
+      "tag": "oj-x-sagamok",       // community tag (always the corpus tag)
+      "dialect": "Nishnaabemwin",  // derived dialect grouping name
+      "label": "Nishnaabemwin (Sagamok)",
+      "slug": "emkwaan",
+      "match_type": "exact",       // per-match tier
+      "match_score": 100,          // 100 for exact; similar_text % for fuzzy
+      "matched_on": "en",          // which side matched: "en" | "oj"
+      "provenance": {
+        "attribution_source": "corpus",
+        "attribution": "Sagamok community Knowledge Keepers",
+        "source_url": "https://www.facebook.com/reel/901425976280455"
+      }
+    }
+  ],
+  "usage": {
+    "governance": "OCAP",
+    "community_governed": true,
+    "noncommercial": true,
+    "attribution": "Sagamok community Knowledge Keepers",
+    "license": null,               // community-governed; NOT an invented licence
+    "terms": "Community-governed; redistribution terms are to be set by the community.",
+    "notice": "Community-governed Anishinaabemowin (Nishnaabemwin) ... NOT Ojibwe People's Dictionary content ...",
+    "reference": {                 // OPD acknowledged as a separate reference only
+      "note": "The Ojibwe People's Dictionary ... is never served through this API.",
+      "url": "https://ojibwe.lib.umn.edu"
+    }
+  }
+}
+```
+
+Matching: exact first (term equals the word, or any English sense after splitting
+comma-separated senses, so `cup` matches `["cup, glass"]`), then fuzzy
+(`similar_text` percent >= 70). Matches are ordered by score desc then word.
+Corpus terms carry the community's own governance (OCAP); the API does not assert a
+redistribution licence on them — that is the community's to set.
+
+### Consumer note (rhtcircle and the RHT nations)
+
+Call server-to-server (no browser CORS). Honour the `usage` envelope: corpus
+content is community-governed (OCAP), non-commercial by default, attributed to the
+community, with formal redistribution terms to be set by the community. Do not
+treat corpus content as OPD or apply the OPD (CC BY-NC-SA 3.0) terms to it, and do
+not relay OPD content through this API.
+
 ## Governance gate (Phase 0)
 
 Nothing derived from Steven Bennett's paired audio corpus may be published, and no model

--- a/src/Http/Controller/Language/LanguageApiController.php
+++ b/src/Http/Controller/Language/LanguageApiController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controller\Language;
 
 use App\Http\Controller\Concerns\JsonResponseTrait;
+use App\Language\CorpusLexiconService;
 use App\Language\DialectCodeProvider;
 use App\Language\TranslationMemoryService;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -43,9 +44,33 @@ final class LanguageApiController
         'license_url' => 'https://creativecommons.org/licenses/by-nc-sa/3.0/',
     ];
 
+    /**
+     * Redistribution terms for the community corpus served by /api/lang/lookup.
+     * Unlike the OPD (a licensed external reference), the Sagamok corpus is
+     * community-governed under OCAP: there is no invented redistribution licence
+     * here; formal terms are the community's to set. The OPD is acknowledged as a
+     * separate reference only and is never served through this API.
+     *
+     * @var array<string, mixed>
+     */
+    private const CORPUS_USAGE_NOTICE = [
+        'governance' => 'OCAP',
+        'community_governed' => true,
+        'noncommercial' => true,
+        'attribution' => 'Sagamok community Knowledge Keepers',
+        'license' => null,
+        'terms' => 'Community-governed; redistribution terms are to be set by the community.',
+        'notice' => 'Community-governed Anishinaabemowin (Nishnaabemwin) from the Sagamok community, shared under the community\'s own governance (OCAP: Ownership, Control, Access, Possession). This is NOT Ojibwe People\'s Dictionary content. Treat as non-commercial and consult the community before reuse; formal redistribution terms are to be set by the community.',
+        'reference' => [
+            'note' => 'The Ojibwe People\'s Dictionary (Southwestern Ojibwe, CC BY-NC-SA 3.0) is a separate reference and is never served through this API.',
+            'url' => 'https://ojibwe.lib.umn.edu',
+        ],
+    ];
+
     public function __construct(
         private readonly DialectCodeProvider $dialects,
         private readonly TranslationMemoryService $translationMemory,
+        private readonly CorpusLexiconService $corpus,
     ) {
     }
 
@@ -92,6 +117,57 @@ final class LanguageApiController
         if (!isset($result['usage'])) {
             $result['usage'] = self::USAGE_NOTICE;
         }
+
+        return $this->json($result);
+    }
+
+    /**
+     * GET /api/lang/lookup?q=&tag=&dir=: look up one term in Minoo's OWN community
+     * corpus (the Sagamok Nishnaabemwin lexicon). Reads only dictionary_entry rows
+     * with attribution_source = 'corpus', which is also the OPD exclusion: no
+     * Ojibwe People's Dictionary content is ever returned here.
+     *
+     * `dir` is 'en' (English term, match definitions), 'oj' (Anishinaabemowin
+     * term, match the word), or omitted (match both). `tag` is a BCP 47 tag,
+     * validated the same way as /api/lang/translate (a malformed tag is a 422).
+     *
+     * This is the lexicon endpoint; /api/lang/translate is the translation memory.
+     * The endpoint is public but intended for server-to-server use (e.g.
+     * rhtcircle's PHP backend); it sets no CORS header, so it is not callable from
+     * a browser cross-origin.
+     *
+     * @param array<string, mixed> $query
+     */
+    public function lookup(#[MapQuery] array $query, AccountInterface $account): JsonResponse
+    {
+        $q = is_string($query['q'] ?? null) ? trim($query['q']) : '';
+        if ($q === '') {
+            return $this->json(['error' => 'Missing required query parameter: q'], 422);
+        }
+
+        $rawTag = $query['tag'] ?? null;
+        $tag = is_string($rawTag) && $rawTag !== '' ? $rawTag : null;
+        if ($tag !== null && !$this->dialects->isValid($tag)) {
+            return $this->json([
+                'error' => 'Malformed language tag',
+                'tag' => $tag,
+                'hint' => 'Expected a BCP 47 tag: oj, an oj-<dialect> tag, or oj-x-<community> (for example oj-x-sagamok).',
+                'recognized_dialects' => $this->dialects->codes(),
+            ], 422);
+        }
+
+        $rawDir = $query['dir'] ?? null;
+        $dir = is_string($rawDir) && $rawDir !== '' ? strtolower($rawDir) : null;
+        if ($dir !== null && !in_array($dir, ['en', 'oj'], true)) {
+            return $this->json([
+                'error' => 'Invalid dir parameter',
+                'dir' => $rawDir,
+                'hint' => "Expected 'en' (English term) or 'oj' (Anishinaabemowin term); omit to match both directions.",
+            ], 422);
+        }
+
+        $result = $this->corpus->lookup($q, $tag, $dir, $account);
+        $result['usage'] = self::CORPUS_USAGE_NOTICE;
 
         return $this->json($result);
     }

--- a/src/Language/CorpusLexiconService.php
+++ b/src/Language/CorpusLexiconService.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Language;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * The own-corpus lexicon lookup behind GET /api/lang/lookup (issue #916).
+ *
+ * This is the LEXICON endpoint: it reads `dictionary_entry` but ONLY Minoo's own
+ * community corpus (`attribution_source = 'corpus'`, the Sagamok Nishnaabemwin
+ * lexicon). That equality filter is also the OPD exclusion: every Ojibwe People's
+ * Dictionary row carries a different `attribution_source`, so no OPD content can
+ * ever surface here. OPD is reference-only and is never served through /api/lang.
+ *
+ * Distinct from {@see TranslationMemoryService}, which backs /api/lang/translate:
+ * that is the translation MEMORY (English -> community translation, exact then
+ * fuzzy then gap-log). This service is the dictionary lexicon (a term in either
+ * direction -> community entries), returns ALL matches rather than one best
+ * translation, and never writes a gap-log row.
+ *
+ * Reads are consent-gated through the access-checked query (the request account
+ * is bound, so LanguageAccessPolicy filters to published, public-consent rows).
+ */
+final class CorpusLexiconService
+{
+    /** Minimum similar_text percent for a fuzzy hit (mirrors the TM threshold). */
+    public const int FUZZY_THRESHOLD = 70;
+
+    /**
+     * The corpus is the Sagamok community lexicon, so every match carries the
+     * Sagamok community tag regardless of the row's stored `language_code` (the
+     * corpus rows predate per-row community tagging and store plain `oj`).
+     */
+    public const string CORPUS_TAG = 'oj-x-sagamok';
+
+    /** The own-corpus marker. Equality on this is also the OPD exclusion. */
+    private const string CORPUS_SOURCE = 'corpus';
+
+    /**
+     * Cap on corpus rows scanned. A perf guard, not a silent truncation of a real
+     * result set: the community lexicon is small (tens of rows). A large corpus
+     * would want a trigram index instead of an in-PHP scan.
+     */
+    private const int SCAN_LIMIT = 1000;
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly DialectCodeProvider $dialects,
+    ) {
+    }
+
+    /**
+     * Look up a term in the community corpus. `$dir` is 'en' (the term is English,
+     * match the definitions), 'oj' (the term is Anishinaabemowin, match the word),
+     * or null (match both sides). Exact matches first; if none, fuzzy matches.
+     *
+     * @return array<string, mixed>
+     */
+    public function lookup(string $term, ?string $tag, ?string $dir, AccountInterface $account): array
+    {
+        $normalized = self::normalize($term);
+        if ($normalized === '') {
+            return $this->envelope('invalid', $term, $tag, $dir, []);
+        }
+
+        $tag = $tag !== null && $tag !== '' ? $tag : null;
+
+        // The corpus is oj-x-sagamok. A requested tag that is neither tag-agnostic,
+        // the corpus tag, nor in the same derived dialect grouping has no corpus
+        // content, so there is nothing to return (a 200 miss, not a 422 — the tag
+        // is well-formed, it just selects no community we hold).
+        if ($tag !== null && !$this->tagSelectsCorpus($tag)) {
+            return $this->envelope('miss', $term, $tag, $dir, []);
+        }
+
+        $exact = [];
+        $fuzzy = [];
+        foreach ($this->loadCorpusRows($account) as $row) {
+            $match = $this->matchRow($row, $normalized, $dir);
+            if ($match === null) {
+                continue;
+            }
+            if ($match['match_type'] === 'exact') {
+                $exact[] = $match;
+            } else {
+                $fuzzy[] = $match;
+            }
+        }
+
+        if ($exact !== []) {
+            return $this->envelope('exact', $term, $tag, $dir, $this->sortMatches($exact));
+        }
+        if ($fuzzy !== []) {
+            return $this->envelope('fuzzy', $term, $tag, $dir, $this->sortMatches($fuzzy));
+        }
+
+        return $this->envelope('miss', $term, $tag, $dir, []);
+    }
+
+    /**
+     * Normalize a term for matching: trim, collapse internal whitespace, lowercase.
+     */
+    public static function normalize(string $term): string
+    {
+        $collapsed = (string) preg_replace('/\s+/', ' ', trim($term));
+
+        return mb_strtolower($collapsed);
+    }
+
+    /**
+     * The corpus rows (own corpus only; OPD excluded by the equality filter),
+     * consent-gated via the access-checked query.
+     *
+     * @return list<EntityInterface>
+     */
+    private function loadCorpusRows(AccountInterface $account): array
+    {
+        $storage = $this->entityTypeManager->getStorage('dictionary_entry');
+        $ids = $storage->getQuery()->setAccount($account)
+            ->condition('status', 1)
+            ->condition('consent_public', 1)
+            ->condition('attribution_source', self::CORPUS_SOURCE)
+            ->execute();
+        if ($ids === []) {
+            // Guard the loadMultiple([]) "load all" footgun (see CLAUDE.md): an
+            // empty id set must never widen to the whole table (which would leak
+            // OPD rows into the corpus-only endpoint).
+            return [];
+        }
+
+        $ids = array_slice($ids, 0, self::SCAN_LIMIT);
+
+        return array_values($storage->loadMultiple($ids));
+    }
+
+    /**
+     * Match one corpus row against the normalized term in the requested direction.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function matchRow(EntityInterface $row, string $normalizedTerm, ?string $dir): ?array
+    {
+        $word = (string) $row->get('word');
+        $wordNorm = self::normalize($word);
+        $senses = $this->definitionSenses($row);
+        $matchSenses = $this->splitSenses($senses);
+
+        $checkOj = $dir === null || $dir === 'oj';
+        $checkEn = $dir === null || $dir === 'en';
+
+        // Exact: the term equals the word (oj side) or any english (sub)sense. The
+        // term is always non-empty (the caller guards), so an empty word never
+        // produces a spurious exact hit.
+        if ($checkOj && $wordNorm === $normalizedTerm) {
+            return $this->buildMatch($row, $word, $senses, 'exact', 100, 'oj');
+        }
+        if ($checkEn) {
+            foreach ($matchSenses as $sense) {
+                if (self::normalize($sense) === $normalizedTerm) {
+                    return $this->buildMatch($row, $word, $senses, 'exact', 100, 'en');
+                }
+            }
+        }
+
+        // Fuzzy: the best similar_text percent across the considered sides
+        // (similarity() returns 0 for an empty side, so no guard is needed).
+        $bestScore = 0;
+        $bestSide = null;
+        if ($checkOj) {
+            $score = $this->similarity($normalizedTerm, $wordNorm);
+            if ($score > $bestScore) {
+                $bestScore = $score;
+                $bestSide = 'oj';
+            }
+        }
+        if ($checkEn) {
+            foreach ($matchSenses as $sense) {
+                $score = $this->similarity($normalizedTerm, self::normalize($sense));
+                if ($score > $bestScore) {
+                    $bestScore = $score;
+                    $bestSide = 'en';
+                }
+            }
+        }
+
+        if ($bestSide !== null && $bestScore >= self::FUZZY_THRESHOLD) {
+            return $this->buildMatch($row, $word, $senses, 'fuzzy', $bestScore, $bestSide);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $senses
+     *
+     * @return array<string, mixed>
+     */
+    private function buildMatch(EntityInterface $row, string $word, array $senses, string $type, int $score, string $side): array
+    {
+        $grouping = $this->dialects->dialectFor(self::CORPUS_TAG);
+
+        return [
+            'word' => $word,
+            'definition' => $senses,
+            'tag' => self::CORPUS_TAG,
+            'dialect' => $grouping !== null ? $grouping['name'] : 'Nishnaabemwin',
+            'label' => $this->dialects->label(self::CORPUS_TAG),
+            'slug' => (string) $row->get('slug'),
+            'match_type' => $type,
+            'match_score' => $score,
+            'matched_on' => $side,
+            'provenance' => [
+                'attribution_source' => self::CORPUS_SOURCE,
+                'attribution' => 'Sagamok community Knowledge Keepers',
+                'source_url' => (string) $row->get('attribution_url'),
+            ],
+        ];
+    }
+
+    /**
+     * The decoded english senses for display (the `definition` field is a
+     * JSON-encoded array such as `["cup, glass"]`).
+     *
+     * @return list<string>
+     */
+    private function definitionSenses(EntityInterface $row): array
+    {
+        $raw = (string) $row->get('definition');
+        if ($raw === '') {
+            return [];
+        }
+        $decoded = json_decode($raw, true);
+        $list = is_array($decoded) ? $decoded : [$raw];
+
+        $out = [];
+        foreach ($list as $item) {
+            $sense = trim((string) $item);
+            if ($sense !== '') {
+                $out[] = $sense;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Display senses split on commas into atomic sub-senses for matching, so a
+     * query for "cup" matches a `["cup, glass"]` entry.
+     *
+     * @param list<string> $senses
+     *
+     * @return list<string>
+     */
+    private function splitSenses(array $senses): array
+    {
+        $out = [];
+        foreach ($senses as $sense) {
+            foreach (explode(',', $sense) as $part) {
+                $part = trim($part);
+                if ($part !== '') {
+                    $out[] = $part;
+                }
+            }
+        }
+
+        return array_values(array_unique($out));
+    }
+
+    private function similarity(string $a, string $b): int
+    {
+        if ($a === '' || $b === '') {
+            return 0;
+        }
+        $percent = 0.0;
+        similar_text($a, $b, $percent);
+
+        return (int) round($percent);
+    }
+
+    /**
+     * Whether a well-formed tag selects the community corpus: tag-agnostic (`oj`),
+     * the corpus tag itself, or any tag in the same derived dialect grouping.
+     */
+    private function tagSelectsCorpus(string $tag): bool
+    {
+        if ($tag === 'oj' || $tag === self::CORPUS_TAG) {
+            return true;
+        }
+        $corpusGrouping = $this->dialects->dialectCodeForTag(self::CORPUS_TAG);
+        $requested = $this->dialects->dialectCodeForTag($tag);
+
+        return $requested !== null && $requested === $corpusGrouping;
+    }
+
+    /**
+     * Order matches deterministically: higher score first, then by word.
+     *
+     * @param list<array<string, mixed>> $matches
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function sortMatches(array $matches): array
+    {
+        usort($matches, static function (array $a, array $b): int {
+            return ((int) $b['match_score'] <=> (int) $a['match_score'])
+                ?: strcmp((string) $a['word'], (string) $b['word']);
+        });
+
+        return $matches;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $matches
+     *
+     * @return array<string, mixed>
+     */
+    private function envelope(string $matchType, string $term, ?string $tag, ?string $dir, array $matches): array
+    {
+        return [
+            'match_type' => $matchType,
+            'query' => $term,
+            'tag' => $tag,
+            'dir' => $dir,
+            'count' => count($matches),
+            'matches' => $matches,
+        ];
+    }
+}

--- a/src/Provider/LanguageModuleServiceProvider.php
+++ b/src/Provider/LanguageModuleServiceProvider.php
@@ -9,6 +9,7 @@ use App\Entity\Language\TmGapLog;
 use App\Entity\Language\TranslationMemory;
 use App\Language\Asr\AsrClient;
 use App\Language\Asr\UnavailableAsrClient;
+use App\Language\CorpusLexiconService;
 use App\Language\DialectCodeProvider;
 use App\Language\TranslationMemoryService;
 use App\Seed\TranslationBacklogSeeder;
@@ -47,6 +48,17 @@ final class LanguageModuleServiceProvider extends AppCoreServiceProvider
         $this->singleton(
             TranslationMemoryService::class,
             fn (): TranslationMemoryService => new TranslationMemoryService(
+                $this->resolve(EntityTypeManager::class),
+                $this->resolve(DialectCodeProvider::class),
+            ),
+        );
+
+        // The own-corpus lexicon lookup behind /api/lang/lookup (#916): reads
+        // dictionary_entry but only the community corpus (attribution_source =
+        // 'corpus'), which is also the OPD exclusion. Reads are consent-gated.
+        $this->singleton(
+            CorpusLexiconService::class,
+            fn (): CorpusLexiconService => new CorpusLexiconService(
                 $this->resolve(EntityTypeManager::class),
                 $this->resolve(DialectCodeProvider::class),
             ),

--- a/src/Provider/Routing/LanguageApiRouteProvider.php
+++ b/src/Provider/Routing/LanguageApiRouteProvider.php
@@ -47,5 +47,17 @@ final class LanguageApiRouteProvider extends AppCoreServiceProvider
                 ->methods('GET')
                 ->build(),
         );
+
+        // The own-corpus lexicon endpoint (#916). Public read but server-to-server
+        // by intent (no CORS header is set); reads only the community corpus, never
+        // OPD.
+        $router->addRoute(
+            'api.lang.lookup',
+            RouteBuilder::create('/api/lang/lookup')
+                ->controller('App\Http\Controller\Language\LanguageApiController::lookup')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
     }
 }

--- a/tests/App/Integration/Http/Language/LanguageApiTest.php
+++ b/tests/App/Integration/Http/Language/LanguageApiTest.php
@@ -54,6 +54,24 @@ final class LanguageApiTest extends HttpKernelTestCase
             'created_at' => time(),
             'updated_at' => time(),
         ]));
+
+        // dictionary_entry rows for the /api/lang/lookup lexicon endpoint. Own
+        // corpus (attribution_source 'corpus') vs OPD (must NEVER be served).
+        $entries = self::$kernel->getEntityTypeManager()->getStorage('dictionary_entry');
+        $entry = static function (array $values) use ($entries): void {
+            $entries->save($entries->create($values + [
+                'language_code' => 'oj',
+                'status' => 1,
+                'consent_public' => 1,
+                'created_at' => time(),
+                'updated_at' => time(),
+            ]));
+        };
+        // Own community corpus.
+        $entry(['word' => 'Emkwaan', 'slug' => 'emkwaan', 'definition' => '["spoon"]', 'attribution_source' => 'corpus', 'attribution_url' => 'https://www.facebook.com/reel/901425976280455']);
+        $entry(['word' => 'naagnens', 'slug' => 'naagnens', 'definition' => '["cup, glass"]', 'attribution_source' => 'corpus', 'attribution_url' => 'https://www.facebook.com/reel/1454763089179769']);
+        // OPD row: licensed external reference, must never appear in /api/lang.
+        $entry(['word' => 'aw', 'slug' => 'aw', 'definition' => '["that (animate)"]', 'language_code' => 'oj-sw', 'license' => 'CC BY-NC-SA 3.0', 'attribution_source' => "Ojibwe People's Dictionary, University of Minnesota", 'attribution_url' => 'https://ojibwe.lib.umn.edu/main-entry/aw-pron']);
     }
 
     #[Test]
@@ -169,6 +187,123 @@ final class LanguageApiTest extends HttpKernelTestCase
     {
         // The old custom dialect code is no longer a valid tag.
         self::assertSame(422, $this->send('GET', '/api/lang/translate', ['q' => 'bear', 'tag' => 'oji-east'])->getStatusCode());
+    }
+
+    #[Test]
+    public function lookup_returns_a_corpus_word_for_an_english_term(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'spoon']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame(1, $body['count']);
+        $match = $body['matches'][0];
+        self::assertSame('Emkwaan', $match['word']);
+        self::assertSame(['spoon'], $match['definition']);
+        self::assertSame('oj-x-sagamok', $match['tag']);
+        self::assertSame('Nishnaabemwin', $match['dialect']);
+        self::assertSame('en', $match['matched_on']);
+        self::assertSame('corpus', $match['provenance']['attribution_source']);
+    }
+
+    #[Test]
+    public function lookup_matches_an_anishinaabemowin_term_in_the_oj_direction(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'Emkwaan', 'dir' => 'oj']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame('Emkwaan', $body['matches'][0]['word']);
+        self::assertSame('oj', $body['matches'][0]['matched_on']);
+    }
+
+    #[Test]
+    public function lookup_splits_comma_senses_so_cup_matches(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'cup']));
+
+        self::assertSame('exact', $body['match_type']);
+        self::assertSame('naagnens', $body['matches'][0]['word']);
+    }
+
+    #[Test]
+    public function lookup_fuzzy_matches_a_near_spelling(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'spoonn']));
+
+        self::assertSame('fuzzy', $body['match_type']);
+        self::assertSame('Emkwaan', $body['matches'][0]['word']);
+        self::assertGreaterThanOrEqual(70, $body['matches'][0]['match_score']);
+    }
+
+    #[Test]
+    public function lookup_never_returns_opd_content(): void
+    {
+        // 'aw' is a seeded OPD row. It must not surface in either direction, and
+        // no match in any lookup may carry an umn.edu (OPD) source.
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'aw']));
+        self::assertSame('miss', $body['match_type']);
+        self::assertSame([], $body['matches']);
+
+        $byOj = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'aw', 'dir' => 'oj']));
+        self::assertSame('miss', $byOj['match_type']);
+
+        // Sweep every corpus match across a broad query; none may be OPD.
+        $all = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'a']));
+        foreach ($all['matches'] as $match) {
+            self::assertStringNotContainsStringIgnoringCase('ojibwe.lib.umn.edu', (string) ($match['provenance']['source_url'] ?? ''));
+            self::assertSame('corpus', $match['provenance']['attribution_source']);
+        }
+    }
+
+    #[Test]
+    public function lookup_with_a_valid_but_other_dialect_tag_returns_no_matches(): void
+    {
+        // oj-ojb (Northwestern Ojibwe) is well-formed but selects no community we
+        // hold, so it is a 200 miss, not a 422.
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'spoon', 'tag' => 'oj-ojb']));
+
+        self::assertSame('miss', $body['match_type']);
+        self::assertSame([], $body['matches']);
+    }
+
+    #[Test]
+    public function lookup_accepts_the_community_and_agnostic_tags(): void
+    {
+        foreach (['oj-x-sagamok', 'oj'] as $tag) {
+            $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'spoon', 'tag' => $tag]));
+            self::assertSame('exact', $body['match_type'], "tag {$tag} should resolve corpus content");
+            self::assertSame('Emkwaan', $body['matches'][0]['word']);
+        }
+    }
+
+    #[Test]
+    public function lookup_malformed_tag_is_a_422(): void
+    {
+        self::assertSame(422, $this->send('GET', '/api/lang/lookup', ['q' => 'spoon', 'tag' => 'oji-east'])->getStatusCode());
+    }
+
+    #[Test]
+    public function lookup_invalid_dir_is_a_422(): void
+    {
+        self::assertSame(422, $this->send('GET', '/api/lang/lookup', ['q' => 'spoon', 'dir' => 'sideways'])->getStatusCode());
+    }
+
+    #[Test]
+    public function lookup_missing_q_is_a_422(): void
+    {
+        self::assertSame(422, $this->send('GET', '/api/lang/lookup', [])->getStatusCode());
+    }
+
+    #[Test]
+    public function lookup_usage_notice_is_community_governed_not_opd(): void
+    {
+        $body = $this->decode($this->send('GET', '/api/lang/lookup', ['q' => 'spoon']));
+
+        self::assertSame('OCAP', $body['usage']['governance']);
+        self::assertTrue($body['usage']['community_governed']);
+        // No invented licence for the corpus: it is the community's to set.
+        self::assertNull($body['usage']['license']);
+        // OPD is acknowledged as a reference only, never served.
+        self::assertSame('https://ojibwe.lib.umn.edu', $body['usage']['reference']['url']);
     }
 
     /**


### PR DESCRIPTION
Closes #916.

Adds `GET /api/lang/lookup` so rhtcircle and the RHT nations can query **Minoo's own community corpus** server-to-server. OPD stays reference-only and is never served through the API.

## Endpoint
`GET /api/lang/lookup?q=<term>&tag=<bcp47>&dir=en|oj`

- Reads `dictionary_entry` but **only** `attribution_source = 'corpus'` (the Sagamok Nishnaabemwin lexicon). That equality filter is also the **OPD exclusion** — every OPD row has a different `attribution_source`, so no OPD content can surface. Consent-gated at the entity layer; the `loadMultiple([])` "load all" footgun is guarded.
- `q` required (422 if empty). `tag` optional BCP 47 (422 if malformed, same validator as `translate`; a well-formed but other-dialect tag like `oj-ojb` is a **200 miss**, not a 422). `dir` = `en`|`oj` (422 if other; omit to match both).
- Returns **all** matches (exact then fuzzy, `similar_text >= 70`): word, English definition(s), community tag `oj-x-sagamok`, dialect `Nishnaabemwin`, slug, `match_type`/`match_score`, `matched_on`, and corpus provenance. Comma senses split so `cup` matches `["cup, glass"]`.

## Boundaries
- **No OPD served.** Envelope carries only a *reference* link to ojibwe.lib.umn.edu; no OPD entries.
- **No CORS header** — public read but server-to-server by intent (rhtcircle's PHP backend).
- `usage` marks the corpus **community-governed (OCAP)**, non-commercial by default, attributed to the community, with **no invented licence** (`license: null`, terms to be set by the community) — distinct from OPD.
- `/api/lang/translate` (the `translation_memory` exact->fuzzy->gap-log) is **unchanged**. `lookup` is the lexicon; `translate` is the TM. Distinction documented.

## Contract
Written into `docs/anishinaabemowin-language-api-tracker.md` (`## /api/lang surface (ecosystem contract)`) as the single ecosystem source of truth. The rhtcircle repo is not touched.

## Tests (11 new, in `LanguageApiTest`)
Corpus hit (spoon -> Emkwaan), oj-direction, comma-sense split, fuzzy, **OPD-never-returned** (seeded `aw` absent in both directions + no umn.edu source in any match), malformed-tag / invalid-dir / missing-q 422s, other-dialect-tag miss, agnostic+community tag acceptance, community-governed usage notice. Full unit (530) + integration (154) suites and PHPStan level 5 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)