### PR TITLE
fix(#922): nav active-state — provide the current path to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dead code: unrouted controller methods, unregistered `SecurityHeadersMiddleware`, stale engagement target types (#920).
 
 ### Fixed
+- Sidebar nav active-state now fires: a render-time `current_path()` Twig function (language prefix stripped) feeds the template's `current_path` comparisons, which no layer previously provided; `/feed` highlights Home (#922).
 - `composer phpstan:dead-code` gate runs again — 45 stale baseline entries removed, route-string concat controllers now recognized (#920).
 
 ## [1.0.3] — 2026-03-14

--- a/src/Provider/AppBootServiceProvider.php
+++ b/src/Provider/AppBootServiceProvider.php
@@ -140,5 +140,32 @@ class AppBootServiceProvider extends AppCoreServiceProvider
         foreach ($twigTargets as $env) {
             $env->addFunction($ogImagePath);
         }
+
+        // =====================================================================
+        // --- Twig: current_path() for sidebar nav active-state (#922) ---
+        // =====================================================================
+
+        // Registered as a render-time function — NOT a boot-time global —
+        // because boot() runs once per kernel while one booted kernel can
+        // serve many requests (the integration harness does exactly that), so
+        // the value must be derived per render. Same lazy per-request pattern
+        // as lang_url(). A language prefix is stripped (/oj/communities →
+        // /communities) so template comparisons match in every language.
+        $currentPath = new TwigFunction('current_path', static function () use ($manager): string {
+            $path = parse_url((string) ($_SERVER['REQUEST_URI'] ?? '/'), PHP_URL_PATH);
+            if (!is_string($path) || $path === '') {
+                return '/';
+            }
+            $firstSegment = explode('/', ltrim($path, '/'))[0];
+            if ($firstSegment !== '' && array_key_exists($firstSegment, $manager->getLanguages())) {
+                $stripped = substr($path, strlen('/' . $firstSegment));
+                $path = $stripped === '' ? '/' : $stripped;
+            }
+
+            return $path;
+        });
+        foreach ($twigTargets as $env) {
+            $env->addFunction($currentPath);
+        }
     }
 }

--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -1,9 +1,12 @@
 {# Required: —
-   Optional: account, active #}
+   Optional: account #}
 {# Sidebar navigation — learn → practice → belong (#863). #}
+{# Active state (#922): current_path() derives the request path at render time
+   (language prefix stripped), so the comparisons below fire on every page. #}
+{% set current_path = current_path() %}
 <nav aria-label="{{ trans('sidebar.navigate') }}">
   <div class="sbx__group">
-    <a href="{{ lang_url('/') }}" class="sbx__item{% if current_path is defined and current_path == '/' %} sbx__item--active{% endif %}">
+    <a href="{{ lang_url('/') }}" class="sbx__item{% if current_path is defined and (current_path == '/' or current_path starts with '/feed') %} sbx__item--active{% endif %}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
       <span>{{ trans('sidebar.home') }}</span>
     </a>

--- a/tests/App/Integration/Http/SidebarNavActiveStateTest.php
+++ b/tests/App/Integration/Http/SidebarNavActiveStateTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Sidebar nav active-state (#922): the `current_path()` Twig function derives
+ * the request path at render time, so on every page exactly the sidebar link
+ * matching the current path carries `sbx__item--active` — and no other link
+ * does. Locks the exact-match ('/'), prefix-match ('/language', '/events'),
+ * and exact-vs-prefix discrimination ('/language/search') behaviors.
+ */
+#[CoversNothing]
+final class SidebarNavActiveStateTest extends HttpKernelTestCase
+{
+    private static int $uid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $user = $users->create(['name' => 'Sidebar Nav Tester', 'mail' => 'sidebar-nav@example.test', 'status' => true, 'created' => time(), 'roles' => [], 'permissions' => []]);
+        $users->save($user);
+        self::$uid = (int) $user->id();
+    }
+
+    /**
+     * Hrefs of sidebar links rendered with the active class.
+     *
+     * @return list<string>
+     */
+    private function activeSidebarHrefs(string $body): array
+    {
+        preg_match_all('/<a href="([^"]*)" class="sbx__item sbx__item--active"/', $body, $matches);
+
+        return $matches[1];
+    }
+
+    #[Test]
+    public function home_is_active_on_root_and_no_other_link_is(): void
+    {
+        $response = $this->send('GET', '/');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(['/'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    #[Test]
+    public function dictionary_is_active_on_language_but_search_and_home_are_not(): void
+    {
+        $response = $this->send('GET', '/language');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(['/language'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    #[Test]
+    public function search_is_active_on_language_search_but_dictionary_is_not(): void
+    {
+        $response = $this->send('GET', '/language/search', ['q' => 'nibi']);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(['/language/search'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    #[Test]
+    public function events_is_active_on_events_index(): void
+    {
+        $response = $this->send('GET', '/events');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(['/events'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    #[Test]
+    public function home_is_active_on_feed_for_an_authenticated_member(): void
+    {
+        $response = $this->sendAuthenticated('/feed');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(['/'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    #[Test]
+    public function language_prefixed_urls_still_activate_the_matching_link(): void
+    {
+        $response = $this->send('GET', '/oj/language');
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        // With current language oj, lang_url renders prefixed hrefs — the
+        // Dictionary link is /oj/language and must still be the active one.
+        self::assertSame(['/oj/language'], $this->activeSidebarHrefs((string) $response->getContent()));
+    }
+
+    /**
+     * Same session-injection pattern as FeedFilterTabTest::sendAuthenticated —
+     * /feed redirects anonymous visitors to /, so the active-state on /feed is
+     * only observable with a logged-in account.
+     */
+    private function sendAuthenticated(string $path): Response
+    {
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = self::$uid;
+
+        try {
+            return self::$kernel->handle();
+        } finally {
+            unset($_SESSION['waaseyaa_uid']);
+        }
+    }
+}


### PR DESCRIPTION
Closes #922

The sidebar's active-state guards compared against a `current_path` variable no layer ever provided. Fix: a per-request `current_path()` Twig function (same lazy pattern as `lang_url`/`og_image_path` — a boot-time global would freeze one path across the kernel's lifetime, proven by the test class which asserts different active links across 6 requests on a single booted kernel). Handles the `/oj/` language prefix; Home also activates on `/feed`.

TDD: `SidebarNavActiveStateTest` (6 tests, red-first). Adversarial review: MERGE, all mechanism/semantics/test-honesty checks confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAkZPfGeaYKnhYgzsC16d5