### PR TITLE
feat(#817): wire the feed engagement UI — reactions, comments, share, delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Feed engagement UI (#817): `public/js/engagement.js` wires the inert feed-card buttons to the social spine API — optimistic reaction toggle, inline comment view/add, share, and delete-own-post — plus an authenticated-only Feed entry in the sidebar navigation.
 - Navigation links for `/events`, `/groups`, and `/chat` in the sidebar (#920) — all three pages were fully built but unreachable.
 - 301 redirects preserving old URLs: `/media/corpus/video/{id}` → `/lessons/media/video/{id}` (stored in pre-2026-07 corpus rows), `/home` → `/`, `/studio` → `/` (#920).
 

--- a/public/js/engagement.js
+++ b/public/js/engagement.js
@@ -216,8 +216,17 @@
 
   // ── Comments (view + add) ────────────────────────────────────────────────
 
+  /** created_at arrives as a Unix timestamp (entity _data); render Y-m-d. */
+  function commentTime(value) {
+    if (value == null || value === '') return '';
+    var d = /^\d+$/.test(String(value))
+      ? new Date(Number(value) * 1000)
+      : new Date(String(value).replace(' ', 'T'));
+    return isNaN(d.getTime()) ? String(value).slice(0, 10) : d.toISOString().slice(0, 10);
+  }
+
   function commentHtml(comment) {
-    var when = String(comment.created_at || '').slice(0, 10);
+    var when = commentTime(comment.created_at);
     return '<div class="feed-comment" data-comment-id="' + escapeHtml(comment.id) + '">' +
       '<div class="feed-comment__content">' +
       '<div class="feed-comment__header"><span class="feed-comment__time">' + escapeHtml(when) + '</span></div>' +

--- a/public/js/engagement.js
+++ b/public/js/engagement.js
@@ -1,0 +1,376 @@
+/**
+ * Engagement — feed card interactions (#817).
+ *
+ * Wires the server-rendered feed cards (components/domain/feed/card.html.twig
+ * + engagement.html.twig) to the social spine write API (#813):
+ *
+ *   react       POST   /api/engagement/react              (optimistic toggle)
+ *   un-react    DELETE /api/engagement/react/{id}
+ *   comments    GET    /api/engagement/comments/{type}/{id}
+ *   comment     POST   /api/engagement/comment
+ *   delete post DELETE /api/engagement/post/{id}
+ *   share       navigator.share / clipboard fallback
+ *
+ * CSRF: POSTs send Content-Type: application/json (exempt in the framework
+ * CsrfMiddleware) and every request carries X-XSRF-TOKEN read from the
+ * XSRF-TOKEN cookie — required for bodyless DELETEs, which have no
+ * content-type exemption.
+ *
+ * The server renders no per-user reaction state (FeedItem.userReaction is
+ * never populated), so the reacted/is-active state is session-local: a
+ * successful POST stores the reaction id on the button for the toggle-off
+ * DELETE. Vanilla JS, no frameworks — same idiom as games-common.js.
+ */
+(function () {
+  'use strict';
+
+  /** Reaction vocabulary per target type — mirrors the feed.action_* labels
+   *  and EngagementController::ALLOWED_REACTION_TYPES. */
+  var REACTION_BY_TYPE = {
+    post: 'miigwech',
+    event: 'interested',
+    community_group: 'interested',
+    community: 'interested',
+    dictionary_entry: 'miigwech'
+  };
+
+  /** Escape for BOTH element and double-quoted attribute contexts. All
+   *  dynamic values are passed through this before any innerHTML write. */
+  function escapeHtml(str) {
+    return String(str == null ? '' : str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function xsrfToken() {
+    var m = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+    return m ? m[1] : '';
+  }
+
+  function api(method, path, body) {
+    var headers = { 'Content-Type': 'application/json' };
+    var token = xsrfToken();
+    if (token) headers['X-XSRF-TOKEN'] = token;
+    return fetch(path, {
+      method: method,
+      headers: headers,
+      credentials: 'same-origin',
+      body: body === undefined ? undefined : JSON.stringify(body)
+    });
+  }
+
+  /** Brief toast at the bottom of the screen (reuses .game-toast styling). */
+  function toast(message, linkHref, linkText) {
+    var existing = document.querySelector('.game-toast');
+    if (existing) existing.remove();
+
+    var el = document.createElement('div');
+    el.className = 'game-toast';
+    el.setAttribute('role', 'alert');
+    el.textContent = message;
+    if (linkHref) {
+      el.appendChild(document.createTextNode(' '));
+      var a = document.createElement('a');
+      a.href = linkHref;
+      a.textContent = linkText || linkHref;
+      el.appendChild(a);
+    }
+    document.body.appendChild(el);
+    setTimeout(function () { el.remove(); }, 4000);
+  }
+
+  /** Unobtrusive failure handler: 401 → sign-in prompt, else generic. */
+  function failed(res) {
+    if (res && res.status === 401) {
+      toast('Sign in to join the conversation —', '/login', 'Sign in');
+    } else {
+      toast('Something went wrong — please try again');
+    }
+  }
+
+  /** data-id is the composite feed id ("post:12"); returns { type, id }. */
+  function target(el) {
+    var raw = String(el.dataset.id || '');
+    var idx = raw.lastIndexOf(':');
+    return {
+      type: String(el.dataset.type || ''),
+      id: parseInt(idx === -1 ? raw : raw.slice(idx + 1), 10) || 0
+    };
+  }
+
+  // ── Counts row ("N interested · M comments") ─────────────────────────────
+
+  function counts(engagement) {
+    if (engagement.dataset.countsInit !== '1') {
+      var r = engagement.querySelector('.feed-card__count--reactions');
+      var c = engagement.querySelector('.feed-card__count--comments');
+      engagement.dataset.rc = String(r ? parseInt(r.textContent, 10) || 0 : 0);
+      engagement.dataset.cc = String(c ? parseInt(c.textContent, 10) || 0 : 0);
+      engagement.dataset.countsInit = '1';
+    }
+    return {
+      reactions: parseInt(engagement.dataset.rc, 10) || 0,
+      comments: parseInt(engagement.dataset.cc, 10) || 0
+    };
+  }
+
+  /** Re-render the counts <p> to match the server template's structure. */
+  function renderCounts(engagement) {
+    var n = counts(engagement);
+    var p = engagement.querySelector('.feed-card__counts');
+
+    if (n.reactions <= 0 && n.comments <= 0) {
+      if (p) p.remove();
+      return;
+    }
+
+    var html = '';
+    if (n.reactions > 0) {
+      html += '<span class="feed-card__count feed-card__count--reactions">' + n.reactions + ' interested</span>';
+    }
+    if (n.reactions > 0 && n.comments > 0) {
+      html += '<span class="feed-card__count-separator">&middot;</span>';
+    }
+    if (n.comments > 0) {
+      html += '<span class="feed-card__count feed-card__count--comments">' + n.comments + ' comments</span>';
+    }
+
+    if (!p) {
+      p = document.createElement('p');
+      p.className = 'feed-card__counts';
+      engagement.insertBefore(p, engagement.firstChild);
+    }
+    p.innerHTML = html;
+  }
+
+  function bump(engagement, kind, delta) {
+    counts(engagement); // ensure initialised
+    var key = kind === 'comments' ? 'cc' : 'rc';
+    var next = (parseInt(engagement.dataset[key], 10) || 0) + delta;
+    engagement.dataset[key] = String(next < 0 ? 0 : next);
+    renderCounts(engagement);
+  }
+
+  // ── Reactions (optimistic toggle) ────────────────────────────────────────
+
+  function react(btn) {
+    if (btn.dataset.busy === '1') return;
+    var engagement = btn.closest('.feed-card__engagement');
+    if (!engagement) return;
+
+    var t = target(btn);
+    btn.dataset.busy = '1';
+
+    if (!btn.classList.contains('is-active')) {
+      // Optimistic: mark reacted + bump the count, reconcile with the server.
+      btn.classList.add('is-active');
+      btn.setAttribute('aria-pressed', 'true');
+      bump(engagement, 'reactions', 1);
+
+      api('POST', '/api/engagement/react', {
+        reaction_type: REACTION_BY_TYPE[t.type] || 'like',
+        target_type: t.type,
+        target_id: t.id
+      }).then(function (res) {
+        if (!res.ok) throw res;
+        return res.json();
+      }).then(function (data) {
+        btn.dataset.reactionId = String(data.id);
+      }).catch(function (err) {
+        btn.classList.remove('is-active');
+        btn.setAttribute('aria-pressed', 'false');
+        bump(engagement, 'reactions', -1);
+        failed(err instanceof Response ? err : null);
+      }).finally(function () {
+        delete btn.dataset.busy;
+      });
+      return;
+    }
+
+    // Toggle off — only possible for a reaction created this page-session.
+    var reactionId = btn.dataset.reactionId;
+    if (!reactionId) {
+      delete btn.dataset.busy;
+      return;
+    }
+
+    btn.classList.remove('is-active');
+    btn.setAttribute('aria-pressed', 'false');
+    bump(engagement, 'reactions', -1);
+
+    api('DELETE', '/api/engagement/react/' + reactionId).then(function (res) {
+      if (!res.ok) throw res;
+      delete btn.dataset.reactionId;
+    }).catch(function (err) {
+      btn.classList.add('is-active');
+      btn.setAttribute('aria-pressed', 'true');
+      bump(engagement, 'reactions', 1);
+      failed(err instanceof Response ? err : null);
+    }).finally(function () {
+      delete btn.dataset.busy;
+    });
+  }
+
+  // ── Comments (view + add) ────────────────────────────────────────────────
+
+  function commentHtml(comment) {
+    var when = String(comment.created_at || '').slice(0, 10);
+    return '<div class="feed-comment" data-comment-id="' + escapeHtml(comment.id) + '">' +
+      '<div class="feed-comment__content">' +
+      '<div class="feed-comment__header"><span class="feed-comment__time">' + escapeHtml(when) + '</span></div>' +
+      '<div class="feed-comment__body">' + escapeHtml(comment.body) + '</div>' +
+      '</div></div>';
+  }
+
+  function renderComments(container, items, t) {
+    var list = items.map(commentHtml).join('');
+    container.innerHTML =
+      '<div class="feed-comments__list">' + list + '</div>' +
+      '<form class="feed-comments__form" data-type="' + escapeHtml(t.type) + '" data-id="' + escapeHtml(String(t.id)) + '">' +
+      '<input class="feed-comments__input" name="body" maxlength="2000" required placeholder="Write a comment...">' +
+      '<button type="submit" class="feed-comments__submit">Comment</button>' +
+      '</form>';
+  }
+
+  function toggleComments(btn) {
+    var card = btn.closest('.feed-card');
+    var container = card && card.querySelector('.feed-card__comments');
+    if (!container) return;
+
+    if (!container.hidden) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+
+    if (container.dataset.loaded === '1') return;
+
+    var t = target(btn);
+    api('GET', '/api/engagement/comments/' + encodeURIComponent(t.type) + '/' + t.id)
+      .then(function (res) {
+        if (!res.ok) throw res;
+        return res.json();
+      }).then(function (data) {
+        renderComments(container, data.comments || [], t);
+        container.dataset.loaded = '1';
+        var input = container.querySelector('.feed-comments__input');
+        if (input) input.focus();
+      }).catch(function (err) {
+        container.hidden = true;
+        failed(err instanceof Response ? err : null);
+      });
+  }
+
+  function submitComment(form) {
+    var input = form.querySelector('.feed-comments__input');
+    var submit = form.querySelector('.feed-comments__submit');
+    var body = input ? input.value.trim() : '';
+    if (body === '' || form.dataset.busy === '1') return;
+
+    var t = target(form);
+    var engagement = form.closest('.feed-card__engagement');
+    form.dataset.busy = '1';
+    if (submit) submit.disabled = true;
+
+    api('POST', '/api/engagement/comment', {
+      body: body,
+      target_type: t.type,
+      target_id: t.id
+    }).then(function (res) {
+      if (!res.ok) throw res;
+      return res.json();
+    }).then(function (data) {
+      var list = form.parentElement.querySelector('.feed-comments__list');
+      if (list) list.insertAdjacentHTML('afterbegin', commentHtml(data));
+      if (input) input.value = '';
+      if (engagement) bump(engagement, 'comments', 1);
+    }).catch(function (err) {
+      failed(err instanceof Response ? err : null);
+    }).finally(function () {
+      delete form.dataset.busy;
+      if (submit) submit.disabled = false;
+    });
+  }
+
+  // ── Post menu + delete own post ──────────────────────────────────────────
+
+  function closeMenus(except) {
+    document.querySelectorAll('.feed-card__menu-dropdown:not([hidden])').forEach(function (dd) {
+      if (dd === except) return;
+      dd.hidden = true;
+      var trigger = dd.parentElement.querySelector('.feed-card__menu-trigger');
+      if (trigger) trigger.setAttribute('aria-expanded', 'false');
+    });
+  }
+
+  function toggleMenu(btn) {
+    var dropdown = btn.parentElement.querySelector('.feed-card__menu-dropdown');
+    if (!dropdown) return;
+    closeMenus(dropdown);
+    dropdown.hidden = !dropdown.hidden;
+    btn.setAttribute('aria-expanded', dropdown.hidden ? 'false' : 'true');
+  }
+
+  function deletePost(btn) {
+    if (!window.confirm('Delete this post?')) {
+      closeMenus();
+      return;
+    }
+    var card = btn.closest('.feed-card');
+    var id = parseInt(String(btn.dataset.id || ''), 10) || 0;
+
+    api('DELETE', '/api/engagement/post/' + id).then(function (res) {
+      if (!res.ok) throw res;
+      if (card) card.remove();
+    }).catch(function (err) {
+      failed(err instanceof Response ? err : null);
+    });
+  }
+
+  // ── Share ────────────────────────────────────────────────────────────────
+
+  function share(btn) {
+    var url = new URL(btn.dataset.url || '/', window.location.origin).href;
+    var title = btn.dataset.title || document.title;
+
+    if (navigator.share) {
+      navigator.share({ title: title, url: url }).catch(function () { /* dismissed */ });
+      return;
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(function () {
+        toast('Link copied');
+      }, function () {
+        toast('Could not copy link');
+      });
+    }
+  }
+
+  // ── Delegated wiring ─────────────────────────────────────────────────────
+
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('[data-action]');
+
+    if (!el || el.dataset.action !== 'toggle-menu') closeMenus();
+    if (!el) return;
+
+    switch (el.dataset.action) {
+      case 'react': react(el); break;
+      case 'comment': toggleComments(el); break;
+      case 'share': share(el); break;
+      case 'toggle-menu': toggleMenu(el); break;
+      case 'delete-post': deletePost(el); break;
+      // 'edit-post' is not wired yet — editing needs an update endpoint.
+    }
+  });
+
+  document.addEventListener('submit', function (e) {
+    var form = e.target.closest('.feed-comments__form');
+    if (!form) return;
+    e.preventDefault();
+    submitComment(form);
+  });
+})();

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -985,6 +985,7 @@ return [
     'sidebar.programs' => 'Programs',
     'sidebar.your_communities' => 'Your Communities',
     'sidebar.home' => 'Home',
+    'sidebar.feed' => 'Feed',
 
     // Feed - Image Upload
     'feed.photo' => 'Photo',

--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -6,7 +6,7 @@
 {% set current_path = current_path() %}
 <nav aria-label="{{ trans('sidebar.navigate') }}">
   <div class="sbx__group">
-    <a href="{{ lang_url('/') }}" class="sbx__item{% if current_path is defined and (current_path == '/' or current_path starts with '/feed') %} sbx__item--active{% endif %}">
+    <a href="{{ lang_url('/') }}" class="sbx__item{% if current_path is defined and current_path == '/' %} sbx__item--active{% endif %}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
       <span>{{ trans('sidebar.home') }}</span>
     </a>

--- a/templates/components/shared/layout/sidebar-nav.html.twig
+++ b/templates/components/shared/layout/sidebar-nav.html.twig
@@ -10,6 +10,12 @@
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
       <span>{{ trans('sidebar.home') }}</span>
     </a>
+    {% if account is defined and account.isAuthenticated() %}
+    <a href="{{ lang_url('/feed') }}" class="sbx__item{% if current_path is defined and current_path == '/feed' %} sbx__item--active{% endif %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+      <span>{{ trans('sidebar.feed') }}</span>
+    </a>
+    {% endif %}
   </div>
 
   <div class="sbx__group">

--- a/templates/pages/feed/index.html.twig
+++ b/templates/pages/feed/index.html.twig
@@ -36,4 +36,6 @@
       {% endif %}
     {% endif %}
   </div>
+
+  <script src="/js/engagement.js?v=1" defer></script>
 {% endblock %}

--- a/tests/App/Integration/Http/FeedEngagementUiTest.php
+++ b/tests/App/Integration/Http/FeedEngagementUiTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Locks the engagement-UI wiring (#817): the feed page must load
+ * engagement.js (with a cache-bust param), and the sidebar Feed entry must be
+ * authenticated-only — anonymous visitors are redirected off /feed, so an
+ * anonymous Feed link would dead-end at the homepage.
+ */
+#[CoversNothing]
+final class FeedEngagementUiTest extends HttpKernelTestCase
+{
+    private static int $uid = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $users = self::$kernel->getEntityTypeManager()->getStorage('user');
+        $user = $users->create(['name' => 'Engagement UI Tester', 'mail' => 'engagement-ui@example.test', 'status' => true, 'created' => time(), 'roles' => [], 'permissions' => []]);
+        $users->save($user);
+        self::$uid = (int) $user->id();
+    }
+
+    #[Test]
+    public function feed_page_loads_engagement_js_with_cache_bust(): void
+    {
+        $response = $this->sendAuthenticated('/feed');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#<script src="/js/engagement\.js\?v=\d+" defer></script>#',
+            $body,
+            'The feed page must load engagement.js with a ?v=N cache-bust.',
+        );
+    }
+
+    #[Test]
+    public function sidebar_feed_entry_is_present_for_authenticated_users(): void
+    {
+        $response = $this->sendAuthenticated('/feed');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#<a href="[^"]*/feed" class="sbx__item#',
+            $body,
+            'Authenticated pages must show the Feed sidebar entry.',
+        );
+    }
+
+    #[Test]
+    public function sidebar_feed_entry_is_absent_for_anonymous_visitors(): void
+    {
+        $response = $this->send('GET', '/');
+        $body = (string) $response->getContent();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertDoesNotMatchRegularExpression(
+            '#<a href="[^"]*/feed" class="sbx__item#',
+            $body,
+            'Anonymous visitors must not see the Feed sidebar entry (anonymous /feed redirects home).',
+        );
+    }
+
+    private function sendAuthenticated(string $path): Response
+    {
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_REQUEST = [];
+        $_FILES = [];
+        $_SERVER = array_merge($_SERVER, [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => $path,
+            'QUERY_STRING' => '',
+            'PATH_INFO' => $path,
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'HTTPS' => '',
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+        ]);
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['waaseyaa_uid'] = self::$uid;
+
+        try {
+            return self::$kernel->handle();
+        } finally {
+            unset($_SESSION['waaseyaa_uid']);
+        }
+    }
+}

--- a/tests/App/Integration/Http/SidebarNavActiveStateTest.php
+++ b/tests/App/Integration/Http/SidebarNavActiveStateTest.php
@@ -75,11 +75,13 @@ final class SidebarNavActiveStateTest extends HttpKernelTestCase
     }
 
     #[Test]
-    public function home_is_active_on_feed_for_an_authenticated_member(): void
+    public function feed_entry_is_the_sole_active_item_on_feed(): void
     {
+        // The Home-activates-on-/feed rule from #922 was retired when #817
+        // added a dedicated authenticated Feed entry — Feed alone is active.
         $response = $this->sendAuthenticated('/feed');
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
-        self::assertSame(['/'], $this->activeSidebarHrefs((string) $response->getContent()));
+        self::assertSame(['/feed'], $this->activeSidebarHrefs((string) $response->getContent()));
     }
 
     #[Test]

--- a/tests/playwright/engagement.spec.ts
+++ b/tests/playwright/engagement.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Feed engagement UI (#817) — react flow.
+ *
+ * Uses the seeded test@minoo.test account (global-setup.ts → bin/seed-test-user),
+ * the same authenticated pattern as auth.spec.ts. The feed's contents depend on
+ * whatever the local database holds, so each test runtime-skips when no feed
+ * card with a react button is present rather than inventing seed plumbing.
+ */
+
+async function login(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', 'test@minoo.test');
+  await page.fill('input[name="password"]', 'TestPass123!');
+  await page.click('.form button[type="submit"]');
+  await page.waitForURL('/');
+}
+
+test.describe('Feed engagement', () => {
+  test('feed page loads engagement.js', async ({ page }) => {
+    await login(page);
+    await page.goto('/feed');
+    await expect(page.locator('script[src^="/js/engagement.js"]')).toBeAttached();
+  });
+
+  test('sidebar shows Feed entry only when authenticated', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.sbx a[href="/feed"]')).toHaveCount(0);
+
+    await login(page);
+    await page.goto('/feed');
+    await expect(page.locator('.sbx a[href="/feed"]').first()).toBeVisible();
+  });
+
+  test('clicking react fires POST /api/engagement/react and toggles the button', async ({ page }) => {
+    await login(page);
+    await page.goto('/feed');
+
+    const react = page.locator('.feed-card__action--react').first();
+    test.skip(await react.count() === 0, 'no feed cards in the local database');
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/engagement/react') && r.request().method() === 'POST',
+      ),
+      react.click(),
+    ]);
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.id).toBeTruthy();
+    await expect(react).toHaveClass(/is-active/);
+    await expect(react).toHaveAttribute('aria-pressed', 'true');
+
+    // Toggle off — session-local reaction id drives the DELETE.
+    const [del] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/engagement/react/') && r.request().method() === 'DELETE',
+      ),
+      react.click(),
+    ]);
+
+    expect(del.status()).toBe(200);
+    await expect(react).not.toHaveClass(/is-active/);
+  });
+});

--- a/tests/playwright/engagement.spec.ts
+++ b/tests/playwright/engagement.spec.ts
@@ -37,8 +37,15 @@ test.describe('Feed engagement', () => {
     await login(page);
     await page.goto('/feed');
 
-    const react = page.locator('.feed-card__action--react').first();
-    test.skip(await react.count() === 0, 'no feed cards in the local database');
+    // Only these card types are valid reaction targets server-side
+    // (EngagementController::ALLOWED_TARGET_TYPES) — the synthetic/featured
+    // cards render a react button but the API rejects them with 422.
+    const react = page.locator(
+      ['post', 'event', 'community_group']
+        .map((t) => `.feed-card__action--react[data-type="${t}"]`)
+        .join(', '),
+    ).first();
+    test.skip(await react.count() === 0, 'no reactable feed cards in the local database');
 
     const [response] = await Promise.all([
       page.waitForResponse(


### PR DESCRIPTION
Part of #817

The engagement endpoints and feed-card markup existed; the client died with the messaging era, leaving inert buttons. This wires them: `public/js/engagement.js` (vanilla, games-common idiom) — optimistic reaction toggle with server reconcile, lazy comment view/add, share via `navigator.share`/clipboard, delete-own-post; JSON content-type + `X-XSRF-TOKEN` for bodyless DELETEs; non-2xx reverts with a toast, 401 prompts sign-in. Plus the authenticated-only Feed sidebar entry.

Verified in a real browser (php -S + Playwright): react POST 201 → count updates → toggle DELETE 200; comment posted and rendered; screenshots + network log in the evidence report. Tests: PHP locks (script tag, nav auth-gating both directions) + a real Playwright spec using the seeded-login pattern. Adversarial review: MERGE — XSS-safe (all dynamic values through `escapeHtml`), CSRF verified against the framework middleware source.

Known server-side gaps documented for follow-up (not this PR): `FeedItem.userReaction` never populated so prior-session reactions can't be shown/toggled; featured/synthetic cards render a react button the API 422s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAkZPfGeaYKnhYgzsC16d5